### PR TITLE
Remove the Sized bound on to_value<T>()

### DIFF
--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -990,7 +990,13 @@ impl<'a> de::Deserializer for MapDeserializer<'a> {
 }
 
 /// Shortcut function to encode a `T` into a JSON `Value`
-pub fn to_value<T>(value: &T) -> Value
+///
+/// ```rust
+/// use serde_json::to_value;
+/// let val = to_value("foo");
+/// assert_eq!(val.as_string(), Some("foo"))
+/// ```
+pub fn to_value<T: ?Sized>(value: &T) -> Value
     where T: ser::Serialize
 {
     let mut ser = Serializer::new();


### PR DESCRIPTION
This allows to_value() to accept &str arguments directly.