### PR TITLE
Make the constructor methods publicly visible for the PrettyFormatter.

### DIFF
--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -440,11 +440,11 @@ pub struct PrettyFormatter<'a> {
 }
 
 impl<'a> PrettyFormatter<'a> {
-    fn new() -> Self {
+    pub fn new() -> Self {
         PrettyFormatter::with_indent(b"  ")
     }
 
-    fn with_indent(indent: &'a [u8]) -> Self {
+    pub fn with_indent(indent: &'a [u8]) -> Self {
         PrettyFormatter {
             current_indent: 0,
             indent: indent,


### PR DESCRIPTION
Unable to set the indent constant for a new PrettyFormatter instance, nor reuse PrettyFormatter in an external crate outside of the serde_json::ser::Serializer.

If you kept these private on purpose because you weren't sure of the API choice for setting the indent, let me know.