### PR TITLE
Fix negative zero

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -284,9 +284,7 @@ impl<Iter> Deserializer<Iter>
                 if pos {
                     visitor.visit_u64(res)
                 } else {
-                    // FIXME: `wrapping_neg` will be stable in Rust 1.2
-                    //let res_i64 = (res as i64).wrapping_neg();
-                    let res_i64 = (!res + 1) as i64;
+                    let res_i64 = (res as i64).wrapping_neg();
 
                     // Convert into a float if we underflow.
                     if res_i64 > 0 {

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -755,6 +755,14 @@ fn test_parse_u64() {
 }
 
 #[test]
+fn test_parse_negative_zero() {
+    assert_eq!(0, from_str::<u32>("-0").unwrap());
+    assert_eq!(0, from_str::<u32>("-0.0").unwrap());
+    assert_eq!(0, from_str::<u32>("-0e2").unwrap());
+    assert_eq!(0, from_str::<u32>("-0.0e2").unwrap());
+}
+
+#[test]
 fn test_parse_f64() {
     test_parse_ok(vec![
         ("0.0", 0.0f64),


### PR DESCRIPTION
Currently there is a fixme that was never fixed, which causes `-0` to explode with an overflow.