### PR TITLE
Add helper function to parse stream of json values

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -861,16 +861,16 @@ impl <T, Iter> Iterator for JSONStream<T, Iter>
         // skip whitespaces, if any
         // this helps with trailing whitespaces, since whitespaces between
         // values are handled for us.
-        let _:Result<()> = self.deser.parse_whitespace();
-        // Since Deserializer.eof() always return Ok(_), it's safe to
-        // call .ok() here
-        if self.deser.eof().ok().unwrap() {
-            None
-        } else {
-            match de::Deserialize::deserialize(&mut self.deser) {
+        if let Err(e) = self.deser.parse_whitespace() {
+            return Some(Err(e))
+        };
+        match self.deser.eof() {
+            Ok(true) => None,
+            Ok(false) => match de::Deserialize::deserialize(&mut self.deser) {
                 Ok(v) => Some(Ok(v)),
                 Err(e) => Some(Err(e))
-            }
+            },
+            Err(e) => Some(Err(e))
         }
     }
 }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -115,8 +115,8 @@
 //! ```
 
 #![deny(missing_docs)]
-
 extern crate num;
+extern crate core;
 extern crate serde;
 
 pub use self::de::{
@@ -125,6 +125,8 @@ pub use self::de::{
     from_reader,
     from_slice,
     from_str,
+    parse_stream,
+    JSONStream,
 };
 pub use self::error::{Error, ErrorCode, Result};
 pub use self::ser::{

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -53,14 +53,14 @@
 //!     Address: Address,
 //!     PhoneNumbers: Vec<String>
 //! }
-//! 
+//!
 //! #[derive(Serialize, Deserialize)]
 //! struct Address {
 //!     Street: String,
 //!     City: String,
 //!     Country: String
 //! }
-//! ``` 
+//! ```
 //!
 //! # Type-based Serialization and Deserialization
 //!
@@ -121,12 +121,11 @@ extern crate serde;
 
 pub use self::de::{
     Deserializer,
+    JSONStream,
     from_iter,
     from_reader,
     from_slice,
     from_str,
-    parse_stream,
-    JSONStream,
 };
 pub use self::error::{Error, ErrorCode, Result};
 pub use self::ser::{

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -1412,6 +1412,16 @@ fn test_json_stream_newlines() {
 }
 
 #[test]
+fn test_json_stream_trailing_whitespaces() {
+    let stream = "{\"x\":42} \t\n".to_string();
+    let mut parsed:JSONStream<Value, _> = JSONStream::new(
+        stream.as_bytes().iter().map(|byte| Ok(*byte)));
+    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+               &Value::U64(42));
+    assert!(parsed.next().is_none());
+}
+
+#[test]
 fn test_json_stream_truncated() {
     let stream = "{\"x\":40}\n{\"x\":".to_string();
     let mut parsed:JSONStream<Value, _> = JSONStream::new(

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -14,6 +14,8 @@ use serde_json::{
     Value,
     from_str,
     from_value,
+    parse_stream,
+    JSONStream,
     to_value,
 };
 
@@ -1392,4 +1394,20 @@ fn test_byte_buf_de() {
     let bytes = ByteBuf::from(vec![1, 2, 3]);
     let v: ByteBuf = serde_json::from_str("[1, 2, 3]").unwrap();
     assert_eq!(v, bytes);
+}
+
+#[test]
+fn test_parse_stream() {
+    let stream = "{\"x\":40}{\"x\":41}\n{\"x\":42}".to_string();
+    let mut parsed:JSONStream<Value, _> = parse_stream(stream
+                                                   .as_bytes()
+                                                   .iter()
+                                                   .map(|byte| Ok(*byte)));
+    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+               &Value::U64(40));
+    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+               &Value::U64(41));
+    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+               &Value::U64(42));
+    assert!(parsed.next().is_none());
 }

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -1431,3 +1431,11 @@ fn test_json_stream_truncated() {
     assert!(parsed.next().unwrap().is_err());
     assert!(parsed.next().is_none());
 }
+
+#[test]
+fn test_json_stream_empty() {
+    let stream = "".to_string();
+    let mut parsed:JSONStream<Value, _> = JSONStream::new(
+        stream.as_bytes().iter().map(|byte| Ok(*byte)));
+    assert!(parsed.next().is_none());
+}


### PR DESCRIPTION
Many modern web APIs return their data as stream of (sometimes newline
delimited) JSON values. This commits add handy function `parse_stream`
that returns Iterator over parsed values.

This feature has some drawbacks or issues:

* I'm not sure, whether it's good idea to expose `JSONStream` type, but it seems you cannot currently return abstract `Iterator`
* Ideally, we should accept `io::Read`, but I couldn't get it to work, unfortunately: `expected 'Iter', found `std::io::Bytes<R>`
* The hardest one — naming, — not sure, how to name iterator and helper function. 

Commit contains tests (and they are passing!) 

WDYT? 