### PR TITLE
feat: add more error kinds

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -63,7 +63,7 @@ impl<Iter> Deserializer<Iter>
             Some(ch) => Ok(Some(ch)),
             None => {
                 match self.rdr.next() {
-                    Some(Err(err)) => Err(Error::IoError(err)),
+                    Some(Err(err)) => Err(Error::Io(err)),
                     Some(Ok(ch)) => {
                         self.ch = Some(ch);
                         Ok(self.ch)
@@ -87,7 +87,7 @@ impl<Iter> Deserializer<Iter>
             Some(ch) => Ok(Some(ch)),
             None => {
                 match self.rdr.next() {
-                    Some(Err(err)) => Err(Error::IoError(err)),
+                    Some(Err(err)) => Err(Error::Io(err)),
                     Some(Ok(ch)) => Ok(Some(ch)),
                     None => Ok(None),
                 }
@@ -100,7 +100,7 @@ impl<Iter> Deserializer<Iter>
     }
 
     fn error(&mut self, reason: ErrorCode) -> Error {
-        Error::SyntaxError(reason, self.rdr.line(), self.rdr.col())
+        Error::Syntax(reason, self.rdr.line(), self.rdr.col())
     }
 
     fn parse_whitespace(&mut self) -> Result<()> {
@@ -167,7 +167,7 @@ impl<Iter> Deserializer<Iter>
 
         match value {
             Ok(value) => Ok(value),
-            Err(Error::SyntaxError(code, _, _)) => Err(self.error(code)),
+            Err(Error::Syntax(code, _, _)) => Err(self.error(code)),
             Err(err) => Err(err),
         }
     }

--- a/json/src/error.rs
+++ b/json/src/error.rs
@@ -113,28 +113,28 @@ impl fmt::Debug for ErrorCode {
 #[derive(Debug)]
 pub enum Error {
     /// The JSON value had some syntatic error.
-    SyntaxError(ErrorCode, usize, usize),
+    Syntax(ErrorCode, usize, usize),
 
     /// Some IO error occurred when serializing or deserializing a value.
-    IoError(io::Error),
+    Io(io::Error),
 
     /// Some UTF8 error occurred while serializing or deserializing a value.
-    FromUtf8Error(FromUtf8Error),
+    FromUtf8(FromUtf8Error),
 }
 
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::SyntaxError(..) => "syntax error",
-            Error::IoError(ref error) => error::Error::description(error),
-            Error::FromUtf8Error(ref error) => error.description(),
+            Error::Syntax(..) => "syntax error",
+            Error::Io(ref error) => error::Error::description(error),
+            Error::FromUtf8(ref error) => error.description(),
         }
     }
 
     fn cause(&self) -> Option<&error::Error> {
         match *self {
-            Error::IoError(ref error) => Some(error),
-            Error::FromUtf8Error(ref error) => Some(error),
+            Error::Io(ref error) => Some(error),
+            Error::FromUtf8(ref error) => Some(error),
             _ => None,
         }
     }
@@ -144,47 +144,47 @@ impl error::Error for Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::SyntaxError(ref code, line, col) => {
+            Error::Syntax(ref code, line, col) => {
                 write!(fmt, "{:?} at line {} column {}", code, line, col)
             }
-            Error::IoError(ref error) => fmt::Display::fmt(error, fmt),
-            Error::FromUtf8Error(ref error) => fmt::Display::fmt(error, fmt),
+            Error::Io(ref error) => fmt::Display::fmt(error, fmt),
+            Error::FromUtf8(ref error) => fmt::Display::fmt(error, fmt),
         }
     }
 }
 
 impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Error {
-        Error::IoError(error)
+    fn from(error: io::Error) -> Self {
+        Error::Io(error)
     }
 }
 
 impl From<FromUtf8Error> for Error {
-    fn from(error: FromUtf8Error) -> Error {
-        Error::FromUtf8Error(error)
+    fn from(error: FromUtf8Error) -> Self {
+        Error::FromUtf8(error)
     }
 }
 
 impl From<de::value::Error> for Error {
-    fn from(error: de::value::Error) -> Error {
+    fn from(error: de::value::Error) -> Self {
         match error {
-            de::value::Error::SyntaxError(msg) => {
-                Error::SyntaxError(ErrorCode::Custom(msg.into()), 0, 0)
+            de::value::Error::Syntax(msg) => {
+                Error::Syntax(ErrorCode::Custom(msg.into()), 0, 0)
             }
-            de::value::Error::TypeError(type_) => {
-                Error::SyntaxError(ErrorCode::InvalidType(type_), 0, 0)
+            de::value::Error::Type(type_) => {
+                Error::Syntax(ErrorCode::InvalidType(type_), 0, 0)
             }
-            de::value::Error::LengthError(length) => {
-                Error::SyntaxError(ErrorCode::InvalidLength(length), 0, 0)
+            de::value::Error::Length(length) => {
+                Error::Syntax(ErrorCode::InvalidLength(length), 0, 0)
             }
-            de::value::Error::EndOfStreamError => {
+            de::value::Error::EndOfStream => {
                 de::Error::end_of_stream()
             }
-            de::value::Error::UnknownFieldError(field) => {
-                Error::SyntaxError(ErrorCode::UnknownField(String::from(field)), 0, 0)
+            de::value::Error::UnknownField(field) => {
+                Error::Syntax(ErrorCode::UnknownField(String::from(field)), 0, 0)
             }
-            de::value::Error::MissingFieldError(field) => {
-                Error::SyntaxError(ErrorCode::MissingField(field), 0, 0)
+            de::value::Error::MissingField(field) => {
+                Error::Syntax(ErrorCode::MissingField(field), 0, 0)
             }
         }
     }
@@ -192,27 +192,27 @@ impl From<de::value::Error> for Error {
 
 impl de::Error for Error {
     fn syntax(msg: &str) -> Self {
-        Error::SyntaxError(ErrorCode::Custom(msg.into()), 0, 0)
+        Error::Syntax(ErrorCode::Custom(msg.into()), 0, 0)
     }
 
     fn length_mismatch(length: usize) -> Self {
-        Error::SyntaxError(ErrorCode::InvalidLength(length), 0, 0)
+        Error::Syntax(ErrorCode::InvalidLength(length), 0, 0)
     }
 
     fn type_mismatch(type_: de::Type) -> Self {
-        Error::SyntaxError(ErrorCode::InvalidType(type_), 0, 0)
+        Error::Syntax(ErrorCode::InvalidType(type_), 0, 0)
     }
 
-    fn end_of_stream() -> Error {
-        Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 0, 0)
+    fn end_of_stream() -> Self {
+        Error::Syntax(ErrorCode::EOFWhileParsingValue, 0, 0)
     }
 
-    fn unknown_field(field: &str) -> Error {
-        Error::SyntaxError(ErrorCode::UnknownField(String::from(field)), 0, 0)
+    fn unknown_field(field: &str) -> Self {
+        Error::Syntax(ErrorCode::UnknownField(String::from(field)), 0, 0)
     }
 
-    fn missing_field(field: &'static str) -> Error {
-        Error::SyntaxError(ErrorCode::MissingField(field), 0, 0)
+    fn missing_field(field: &'static str) -> Self {
+        Error::Syntax(ErrorCode::MissingField(field), 0, 0)
     }
 }
 

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -325,58 +325,58 @@ impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
     }
 
     fn visit_bool(&mut self, _value: bool) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_i64(&mut self, _value: i64) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_u64(&mut self, _value: u64) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_f64(&mut self, _value: f64) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_unit(&mut self) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_none(&mut self) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_some<V>(&mut self, _value: V) -> Result<()>
         where V: ser::Serialize
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_seq<V>(&mut self, _visitor: V) -> Result<()>
         where V: ser::SeqVisitor,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_seq_elt<T>(&mut self, _value: T) -> Result<()>
         where T: ser::Serialize,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_map<V>(&mut self, _visitor: V) -> Result<()>
         where V: ser::MapVisitor,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<()>
         where K: ser::Serialize,
               V: ser::Serialize,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 }
 


### PR DESCRIPTION
The trait `serde::de::Error` allows reporting a `type_mismatch`,
`length_mismatch` and a custom message in `syntax`.

These errors are reported distinctly now.

This PR depends on https://github.com/serde-rs/serde/pull/165 or https://github.com/serde-rs/serde/pull/166 to use the extended `de::value::Error`.