### PR TITLE
Eat on errors, fixes problem with StreamDeserializer.

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -162,6 +162,7 @@ impl<Iter> Deserializer<Iter>
                 visitor.visit_map(MapVisitor::new(self))
             }
             _ => {
+                self.eat_char();
                 Err(self.error(ErrorCode::ExpectedSomeValue))
             }
         };


### PR DESCRIPTION
I'm not 100% sure if this is what we want to do in every case, but there is a problem with the `StreamDeserializer` where it reads a `Err` and then keeps reading the same error over and over because the stream hasn't been advanced. For example the JSON `a` will loop forever in the error case.

Here's a complete example:

```rust
extern crate serde_json;

use serde_json::*;
use std::io::{self, Read};

fn main() {
    let stdin = io::stdin();
    let stream_deserializer: StreamDeserializer<Value, _> = StreamDeserializer::new(stdin.bytes());

    for value in stream_deserializer {
        match value {
            Ok(v) => println!("{:?}", v),
            Err(_) => println!("Encountered a json parsing error, closing"),
        }
    }
}
```