### PR TITLE
Forward `InvalidType` and `InvalidLength` errors and remove the redundant `Error` suffix.

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -63,7 +63,7 @@ impl<Iter> Deserializer<Iter>
             Some(ch) => Ok(Some(ch)),
             None => {
                 match self.rdr.next() {
-                    Some(Err(err)) => Err(Error::IoError(err)),
+                    Some(Err(err)) => Err(Error::Io(err)),
                     Some(Ok(ch)) => {
                         self.ch = Some(ch);
                         Ok(self.ch)
@@ -87,7 +87,7 @@ impl<Iter> Deserializer<Iter>
             Some(ch) => Ok(Some(ch)),
             None => {
                 match self.rdr.next() {
-                    Some(Err(err)) => Err(Error::IoError(err)),
+                    Some(Err(err)) => Err(Error::Io(err)),
                     Some(Ok(ch)) => Ok(Some(ch)),
                     None => Ok(None),
                 }
@@ -100,7 +100,7 @@ impl<Iter> Deserializer<Iter>
     }
 
     fn error(&mut self, reason: ErrorCode) -> Error {
-        Error::SyntaxError(reason, self.rdr.line(), self.rdr.col())
+        Error::Syntax(reason, self.rdr.line(), self.rdr.col())
     }
 
     fn parse_whitespace(&mut self) -> Result<()> {
@@ -167,7 +167,7 @@ impl<Iter> Deserializer<Iter>
 
         match value {
             Ok(value) => Ok(value),
-            Err(Error::SyntaxError(code, _, _)) => Err(self.error(code)),
+            Err(Error::Syntax(code, _, _)) => Err(self.error(code)),
             Err(err) => Err(err),
         }
     }
@@ -757,7 +757,7 @@ impl<'a, Iter> de::MapVisitor for MapVisitor<'a, Iter>
                 where V: de::Visitor,
             {
                 let &mut MissingFieldDeserializer(field) = self;
-                Err(de::value::Error::MissingFieldError(field))
+                Err(de::value::Error::MissingField(field))
             }
 
             fn visit_option<V>(&mut self, mut visitor: V) -> std::result::Result<V::Value, Self::Error>

--- a/json/src/error.rs
+++ b/json/src/error.rs
@@ -113,28 +113,28 @@ impl fmt::Debug for ErrorCode {
 #[derive(Debug)]
 pub enum Error {
     /// The JSON value had some syntatic error.
-    SyntaxError(ErrorCode, usize, usize),
+    Syntax(ErrorCode, usize, usize),
 
     /// Some IO error occurred when serializing or deserializing a value.
-    IoError(io::Error),
+    Io(io::Error),
 
     /// Some UTF8 error occurred while serializing or deserializing a value.
-    FromUtf8Error(FromUtf8Error),
+    FromUtf8(FromUtf8Error),
 }
 
 impl error::Error for Error {
     fn description(&self) -> &str {
         match *self {
-            Error::SyntaxError(..) => "syntax error",
-            Error::IoError(ref error) => error::Error::description(error),
-            Error::FromUtf8Error(ref error) => error.description(),
+            Error::Syntax(..) => "syntax error",
+            Error::Io(ref error) => error::Error::description(error),
+            Error::FromUtf8(ref error) => error.description(),
         }
     }
 
     fn cause(&self) -> Option<&error::Error> {
         match *self {
-            Error::IoError(ref error) => Some(error),
-            Error::FromUtf8Error(ref error) => Some(error),
+            Error::Io(ref error) => Some(error),
+            Error::FromUtf8(ref error) => Some(error),
             _ => None,
         }
     }
@@ -144,47 +144,47 @@ impl error::Error for Error {
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            Error::SyntaxError(ref code, line, col) => {
+            Error::Syntax(ref code, line, col) => {
                 write!(fmt, "{:?} at line {} column {}", code, line, col)
             }
-            Error::IoError(ref error) => fmt::Display::fmt(error, fmt),
-            Error::FromUtf8Error(ref error) => fmt::Display::fmt(error, fmt),
+            Error::Io(ref error) => fmt::Display::fmt(error, fmt),
+            Error::FromUtf8(ref error) => fmt::Display::fmt(error, fmt),
         }
     }
 }
 
 impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Error {
-        Error::IoError(error)
+    fn from(error: io::Error) -> Self {
+        Error::Io(error)
     }
 }
 
 impl From<FromUtf8Error> for Error {
-    fn from(error: FromUtf8Error) -> Error {
-        Error::FromUtf8Error(error)
+    fn from(error: FromUtf8Error) -> Self {
+        Error::FromUtf8(error)
     }
 }
 
 impl From<de::value::Error> for Error {
-    fn from(error: de::value::Error) -> Error {
+    fn from(error: de::value::Error) -> Self {
         match error {
-            de::value::Error::SyntaxError(msg) => {
-                Error::SyntaxError(ErrorCode::Custom(msg), 0, 0)
+            de::value::Error::Syntax(msg) => {
+                Error::Syntax(ErrorCode::Custom(msg), 0, 0)
             }
-            de::value::Error::TypeError(_type) => {
-                Error::SyntaxError(ErrorCode::InvalidType(_type), 0, 0)
+            de::value::Error::Type(_type) => {
+                Error::Syntax(ErrorCode::InvalidType(_type), 0, 0)
             }
-            de::value::Error::LengthError(len) => {
-                Error::SyntaxError(ErrorCode::InvalidLength(len), 0, 0)
+            de::value::Error::Length(len) => {
+                Error::Syntax(ErrorCode::InvalidLength(len), 0, 0)
             }
-            de::value::Error::EndOfStreamError => {
+            de::value::Error::EndOfStream => {
                 de::Error::end_of_stream()
             }
-            de::value::Error::UnknownFieldError(field) => {
-                Error::SyntaxError(ErrorCode::UnknownField(field), 0, 0)
+            de::value::Error::UnknownField(field) => {
+                Error::Syntax(ErrorCode::UnknownField(field), 0, 0)
             }
-            de::value::Error::MissingFieldError(field) => {
-                Error::SyntaxError(ErrorCode::MissingField(field), 0, 0)
+            de::value::Error::MissingField(field) => {
+                Error::Syntax(ErrorCode::MissingField(field), 0, 0)
             }
         }
     }
@@ -192,27 +192,27 @@ impl From<de::value::Error> for Error {
 
 impl de::Error for Error {
     fn syntax(msg: &str) -> Self {
-        Error::SyntaxError(ErrorCode::Custom(msg.into()), 0, 0)
+        Error::Syntax(ErrorCode::Custom(msg.into()), 0, 0)
     }
 
     fn length_mismatch(length: usize) -> Self {
-        Error::SyntaxError(ErrorCode::InvalidLength(length), 0, 0)
+        Error::Syntax(ErrorCode::InvalidLength(length), 0, 0)
     }
 
     fn type_mismatch(_type: de::Type) -> Self {
-        Error::SyntaxError(ErrorCode::InvalidType(_type), 0, 0)
+        Error::Syntax(ErrorCode::InvalidType(_type), 0, 0)
     }
 
-    fn end_of_stream() -> Error {
-        Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 0, 0)
+    fn end_of_stream() -> Self {
+        Error::Syntax(ErrorCode::EOFWhileParsingValue, 0, 0)
     }
 
-    fn unknown_field(field: &str) -> Error {
-        Error::SyntaxError(ErrorCode::UnknownField(String::from(field)), 0, 0)
+    fn unknown_field(field: &str) -> Self {
+        Error::Syntax(ErrorCode::UnknownField(String::from(field)), 0, 0)
     }
 
-    fn missing_field(field: &'static str) -> Error {
-        Error::SyntaxError(ErrorCode::MissingField(field), 0, 0)
+    fn missing_field(field: &'static str) -> Self {
+        Error::Syntax(ErrorCode::MissingField(field), 0, 0)
     }
 }
 

--- a/json/src/error.rs
+++ b/json/src/error.rs
@@ -65,6 +65,9 @@ pub enum ErrorCode {
     /// Unknown field in struct.
     UnknownField(String),
 
+    /// Unknown variant in enum.
+    UnknownVariant(String),
+
     /// Struct is missing a field.
     MissingField(&'static str),
 
@@ -100,6 +103,7 @@ impl fmt::Debug for ErrorCode {
             ErrorCode::KeyMustBeAString => "key must be a string".fmt(f),
             ErrorCode::LoneLeadingSurrogateInHexEscape => "lone leading surrogate in hex escape".fmt(f),
             ErrorCode::UnknownField(ref field) => write!(f, "unknown field \"{}\"", field),
+            ErrorCode::UnknownVariant(ref variant) => write!(f, "unknown variant \"{}\"", variant),
             ErrorCode::MissingField(ref field) => write!(f, "missing field \"{}\"", field),
             ErrorCode::TrailingCharacters => "trailing characters".fmt(f),
             ErrorCode::UnexpectedEndOfHexEscape => "unexpected end of hex escape".fmt(f),
@@ -209,6 +213,10 @@ impl de::Error for Error {
 
     fn unknown_field(field: &str) -> Self {
         Error::Syntax(ErrorCode::UnknownField(String::from(field)), 0, 0)
+    }
+
+    fn unknown_variant(variant: &str) -> Self {
+        Error::Syntax(ErrorCode::UnknownVariant(String::from(variant)), 0, 0)
     }
 
     fn missing_field(field: &'static str) -> Self {

--- a/json/src/error.rs
+++ b/json/src/error.rs
@@ -50,6 +50,12 @@ pub enum ErrorCode {
     /// Invalid unicode code point.
     InvalidUnicodeCodePoint,
 
+    /// Invalid value type.
+    InvalidType(de::Type),
+
+    /// Invalid length.
+    InvalidLength(usize),
+
     /// Object key is not a string.
     KeyMustBeAString,
 
@@ -67,6 +73,9 @@ pub enum ErrorCode {
 
     /// Unexpected end of hex excape.
     UnexpectedEndOfHexEscape,
+
+    /// Custom error message.
+    Custom(String),
 }
 
 impl fmt::Debug for ErrorCode {
@@ -86,12 +95,15 @@ impl fmt::Debug for ErrorCode {
             ErrorCode::InvalidEscape => "invalid escape".fmt(f),
             ErrorCode::InvalidNumber => "invalid number".fmt(f),
             ErrorCode::InvalidUnicodeCodePoint => "invalid unicode code point".fmt(f),
+            ErrorCode::InvalidType(ref _type) => write!(f, "invalid type \"{:?}\"", _type),
+            ErrorCode::InvalidLength(ref length) => write!(f, "invalid length \"{}\"", length),
             ErrorCode::KeyMustBeAString => "key must be a string".fmt(f),
             ErrorCode::LoneLeadingSurrogateInHexEscape => "lone leading surrogate in hex escape".fmt(f),
             ErrorCode::UnknownField(ref field) => write!(f, "unknown field \"{}\"", field),
             ErrorCode::MissingField(ref field) => write!(f, "missing field \"{}\"", field),
             ErrorCode::TrailingCharacters => "trailing characters".fmt(f),
             ErrorCode::UnexpectedEndOfHexEscape => "unexpected end of hex escape".fmt(f),
+            ErrorCode::Custom(ref msg) => write!(f, "custom message: \"{}\"", msg),
         }
     }
 }
@@ -156,8 +168,14 @@ impl From<FromUtf8Error> for Error {
 impl From<de::value::Error> for Error {
     fn from(error: de::value::Error) -> Error {
         match error {
-            de::value::Error::SyntaxError => {
-                Error::SyntaxError(ErrorCode::ExpectedSomeValue, 0, 0)
+            de::value::Error::SyntaxError(msg) => {
+                Error::SyntaxError(ErrorCode::Custom(msg), 0, 0)
+            }
+            de::value::Error::TypeError(_type) => {
+                Error::SyntaxError(ErrorCode::InvalidType(_type), 0, 0)
+            }
+            de::value::Error::LengthError(len) => {
+                Error::SyntaxError(ErrorCode::InvalidLength(len), 0, 0)
             }
             de::value::Error::EndOfStreamError => {
                 de::Error::end_of_stream()
@@ -173,8 +191,16 @@ impl From<de::value::Error> for Error {
 }
 
 impl de::Error for Error {
-    fn syntax(_: &str) -> Error {
-        Error::SyntaxError(ErrorCode::ExpectedSomeValue, 0, 0)
+    fn syntax(msg: &str) -> Self {
+        Error::SyntaxError(ErrorCode::Custom(msg.into()), 0, 0)
+    }
+
+    fn length_mismatch(length: usize) -> Self {
+        Error::SyntaxError(ErrorCode::InvalidLength(length), 0, 0)
+    }
+
+    fn type_mismatch(_type: de::Type) -> Self {
+        Error::SyntaxError(ErrorCode::InvalidType(_type), 0, 0)
     }
 
     fn end_of_stream() -> Error {

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -325,58 +325,58 @@ impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
     }
 
     fn visit_bool(&mut self, _value: bool) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_i64(&mut self, _value: i64) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_u64(&mut self, _value: u64) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_f64(&mut self, _value: f64) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_unit(&mut self) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_none(&mut self) -> Result<()> {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_some<V>(&mut self, _value: V) -> Result<()>
         where V: ser::Serialize
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_seq<V>(&mut self, _visitor: V) -> Result<()>
         where V: ser::SeqVisitor,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_seq_elt<T>(&mut self, _value: T) -> Result<()>
         where T: ser::Serialize,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_map<V>(&mut self, _visitor: V) -> Result<()>
         where V: ser::MapVisitor,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
     fn visit_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<()>
         where K: ser::Serialize,
               V: ser::Serialize,
     {
-        Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 }
 

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -916,9 +916,9 @@ fn test_parse_object() {
 #[test]
 fn test_parse_struct() {
     test_parse_err::<Outer>(vec![
-        ("5", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 1)),
-        ("\"hello\"", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 7)),
-        ("{\"inner\": true}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 14)),
+        ("5", Error::SyntaxError(ErrorCode::InvalidType(de::Type::U64), 1, 1)),
+        ("\"hello\"", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Str), 1, 7)),
+        ("{\"inner\": true}", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Bool), 1, 14)),
         ("{}", Error::SyntaxError(ErrorCode::MissingField("inner"), 1, 2)),
         (r#"{"inner": [{"b": 42, "c": []}]}"#, Error::SyntaxError(ErrorCode::MissingField("a"), 1, 29)),
     ]);
@@ -991,8 +991,8 @@ fn test_parse_enum_errors() {
         ("{\"Dog\":", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 7)),
         ("{\"Dog\":}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 8)),
         ("{\"unknown\":[]}", Error::SyntaxError(ErrorCode::UnknownField("unknown".to_string()), 1, 10)),
-        ("{\"Dog\":{}}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 8)),
-        ("{\"Frog\":{}}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 9)),
+        ("{\"Dog\":{}}", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Map), 1, 8)),
+        ("{\"Frog\":{}}", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Map), 1, 9)),
         ("{\"Cat\":[]}", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 9)),
     ]);
 }

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -671,8 +671,8 @@ fn test_parse_err<T>(errors: Vec<(&'static str, Error)>)
     for (s, err) in errors {
         match (err, from_str::<T>(s).unwrap_err()) {
             (
-                Error::SyntaxError(expected_code, expected_line, expected_col),
-                Error::SyntaxError(actual_code, actual_line, actual_col),
+                Error::Syntax(expected_code, expected_line, expected_col),
+                Error::Syntax(actual_code, actual_line, actual_col),
             ) => {
                 assert_eq!(
                     (expected_code, expected_line, expected_col),
@@ -689,9 +689,9 @@ fn test_parse_err<T>(errors: Vec<(&'static str, Error)>)
 #[test]
 fn test_parse_null() {
     test_parse_err::<()>(vec![
-        ("n", Error::SyntaxError(ErrorCode::ExpectedSomeIdent, 1, 1)),
-        ("nul", Error::SyntaxError(ErrorCode::ExpectedSomeIdent, 1, 3)),
-        ("nulla", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 5)),
+        ("n", Error::Syntax(ErrorCode::ExpectedSomeIdent, 1, 1)),
+        ("nul", Error::Syntax(ErrorCode::ExpectedSomeIdent, 1, 3)),
+        ("nulla", Error::Syntax(ErrorCode::TrailingCharacters, 1, 5)),
     ]);
 
     test_parse_ok(vec![
@@ -702,12 +702,12 @@ fn test_parse_null() {
 #[test]
 fn test_parse_bool() {
     test_parse_err::<bool>(vec![
-        ("t", Error::SyntaxError(ErrorCode::ExpectedSomeIdent, 1, 1)),
-        ("truz", Error::SyntaxError(ErrorCode::ExpectedSomeIdent, 1, 4)),
-        ("f", Error::SyntaxError(ErrorCode::ExpectedSomeIdent, 1, 1)),
-        ("faz", Error::SyntaxError(ErrorCode::ExpectedSomeIdent, 1, 3)),
-        ("truea", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 5)),
-        ("falsea", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 6)),
+        ("t", Error::Syntax(ErrorCode::ExpectedSomeIdent, 1, 1)),
+        ("truz", Error::Syntax(ErrorCode::ExpectedSomeIdent, 1, 4)),
+        ("f", Error::Syntax(ErrorCode::ExpectedSomeIdent, 1, 1)),
+        ("faz", Error::Syntax(ErrorCode::ExpectedSomeIdent, 1, 3)),
+        ("truea", Error::Syntax(ErrorCode::TrailingCharacters, 1, 5)),
+        ("falsea", Error::Syntax(ErrorCode::TrailingCharacters, 1, 6)),
     ]);
 
     test_parse_ok(vec![
@@ -721,15 +721,15 @@ fn test_parse_bool() {
 #[test]
 fn test_parse_number_errors() {
     test_parse_err::<f64>(vec![
-        ("+", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 1)),
-        (".", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 1)),
-        ("-", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 1)),
-        ("00", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 2)),
-        ("1.", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 2)),
-        ("1e", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 2)),
-        ("1e+", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 3)),
-        ("1a", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 2)),
-        ("1e777777777777777777777777777", Error::SyntaxError(ErrorCode::InvalidNumber, 1, 22)),
+        ("+", Error::Syntax(ErrorCode::ExpectedSomeValue, 1, 1)),
+        (".", Error::Syntax(ErrorCode::ExpectedSomeValue, 1, 1)),
+        ("-", Error::Syntax(ErrorCode::InvalidNumber, 1, 1)),
+        ("00", Error::Syntax(ErrorCode::InvalidNumber, 1, 2)),
+        ("1.", Error::Syntax(ErrorCode::InvalidNumber, 1, 2)),
+        ("1e", Error::Syntax(ErrorCode::InvalidNumber, 1, 2)),
+        ("1e+", Error::Syntax(ErrorCode::InvalidNumber, 1, 3)),
+        ("1a", Error::Syntax(ErrorCode::TrailingCharacters, 1, 2)),
+        ("1e777777777777777777777777777", Error::Syntax(ErrorCode::InvalidNumber, 1, 22)),
     ]);
 }
 
@@ -791,9 +791,9 @@ fn test_parse_f64() {
 #[test]
 fn test_parse_string() {
     test_parse_err::<String>(vec![
-        ("\"", Error::SyntaxError(ErrorCode::EOFWhileParsingString, 1, 1)),
-        ("\"lol", Error::SyntaxError(ErrorCode::EOFWhileParsingString, 1, 4)),
-        ("\"lol\"a", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 6)),
+        ("\"", Error::Syntax(ErrorCode::EOFWhileParsingString, 1, 1)),
+        ("\"lol", Error::Syntax(ErrorCode::EOFWhileParsingString, 1, 4)),
+        ("\"lol\"a", Error::Syntax(ErrorCode::TrailingCharacters, 1, 6)),
     ]);
 
     test_parse_ok(vec![
@@ -813,13 +813,13 @@ fn test_parse_string() {
 #[test]
 fn test_parse_list() {
     test_parse_err::<Vec<f64>>(vec![
-        ("[", Error::SyntaxError(ErrorCode::EOFWhileParsingList, 1, 1)),
-        ("[ ", Error::SyntaxError(ErrorCode::EOFWhileParsingList, 1, 2)),
-        ("[1", Error::SyntaxError(ErrorCode::EOFWhileParsingList,  1, 2)),
-        ("[1,", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 3)),
-        ("[1,]", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 4)),
-        ("[1 2]", Error::SyntaxError(ErrorCode::ExpectedListCommaOrEnd, 1, 4)),
-        ("[]a", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 3)),
+        ("[", Error::Syntax(ErrorCode::EOFWhileParsingList, 1, 1)),
+        ("[ ", Error::Syntax(ErrorCode::EOFWhileParsingList, 1, 2)),
+        ("[1", Error::Syntax(ErrorCode::EOFWhileParsingList,  1, 2)),
+        ("[1,", Error::Syntax(ErrorCode::EOFWhileParsingValue, 1, 3)),
+        ("[1,]", Error::Syntax(ErrorCode::ExpectedSomeValue, 1, 4)),
+        ("[1 2]", Error::Syntax(ErrorCode::ExpectedListCommaOrEnd, 1, 4)),
+        ("[]a", Error::Syntax(ErrorCode::TrailingCharacters, 1, 3)),
     ]);
 
     test_parse_ok(vec![
@@ -865,18 +865,18 @@ fn test_parse_list() {
 #[test]
 fn test_parse_object() {
     test_parse_err::<BTreeMap<String, u32>>(vec![
-        ("{", Error::SyntaxError(ErrorCode::EOFWhileParsingObject, 1, 1)),
-        ("{ ", Error::SyntaxError(ErrorCode::EOFWhileParsingObject, 1, 2)),
-        ("{1", Error::SyntaxError(ErrorCode::KeyMustBeAString, 1, 2)),
-        ("{ \"a\"", Error::SyntaxError(ErrorCode::EOFWhileParsingObject, 1, 5)),
-        ("{\"a\"", Error::SyntaxError(ErrorCode::EOFWhileParsingObject, 1, 4)),
-        ("{\"a\" ", Error::SyntaxError(ErrorCode::EOFWhileParsingObject, 1, 5)),
-        ("{\"a\" 1", Error::SyntaxError(ErrorCode::ExpectedColon, 1, 6)),
-        ("{\"a\":", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 5)),
-        ("{\"a\":1", Error::SyntaxError(ErrorCode::EOFWhileParsingObject, 1, 6)),
-        ("{\"a\":1 1", Error::SyntaxError(ErrorCode::ExpectedObjectCommaOrEnd, 1, 8)),
-        ("{\"a\":1,", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 7)),
-        ("{}a", Error::SyntaxError(ErrorCode::TrailingCharacters, 1, 3)),
+        ("{", Error::Syntax(ErrorCode::EOFWhileParsingObject, 1, 1)),
+        ("{ ", Error::Syntax(ErrorCode::EOFWhileParsingObject, 1, 2)),
+        ("{1", Error::Syntax(ErrorCode::KeyMustBeAString, 1, 2)),
+        ("{ \"a\"", Error::Syntax(ErrorCode::EOFWhileParsingObject, 1, 5)),
+        ("{\"a\"", Error::Syntax(ErrorCode::EOFWhileParsingObject, 1, 4)),
+        ("{\"a\" ", Error::Syntax(ErrorCode::EOFWhileParsingObject, 1, 5)),
+        ("{\"a\" 1", Error::Syntax(ErrorCode::ExpectedColon, 1, 6)),
+        ("{\"a\":", Error::Syntax(ErrorCode::EOFWhileParsingValue, 1, 5)),
+        ("{\"a\":1", Error::Syntax(ErrorCode::EOFWhileParsingObject, 1, 6)),
+        ("{\"a\":1 1", Error::Syntax(ErrorCode::ExpectedObjectCommaOrEnd, 1, 8)),
+        ("{\"a\":1,", Error::Syntax(ErrorCode::EOFWhileParsingValue, 1, 7)),
+        ("{}a", Error::Syntax(ErrorCode::TrailingCharacters, 1, 3)),
     ]);
 
     test_parse_ok(vec![
@@ -916,11 +916,11 @@ fn test_parse_object() {
 #[test]
 fn test_parse_struct() {
     test_parse_err::<Outer>(vec![
-        ("5", Error::SyntaxError(ErrorCode::InvalidType(de::Type::U64), 1, 1)),
-        ("\"hello\"", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Str), 1, 7)),
-        ("{\"inner\": true}", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Bool), 1, 14)),
-        ("{}", Error::SyntaxError(ErrorCode::MissingField("inner"), 1, 2)),
-        (r#"{"inner": [{"b": 42, "c": []}]}"#, Error::SyntaxError(ErrorCode::MissingField("a"), 1, 29)),
+        ("5", Error::Syntax(ErrorCode::InvalidType(de::Type::U64), 1, 1)),
+        ("\"hello\"", Error::Syntax(ErrorCode::InvalidType(de::Type::Str), 1, 7)),
+        ("{\"inner\": true}", Error::Syntax(ErrorCode::InvalidType(de::Type::Bool), 1, 14)),
+        ("{}", Error::Syntax(ErrorCode::MissingField("inner"), 1, 2)),
+        (r#"{"inner": [{"b": 42, "c": []}]}"#, Error::Syntax(ErrorCode::MissingField("a"), 1, 29)),
     ]);
 
     test_parse_ok(vec![
@@ -987,13 +987,13 @@ fn test_parse_option() {
 #[test]
 fn test_parse_enum_errors() {
     test_parse_err::<Animal>(vec![
-        ("{}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 2)),
-        ("{\"Dog\":", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 7)),
-        ("{\"Dog\":}", Error::SyntaxError(ErrorCode::ExpectedSomeValue, 1, 8)),
-        ("{\"unknown\":[]}", Error::SyntaxError(ErrorCode::UnknownField("unknown".to_string()), 1, 10)),
-        ("{\"Dog\":{}}", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Map), 1, 8)),
-        ("{\"Frog\":{}}", Error::SyntaxError(ErrorCode::InvalidType(de::Type::Map), 1, 9)),
-        ("{\"Cat\":[]}", Error::SyntaxError(ErrorCode::EOFWhileParsingValue, 1, 9)),
+        ("{}", Error::Syntax(ErrorCode::ExpectedSomeValue, 1, 2)),
+        ("{\"Dog\":", Error::Syntax(ErrorCode::EOFWhileParsingValue, 1, 7)),
+        ("{\"Dog\":}", Error::Syntax(ErrorCode::ExpectedSomeValue, 1, 8)),
+        ("{\"unknown\":[]}", Error::Syntax(ErrorCode::UnknownField("unknown".to_string()), 1, 10)),
+        ("{\"Dog\":{}}", Error::Syntax(ErrorCode::InvalidType(de::Type::Map), 1, 8)),
+        ("{\"Frog\":{}}", Error::Syntax(ErrorCode::InvalidType(de::Type::Map), 1, 9)),
+        ("{\"Cat\":[]}", Error::Syntax(ErrorCode::EOFWhileParsingValue, 1, 9)),
     ]);
 }
 
@@ -1053,7 +1053,7 @@ fn test_parse_trailing_whitespace() {
 #[test]
 fn test_multiline_errors() {
     test_parse_err::<BTreeMap<String, String>>(vec![
-        ("{\n  \"foo\":\n \"bar\"", Error::SyntaxError(ErrorCode::EOFWhileParsingObject, 3, 6)),
+        ("{\n  \"foo\":\n \"bar\"", Error::Syntax(ErrorCode::EOFWhileParsingObject, 3, 6)),
     ]);
 }
 
@@ -1087,7 +1087,7 @@ fn test_missing_nonoption_field() {
     }
 
     test_parse_err::<Foo>(vec![
-        ("{}", Error::SyntaxError(ErrorCode::MissingField("x"), 1, 2)),
+        ("{}", Error::Syntax(ErrorCode::MissingField("x"), 1, 2)),
     ]);
 }
 
@@ -1371,7 +1371,7 @@ fn test_serialize_rejects_non_key_maps() {
     );
 
     match serde_json::to_vec(&map).unwrap_err() {
-        serde_json::Error::SyntaxError(serde_json::ErrorCode::KeyMustBeAString, 0, 0) => {}
+        serde_json::Error::Syntax(serde_json::ErrorCode::KeyMustBeAString, 0, 0) => {}
         _ => panic!("integers used as keys"),
     }
 }


### PR DESCRIPTION
This change is necessary if https://github.com/serde-rs/serde/pull/166 is merged. More information in the linked PR.