### PR TITLE
docs(typos): Add necessary whitespace, add renaming example

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -39,11 +39,15 @@
 //!     ]
 //! }
 //! ```
-//! If we assume that FirstName is optional and all other fields are mandatory, the above JSON could correspond to the following Rust structs:
+//!
+//! If we assume that FirstName is optional and all other fields are mandatory, the above JSON could
+//! correspond to the following Rust structs:
+//!
 //! ```rust
 //! #[derive(Serialize, Deserialize)]
 //! struct Data {
-//!     FirstName: Option<String>,
+//!     #[serde(rename="FirstName")] // to comply with Rust coding standards
+//!     first_name: Option<String>,
 //!     LastName: String,
 //!     Age: u32,
 //!     Address: Address,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -44,6 +44,7 @@
 //! correspond to the following Rust structs:
 //!
 //! ```rust
+//! //#![feature(custom_derive, plugin)]
 //! #[derive(Serialize, Deserialize)]
 //! struct Data {
 //!     #[serde(rename="FirstName")] // to comply with Rust coding standards


### PR DESCRIPTION
Fixes my formatting mistake introduced in https://github.com/serde-rs/json/pull/15 (sorry!) and also adds a renaming example.
