### PR TITLE
fix(dependencies): Opt-out of default features of `num`

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -10,5 +10,8 @@ readme = "../README.md"
 keywords = ["json", "serde", "serialization"]
 
 [dependencies]
-num = "*"
 serde = "*"
+
+[dependencies.num]
+version = "*"
+default-features = false


### PR DESCRIPTION
`num` pulls in deps for features that `serde` doesn't need, so opt-out of them.