### PR TITLE
Specialize unit enum variants to only serialize variant name

### DIFF
--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -177,12 +177,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
                           _name: &str,
                           _variant_index: usize,
                           variant: &str) -> Result<()> {
-        try!(self.formatter.open(&mut self.writer, b'{'));
-        try!(self.formatter.comma(&mut self.writer, true));
-        try!(self.visit_str(variant));
-        try!(self.formatter.colon(&mut self.writer));
-        try!(self.writer.write_all(b"[]"));
-        self.formatter.close(&mut self.writer, b'}')
+        self.visit_str(variant)
     }
 
     #[inline]

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -538,7 +538,7 @@ fn test_write_enum() {
     test_encode_ok(&[
         (
             Animal::Dog,
-            "{\"Dog\":[]}",
+            "\"Dog\"",
         ),
         (
             Animal::Frog("Henry".to_string(), vec![]),
@@ -565,11 +565,7 @@ fn test_write_enum() {
     test_pretty_encode_ok(&[
         (
             Animal::Dog,
-            concat!(
-                "{\n",
-                "  \"Dog\": []\n",
-                "}"
-            ),
+            "\"Dog\""
         ),
         (
             Animal::Frog("Henry".to_string(), vec![]),
@@ -999,8 +995,8 @@ fn test_parse_enum_errors() {
 #[test]
 fn test_parse_enum() {
     test_parse_ok(vec![
-        ("{\"Dog\":[]}", Animal::Dog),
-        (" { \"Dog\" : [ ] } ", Animal::Dog),
+        ("\"Dog\"", Animal::Dog),
+        (" \"Dog\" ", Animal::Dog),
         (
             "{\"Frog\":[\"Henry\",[]]}",
             Animal::Frog("Henry".to_string(), vec![]),
@@ -1027,7 +1023,7 @@ fn test_parse_enum() {
         (
             concat!(
                 "{",
-                "  \"a\": {\"Dog\": []},",
+                "  \"a\": \"Dog\",",
                 "  \"b\": {\"Frog\":[\"Henry\", []]}",
                 "}"
             ),


### PR DESCRIPTION
this simplifies serialization/deserialization for unit enum variants which only need to serialize the variant name
example:
```rust
enum Animal{
   Cat,
   Dog
}
let animal = Animal::Dog;
```
`animal` will now be serialized as `"Dog"` instead of `{"Dog":[]}`