### PR TITLE
feat(serde-up) Support serde 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,15 @@ before_script:
     export PATH=$HOME/.local/bin:$PATH
 
 script:
+# TEMPORARY UNTIL SERDE 0.7 IS RELEASED
+- |
+  mkdir .travis-deps
+  mkdir .cargo
+  echo 'paths = ["./.travis-deps/serde"]' > .cargo/config
+  git clone https://github.com/serde-rs/serde .travis-deps/serde
+  pushd .travis-deps/serde
+  git reset --hard origin/master
+  popd
 - |
     (cd json && travis-cargo build) &&
     (cd json && travis-cargo test) &&

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -13,6 +13,9 @@ keywords = ["json", "serde", "serialization"]
 nightly-testing = ["clippy"]
 
 [dependencies]
-serde = "~0.6.1"
 num = { version = "~0.1.27", default-features = false }
 clippy = { version = "^0.*", optional = true }
+
+[dependencies.serde]
+serde = "0.6"
+

--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -525,7 +525,7 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, visitor: V) -> Result<V::Value>
+    fn deserialize<V>(&mut self, visitor: V) -> Result<V::Value>
         where V: de::Visitor,
     {
         self.parse_value(visitor)
@@ -533,7 +533,7 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
 
     /// Parses a `null` as a None, and any other values as a `Some(...)`.
     #[inline]
-    fn visit_option<V>(&mut self, mut visitor: V) -> Result<V::Value>
+    fn deserialize_option<V>(&mut self, mut visitor: V) -> Result<V::Value>
         where V: de::Visitor,
     {
         try!(self.parse_whitespace());
@@ -552,7 +552,7 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
 
     /// Parses a newtype struct as the underlying value.
     #[inline]
-    fn visit_newtype_struct<V>(&mut self,
+    fn deserialize_newtype_struct<V>(&mut self,
                                _name: &str,
                                mut visitor: V) -> Result<V::Value>
         where V: de::Visitor,
@@ -563,7 +563,7 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
     /// Parses an enum as an object like `{"$KEY":$VALUE}`, where $VALUE is either a straight
     /// value, a `[..]`, or a `{..}`.
     #[inline]
-    fn visit_enum<V>(&mut self,
+    fn deserialize_enum<V>(&mut self,
                      _name: &str,
                      _variants: &'static [&'static str],
                      mut visitor: V) -> Result<V::Value>
@@ -594,11 +594,6 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
                 Err(self.error(ErrorCode::ExpectedSomeValue))
             }
         }
-    }
-
-    #[inline]
-    fn format() -> &'static str {
-        "json"
     }
 }
 
@@ -753,14 +748,15 @@ impl<'a, Iter> de::MapVisitor for MapVisitor<'a, Iter>
         impl de::Deserializer for MissingFieldDeserializer {
             type Error = de::value::Error;
 
-            fn visit<V>(&mut self, _visitor: V) -> std::result::Result<V::Value, Self::Error>
+            fn deserialize<V>(&mut self, _visitor: V) -> std::result::Result<V::Value, Self::Error>
                 where V: de::Visitor,
             {
                 let &mut MissingFieldDeserializer(field) = self;
-                Err(de::value::Error::MissingFieldError(field))
+                Err(de::value::Error::MissingField(field))
             }
 
-            fn visit_option<V>(&mut self, mut visitor: V) -> std::result::Result<V::Value, Self::Error>
+            fn deserialize_option<V>(&mut self,
+                                     mut visitor: V) -> std::result::Result<V::Value, Self::Error>
                 where V: de::Visitor,
             {
                 visitor.visit_none()
@@ -800,7 +796,7 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
                       visitor: V) -> Result<V::Value>
         where V: de::Visitor,
     {
-        de::Deserializer::visit(self, visitor)
+        de::Deserializer::deserialize(self, visitor)
     }
 
     fn visit_struct<V>(&mut self,
@@ -808,7 +804,7 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
                        visitor: V) -> Result<V::Value>
         where V: de::Visitor,
     {
-        de::Deserializer::visit(self, visitor)
+        de::Deserializer::deserialize(self, visitor)
     }
 }
 

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -67,7 +67,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     type Error = Error;
 
     #[inline]
-    fn visit_bool(&mut self, value: bool) -> Result<()> {
+    fn serialize_bool(&mut self, value: bool) -> Result<()> {
         if value {
             self.writer.write_all(b"true").map_err(From::from)
         } else {
@@ -76,95 +76,95 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_isize(&mut self, value: isize) -> Result<()> {
+    fn serialize_isize(&mut self, value: isize) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i8(&mut self, value: i8) -> Result<()> {
+    fn serialize_i8(&mut self, value: i8) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i16(&mut self, value: i16) -> Result<()> {
+    fn serialize_i16(&mut self, value: i16) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i32(&mut self, value: i32) -> Result<()> {
+    fn serialize_i32(&mut self, value: i32) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_i64(&mut self, value: i64) -> Result<()> {
+    fn serialize_i64(&mut self, value: i64) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_usize(&mut self, value: usize) -> Result<()> {
+    fn serialize_usize(&mut self, value: usize) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u8(&mut self, value: u8) -> Result<()> {
+    fn serialize_u8(&mut self, value: u8) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u16(&mut self, value: u16) -> Result<()> {
+    fn serialize_u16(&mut self, value: u16) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u32(&mut self, value: u32) -> Result<()> {
+    fn serialize_u32(&mut self, value: u32) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_u64(&mut self, value: u64) -> Result<()> {
+    fn serialize_u64(&mut self, value: u64) -> Result<()> {
         write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_f32(&mut self, value: f32) -> Result<()> {
+    fn serialize_f32(&mut self, value: f32) -> Result<()> {
         fmt_f32_or_null(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_f64(&mut self, value: f64) -> Result<()> {
+    fn serialize_f64(&mut self, value: f64) -> Result<()> {
         fmt_f64_or_null(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_char(&mut self, value: char) -> Result<()> {
+    fn serialize_char(&mut self, value: char) -> Result<()> {
         escape_char(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_str(&mut self, value: &str) -> Result<()> {
+    fn serialize_str(&mut self, value: &str) -> Result<()> {
         escape_str(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
-    fn visit_none(&mut self) -> Result<()> {
-        self.visit_unit()
+    fn serialize_none(&mut self) -> Result<()> {
+        self.serialize_unit()
     }
 
     #[inline]
-    fn visit_some<V>(&mut self, value: V) -> Result<()>
+    fn serialize_some<V>(&mut self, value: V) -> Result<()>
         where V: ser::Serialize
     {
         value.serialize(self)
     }
 
     #[inline]
-    fn visit_unit(&mut self) -> Result<()> {
+    fn serialize_unit(&mut self) -> Result<()> {
         self.writer.write_all(b"null").map_err(From::from)
     }
 
     /// Override `visit_newtype_struct` to serialize newtypes without an object wrapper.
     #[inline]
-    fn visit_newtype_struct<T>(&mut self,
+    fn serialize_newtype_struct<T>(&mut self,
                                _name: &'static str,
                                value: T) -> Result<()>
         where T: ser::Serialize,
@@ -173,20 +173,20 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_unit_variant(&mut self,
+    fn serialize_unit_variant(&mut self,
                           _name: &str,
                           _variant_index: usize,
                           variant: &str) -> Result<()> {
         try!(self.formatter.open(&mut self.writer, b'{'));
         try!(self.formatter.comma(&mut self.writer, true));
-        try!(self.visit_str(variant));
+        try!(self.serialize_str(variant));
         try!(self.formatter.colon(&mut self.writer));
         try!(self.writer.write_all(b"[]"));
         self.formatter.close(&mut self.writer, b'}')
     }
 
     #[inline]
-    fn visit_newtype_variant<T>(&mut self,
+    fn serialize_newtype_variant<T>(&mut self,
                                 _name: &str,
                                 _variant_index: usize,
                                 variant: &str,
@@ -195,14 +195,14 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
         try!(self.formatter.comma(&mut self.writer, true));
-        try!(self.visit_str(variant));
+        try!(self.serialize_str(variant));
         try!(self.formatter.colon(&mut self.writer));
         try!(value.serialize(self));
         self.formatter.close(&mut self.writer, b'}')
     }
 
     #[inline]
-    fn visit_seq<V>(&mut self, mut visitor: V) -> Result<()>
+    fn serialize_seq<V>(&mut self, mut visitor: V) -> Result<()>
         where V: ser::SeqVisitor,
     {
         match visitor.len() {
@@ -223,7 +223,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_tuple_variant<V>(&mut self,
+    fn serialize_tuple_variant<V>(&mut self,
                               _name: &str,
                               _variant_index: usize,
                               variant: &str,
@@ -232,14 +232,14 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
         try!(self.formatter.comma(&mut self.writer, true));
-        try!(self.visit_str(variant));
+        try!(self.serialize_str(variant));
         try!(self.formatter.colon(&mut self.writer));
-        try!(self.visit_seq(visitor));
+        try!(self.serialize_seq(visitor));
         self.formatter.close(&mut self.writer, b'}')
     }
 
     #[inline]
-    fn visit_seq_elt<T>(&mut self, value: T) -> Result<()>
+    fn serialize_seq_elt<T>(&mut self, value: T) -> Result<()>
         where T: ser::Serialize,
     {
         try!(self.formatter.comma(&mut self.writer, self.first));
@@ -251,7 +251,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_map<V>(&mut self, mut visitor: V) -> Result<()>
+    fn serialize_map<V>(&mut self, mut visitor: V) -> Result<()>
         where V: ser::MapVisitor,
     {
         match visitor.len() {
@@ -271,7 +271,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     }
 
     #[inline]
-    fn visit_struct_variant<V>(&mut self,
+    fn serialize_struct_variant<V>(&mut self,
                                _name: &str,
                                _variant_index: usize,
                                variant: &str,
@@ -280,15 +280,15 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     {
         try!(self.formatter.open(&mut self.writer, b'{'));
         try!(self.formatter.comma(&mut self.writer, true));
-        try!(self.visit_str(variant));
+        try!(self.serialize_str(variant));
         try!(self.formatter.colon(&mut self.writer));
-        try!(self.visit_map(visitor));
+        try!(self.serialize_map(visitor));
 
         self.formatter.close(&mut self.writer, b'}')
     }
 
     #[inline]
-    fn visit_map_elt<K, V>(&mut self, key: K, value: V) -> Result<()>
+    fn serialize_map_elt<K, V>(&mut self, key: K, value: V) -> Result<()>
         where K: ser::Serialize,
               V: ser::Serialize,
     {
@@ -301,11 +301,6 @@ impl<W, F> ser::Serializer for Serializer<W, F>
         self.first = false;
 
         Ok(())
-    }
-
-    #[inline]
-    fn format() -> &'static str {
-        "json"
     }
 }
 
@@ -320,59 +315,59 @@ impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
     type Error = Error;
 
     #[inline]
-    fn visit_str(&mut self, value: &str) -> Result<()> {
-        self.ser.visit_str(value)
+    fn serialize_str(&mut self, value: &str) -> Result<()> {
+        self.ser.serialize_str(value)
     }
 
-    fn visit_bool(&mut self, _value: bool) -> Result<()> {
+    fn serialize_bool(&mut self, _value: bool) -> Result<()> {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_i64(&mut self, _value: i64) -> Result<()> {
+    fn serialize_i64(&mut self, _value: i64) -> Result<()> {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_u64(&mut self, _value: u64) -> Result<()> {
+    fn serialize_u64(&mut self, _value: u64) -> Result<()> {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_f64(&mut self, _value: f64) -> Result<()> {
+    fn serialize_f64(&mut self, _value: f64) -> Result<()> {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_unit(&mut self) -> Result<()> {
+    fn serialize_unit(&mut self) -> Result<()> {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_none(&mut self) -> Result<()> {
+    fn serialize_none(&mut self) -> Result<()> {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_some<V>(&mut self, _value: V) -> Result<()>
+    fn serialize_some<V>(&mut self, _value: V) -> Result<()>
         where V: ser::Serialize
     {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_seq<V>(&mut self, _visitor: V) -> Result<()>
+    fn serialize_seq<V>(&mut self, _visitor: V) -> Result<()>
         where V: ser::SeqVisitor,
     {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_seq_elt<T>(&mut self, _value: T) -> Result<()>
+    fn serialize_seq_elt<T>(&mut self, _value: T) -> Result<()>
         where T: ser::Serialize,
     {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_map<V>(&mut self, _visitor: V) -> Result<()>
+    fn serialize_map<V>(&mut self, _visitor: V) -> Result<()>
         where V: ser::MapVisitor,
     {
         Err(Error::SyntaxError(ErrorCode::KeyMustBeAString, 0, 0))
     }
 
-    fn visit_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<()>
+    fn serialize_map_elt<K, V>(&mut self, _key: K, _value: V) -> Result<()>
         where K: ser::Serialize,
               V: ser::Serialize,
     {

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -301,12 +301,12 @@ impl ser::Serialize for Value {
         where S: ser::Serializer,
     {
         match *self {
-            Value::Null => serializer.visit_unit(),
-            Value::Bool(v) => serializer.visit_bool(v),
-            Value::I64(v) => serializer.visit_i64(v),
-            Value::U64(v) => serializer.visit_u64(v),
-            Value::F64(v) => serializer.visit_f64(v),
-            Value::String(ref v) => serializer.visit_str(&v),
+            Value::Null => serializer.serialize_unit(),
+            Value::Bool(v) => serializer.serialize_bool(v),
+            Value::I64(v) => serializer.serialize_i64(v),
+            Value::U64(v) => serializer.serialize_u64(v),
+            Value::F64(v) => serializer.serialize_f64(v),
+            Value::String(ref v) => serializer.serialize_str(&v),
             Value::Array(ref v) => v.serialize(serializer),
             Value::Object(ref v) => v.serialize(serializer),
         }
@@ -393,7 +393,7 @@ impl de::Deserialize for Value {
             }
         }
 
-        deserializer.visit(ValueVisitor)
+        deserializer.deserialize(ValueVisitor)
     }
 }
 
@@ -452,16 +452,16 @@ impl Serializer {
 }
 
 impl ser::Serializer for Serializer {
-    type Error = ();
+    type Error = Error;
 
     #[inline]
-    fn visit_bool(&mut self, value: bool) -> Result<(), ()> {
+    fn serialize_bool(&mut self, value: bool) -> Result<(), Error> {
         self.state.push(State::Value(Value::Bool(value)));
         Ok(())
     }
 
     #[inline]
-    fn visit_i64(&mut self, value: i64) -> Result<(), ()> {
+    fn serialize_i64(&mut self, value: i64) -> Result<(), Error> {
         if value < 0 {
             self.state.push(State::Value(Value::I64(value)));
         } else {
@@ -471,53 +471,53 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_u64(&mut self, value: u64) -> Result<(), ()> {
+    fn serialize_u64(&mut self, value: u64) -> Result<(), Error> {
         self.state.push(State::Value(Value::U64(value)));
         Ok(())
     }
 
     #[inline]
-    fn visit_f64(&mut self, value: f64) -> Result<(), ()> {
+    fn serialize_f64(&mut self, value: f64) -> Result<(), Error> {
         self.state.push(State::Value(Value::F64(value as f64)));
         Ok(())
     }
 
     #[inline]
-    fn visit_char(&mut self, value: char) -> Result<(), ()> {
+    fn serialize_char(&mut self, value: char) -> Result<(), Error> {
         let mut s = String::new();
         s.push(value);
-        self.visit_str(&s)
+        self.serialize_str(&s)
     }
 
     #[inline]
-    fn visit_str(&mut self, value: &str) -> Result<(), ()> {
+    fn serialize_str(&mut self, value: &str) -> Result<(), Error> {
         self.state.push(State::Value(Value::String(String::from(value))));
         Ok(())
     }
 
     #[inline]
-    fn visit_none(&mut self) -> Result<(), ()> {
-        self.visit_unit()
+    fn serialize_none(&mut self) -> Result<(), Error> {
+        self.serialize_unit()
     }
 
     #[inline]
-    fn visit_some<V>(&mut self, value: V) -> Result<(), ()>
+    fn serialize_some<V>(&mut self, value: V) -> Result<(), Error>
         where V: ser::Serialize,
     {
         value.serialize(self)
     }
 
     #[inline]
-    fn visit_unit(&mut self) -> Result<(), ()> {
+    fn serialize_unit(&mut self) -> Result<(), Error> {
         self.state.push(State::Value(Value::Null));
         Ok(())
     }
 
     #[inline]
-    fn visit_unit_variant(&mut self,
+    fn serialize_unit_variant(&mut self,
                           _name: &str,
                           _variant_index: usize,
-                          variant: &str) -> Result<(), ()> {
+                          variant: &str) -> Result<(), Error> {
         let mut values = BTreeMap::new();
         values.insert(String::from(variant), Value::Array(vec![]));
 
@@ -527,11 +527,11 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_newtype_variant<T>(&mut self,
+    fn serialize_newtype_variant<T>(&mut self,
                                 _name: &str,
                                 _variant_index: usize,
                                 variant: &str,
-                                value: T) -> Result<(), ()>
+                                value: T) -> Result<(), Error>
         where T: ser::Serialize,
     {
         let mut values = BTreeMap::new();
@@ -543,7 +543,7 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_seq<V>(&mut self, mut visitor: V) -> Result<(), ()>
+    fn serialize_seq<V>(&mut self, mut visitor: V) -> Result<(), Error>
         where V: ser::SeqVisitor,
     {
         let len = visitor.len().unwrap_or(0);
@@ -564,14 +564,14 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_tuple_variant<V>(&mut self,
+    fn serialize_tuple_variant<V>(&mut self,
                               _name: &str,
                               _variant_index: usize,
                               variant: &str,
-                              visitor: V) -> Result<(), ()>
+                              visitor: V) -> Result<(), Error>
         where V: ser::SeqVisitor,
     {
-        try!(self.visit_seq(visitor));
+        try!(self.serialize_seq(visitor));
 
         let value = match self.state.pop().unwrap() {
             State::Value(value) => value,
@@ -588,7 +588,7 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_seq_elt<T>(&mut self, value: T) -> Result<(), ()>
+    fn serialize_seq_elt<T>(&mut self, value: T) -> Result<(), Error>
         where T: ser::Serialize,
     {
         try!(value.serialize(self));
@@ -607,7 +607,7 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_map<V>(&mut self, mut visitor: V) -> Result<(), ()>
+    fn serialize_map<V>(&mut self, mut visitor: V) -> Result<(), Error>
         where V: ser::MapVisitor,
     {
         let values = BTreeMap::new();
@@ -627,14 +627,14 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_struct_variant<V>(&mut self,
+    fn serialize_struct_variant<V>(&mut self,
                                _name: &str,
                                _variant_index: usize,
                                variant: &str,
-                               visitor: V) -> Result<(), ()>
+                               visitor: V) -> Result<(), Error>
         where V: ser::MapVisitor,
     {
-        try!(self.visit_map(visitor));
+        try!(self.serialize_map(visitor));
 
         let value = match self.state.pop().unwrap() {
             State::Value(value) => value,
@@ -651,7 +651,7 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
-    fn visit_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), ()>
+    fn serialize_map_elt<K, V>(&mut self, key: K, value: V) -> Result<(), Error>
         where K: ser::Serialize,
               V: ser::Serialize,
     {
@@ -676,11 +676,6 @@ impl ser::Serializer for Serializer {
 
         Ok(())
     }
-
-    #[inline]
-    fn format() -> &'static str {
-        "json"
-    }
 }
 
 /// Creates a `serde::Deserializer` from a `json::Value` object.
@@ -701,7 +696,7 @@ impl de::Deserializer for Deserializer {
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         let value = match self.value.take() {
@@ -737,7 +732,7 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn visit_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         match self.value {
@@ -748,7 +743,7 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn visit_enum<V>(&mut self,
+    fn deserialize_enum<V>(&mut self,
                      _name: &str,
                      _variants: &'static [&'static str],
                      mut visitor: V) -> Result<V::Value, Error>
@@ -779,17 +774,12 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn visit_newtype_struct<V>(&mut self,
+    fn deserialize_newtype_struct<V>(&mut self,
                                _name: &'static str,
                                mut visitor: V) -> Result<V::Value, Self::Error>
         where V: de::Visitor,
     {
         visitor.visit_newtype_struct(self)
-    }
-
-    #[inline]
-    fn format() -> &'static str {
-        "json"
     }
 }
 
@@ -824,7 +814,7 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         where V: de::Visitor,
     {
         if let Value::Array(fields) = self.val.take().unwrap() {
-            de::Deserializer::visit(
+            de::Deserializer::deserialize(
                 &mut SeqDeserializer {
                     de: self.de,
                     len: fields.len(),
@@ -843,7 +833,7 @@ impl<'a> de::VariantVisitor for VariantDeserializer<'a> {
         where V: de::Visitor,
     {
         if let Value::Object(fields) = self.val.take().unwrap() {
-            de::Deserializer::visit(
+            de::Deserializer::deserialize(
                 &mut MapDeserializer {
                     de: self.de,
                     len: fields.len(),
@@ -868,7 +858,7 @@ impl<'a> de::Deserializer for SeqDeserializer<'a> {
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         if self.len == 0 {
@@ -957,13 +947,13 @@ impl<'a> de::MapVisitor for MapDeserializer<'a> {
         impl de::Deserializer for UnitDeserializer {
             type Error = Error;
 
-            fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+            fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
                 where V: de::Visitor,
             {
                 visitor.visit_unit()
             }
 
-            fn visit_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+            fn deserialize_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
                 where V: de::Visitor,
             {
                 visitor.visit_none()
@@ -982,7 +972,7 @@ impl<'a> de::Deserializer for MapDeserializer<'a> {
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         visitor.visit_map(self)

--- a/json_tests/benches/bench_log.rs
+++ b/json_tests/benches/bench_log.rs
@@ -73,7 +73,7 @@ impl ser::Serialize for HttpProtocol {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: ser::Serializer,
     {
-        serializer.visit_u8(*self as u8)
+        serializer.serialize_u8(*self as u8)
     }
 }
 
@@ -82,7 +82,7 @@ impl de::Deserialize for HttpProtocol {
     fn deserialize<
         S: Deserializer,
     >(state: &mut S) -> Result<HttpProtocol, S::Error> {
-        state.visit(de::impls::PrimitiveVisitor::new())
+        state.deserialize(de::impls::PrimitiveVisitor::new())
     }
 }
 
@@ -150,7 +150,7 @@ impl ser::Serialize for HttpMethod {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: ser::Serializer,
     {
-        serializer.visit_u8(*self as u8)
+        serializer.serialize_u8(*self as u8)
     }
 }
 
@@ -159,7 +159,7 @@ impl de::Deserialize for HttpMethod {
     fn deserialize<
         S: de::Deserializer,
     >(state: &mut S) -> Result<HttpMethod, S::Error> {
-        state.visit(de::impls::PrimitiveVisitor::new())
+        state.deserialize(de::impls::PrimitiveVisitor::new())
     }
 }
 
@@ -213,7 +213,7 @@ impl ser::Serialize for CacheStatus {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: ser::Serializer,
     {
-        serializer.visit_u8(*self as u8)
+        serializer.serialize_u8(*self as u8)
     }
 }
 
@@ -222,7 +222,7 @@ impl de::Deserialize for CacheStatus {
     fn deserialize<
         S: de::Deserializer,
     >(state: &mut S) -> Result<CacheStatus, S::Error> {
-        state.visit(de::impls::PrimitiveVisitor::new())
+        state.deserialize(de::impls::PrimitiveVisitor::new())
     }
 }
 
@@ -282,7 +282,7 @@ impl ser::Serialize for OriginProtocol {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: ser::Serializer,
     {
-        serializer.visit_u8(*self as u8)
+        serializer.serialize_u8(*self as u8)
     }
 }
 
@@ -291,7 +291,7 @@ impl de::Deserialize for OriginProtocol {
     fn deserialize<
         S: de::Deserializer,
     >(state: &mut S) -> Result<OriginProtocol, S::Error> {
-        state.visit(de::impls::PrimitiveVisitor::new())
+        state.deserialize(de::impls::PrimitiveVisitor::new())
     }
 }
 
@@ -347,7 +347,7 @@ impl ser::Serialize for ZonePlan {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: ser::Serializer,
     {
-        serializer.visit_u8(*self as u8)
+        serializer.serialize_u8(*self as u8)
     }
 }
 
@@ -356,7 +356,7 @@ impl de::Deserialize for ZonePlan {
     fn deserialize<
         S: de::Deserializer,
     >(state: &mut S) -> Result<ZonePlan, S::Error> {
-        state.visit(de::impls::PrimitiveVisitor::new())
+        state.deserialize(de::impls::PrimitiveVisitor::new())
     }
 }
 
@@ -913,7 +913,7 @@ impl ser::Serialize for Country {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: ser::Serializer,
     {
-        serializer.visit_u8(*self as u8)
+        serializer.serialize_u8(*self as u8)
     }
 }
 
@@ -922,7 +922,7 @@ impl de::Deserialize for Country {
     fn deserialize<
         S: de::Deserializer,
     >(state: &mut S) -> Result<Country, S::Error> {
-        state.visit(de::impls::PrimitiveVisitor::new())
+        state.deserialize(de::impls::PrimitiveVisitor::new())
     }
 }
 

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -33,6 +33,7 @@ macro_rules! treemap {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 enum Animal {
     Dog,
     Frog(String, Vec<isize>),
@@ -1120,29 +1121,6 @@ fn test_missing_renamed_field() {
 }
 
 #[test]
-fn test_missing_fmt_renamed_field() {
-    #[derive(Debug, PartialEq, Deserialize)]
-    struct Foo {
-        #[serde(rename(json="y"))]
-        x: Option<u32>,
-    }
-
-    let value: Foo = from_str("{}").unwrap();
-    assert_eq!(value, Foo { x: None });
-
-    let value: Foo = from_str("{\"y\": 5}").unwrap();
-    assert_eq!(value, Foo { x: Some(5) });
-
-    let value: Foo = from_value(Value::Object(treemap!())).unwrap();
-    assert_eq!(value, Foo { x: None });
-
-    let value : Foo = from_value(Value::Object(treemap!(
-        "y".to_string() => Value::I64(5)
-            ))).unwrap();
-    assert_eq!(value, Foo { x: Some(5) });
-}
-
-#[test]
 fn test_find_path() {
     let obj: Value = serde_json::from_str(r#"{"x": {"a": 1}, "y": 2}"#).unwrap();
 
@@ -1172,7 +1150,7 @@ fn test_serialize_seq_with_no_len() {
         fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
             where S: ser::Serializer,
         {
-            serializer.visit_seq(ser::impls::SeqIteratorVisitor::new(self.0.iter(), None))
+            serializer.serialize_seq(ser::impls::SeqIteratorVisitor::new(self.0.iter(), None))
         }
     }
 
@@ -1214,7 +1192,7 @@ fn test_serialize_seq_with_no_len() {
         fn deserialize<D>(deserializer: &mut D) -> Result<MyVec<T>, D::Error>
             where D: de::Deserializer,
         {
-            deserializer.visit_map(Visitor { marker: PhantomData })
+            deserializer.deserialize_map(Visitor { marker: PhantomData })
         }
     }
 
@@ -1257,7 +1235,7 @@ fn test_serialize_map_with_no_len() {
         fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
             where S: ser::Serializer,
         {
-            serializer.visit_map(ser::impls::MapIteratorVisitor::new(self.0.iter(), None))
+            serializer.serialize_map(ser::impls::MapIteratorVisitor::new(self.0.iter(), None))
         }
     }
 
@@ -1301,7 +1279,7 @@ fn test_serialize_map_with_no_len() {
         fn deserialize<D>(deserializer: &mut D) -> Result<Map<K, V>, D::Error>
             where D: de::Deserializer,
         {
-            deserializer.visit_map(Visitor { marker: PhantomData })
+            deserializer.deserialize_map(Visitor { marker: PhantomData })
         }
     }
 


### PR DESCRIPTION
**NOT READY** this needs changes before merging; Cargo.toml spec is hard coded to a git rev

Mappings from visit_* to de/serialize_* should be self explanatory. [serde(deny_unknown_fields)] was added to a test struct since it was checking for denial. A couple of error types were added to support new
serde de::value::Error variants. Finally, there are a bunch of throwaway changes pinning the serde version to a 0.7 commit. These should be removed once 0.7 lands in favor of a crates.io semver spec.