### PR TITLE
Correctly escape ASCII control characters in strings

### DIFF
--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -504,6 +504,7 @@ pub fn escape_bytes<W>(wr: &mut W, bytes: &[u8]) -> Result<()>
             b'\n' => b"\\n",
             b'\r' => b"\\r",
             b'\t' => b"\\t",
+            b'\x00' ... b'\x1F' => b"\\u",
             _ => { continue; }
         };
 
@@ -512,6 +513,9 @@ pub fn escape_bytes<W>(wr: &mut W, bytes: &[u8]) -> Result<()>
         }
 
         try!(wr.write_all(escaped));
+        if escaped[1] == b'u' {
+            try!(write!(wr, "{:04x}", *byte));
+        }
 
         start = i + 1;
     }

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -461,7 +461,7 @@ fn test_write_object() {
 
     let complex_obj = Value::Object(treemap!(
         "b".to_string() => Value::Array(vec![
-            Value::Object(treemap!("c".to_string() => Value::String("\x0c\r".to_string()))),
+            Value::Object(treemap!("c".to_string() => Value::String("\x0c\x1f\r".to_string()))),
             Value::Object(treemap!("d".to_string() => Value::String("".to_string())))
         ])
     ));
@@ -471,7 +471,7 @@ fn test_write_object() {
             complex_obj.clone(),
             "{\
                 \"b\":[\
-                    {\"c\":\"\\f\\r\"},\
+                    {\"c\":\"\\f\\u001f\\r\"},\
                     {\"d\":\"\"}\
                 ]\
             }"
@@ -485,7 +485,7 @@ fn test_write_object() {
                 "{\n",
                 "  \"b\": [\n",
                 "    {\n",
-                "      \"c\": \"\\f\\r\"\n",
+                "      \"c\": \"\\f\\u001f\\r\"\n",
                 "    },\n",
                 "    {\n",
                 "      \"d\": \"\"\n",


### PR DESCRIPTION
This patch escapes ASCII control characters in the range 0x00...0x1f, in accordance with the JSON spec.

Fixes #51