### PR TITLE
Serialize unit variants as name only

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -18,6 +18,7 @@ pub struct Deserializer<Iter: Iterator<Item=io::Result<u8>>> {
     rdr: LineColIterator<Iter>,
     ch: Option<u8>,
     str_buf: Vec<u8>,
+    key_only_enum_variant: bool,
 }
 
 macro_rules! try_or_invalid {
@@ -39,6 +40,7 @@ impl<Iter> Deserializer<Iter>
             rdr: LineColIterator::new(rdr),
             ch: None,
             str_buf: Vec::with_capacity(128),
+            key_only_enum_variant: false,
         }
     }
 
@@ -512,8 +514,11 @@ impl<Iter> Deserializer<Iter>
     fn parse_object_colon(&mut self) -> Result<()> {
         try!(self.parse_whitespace());
 
-        match try!(self.next_char()) {
-            Some(b':') => Ok(()),
+        match try!(self.peek()) {
+            Some(b':') => {
+                self.eat_char();
+                Ok(())
+            }
             Some(_) => Err(self.error(ErrorCode::ExpectedColon)),
             None => Err(self.error(ErrorCode::EOFWhileParsingObject)),
         }
@@ -572,8 +577,9 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
     {
         try!(self.parse_whitespace());
 
-        match try!(self.next_char_or_null()) {
+        match try!(self.peek_or_null()) {
             b'{' => {
+                self.eat_char();
                 try!(self.parse_whitespace());
 
                 let value = {
@@ -590,6 +596,10 @@ impl<Iter> de::Deserializer for Deserializer<Iter>
                         Err(self.error(ErrorCode::ExpectedSomeValue))
                     }
                 }
+            }
+            b'"' => {
+                self.key_only_enum_variant = true;
+                visitor.visit(&mut *self)
             }
             _ => {
                 Err(self.error(ErrorCode::ExpectedSomeValue))
@@ -778,17 +788,25 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
         where V: de::Deserialize
     {
         let val = try!(de::Deserialize::deserialize(self));
-        try!(self.parse_object_colon());
+        if !self.key_only_enum_variant {
+            try!(self.parse_object_colon());
+        }
         Ok(val)
     }
 
     fn visit_unit(&mut self) -> Result<()> {
-        de::Deserialize::deserialize(self)
+        if self.key_only_enum_variant {
+            self.key_only_enum_variant = false;
+            Ok(())
+        } else {
+            de::Deserialize::deserialize(self)
+        }
     }
 
     fn visit_newtype<T>(&mut self) -> Result<T>
         where T: de::Deserialize,
     {
+        self.key_only_enum_variant = false;
         de::Deserialize::deserialize(self)
     }
 
@@ -797,6 +815,7 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
                       visitor: V) -> Result<V::Value>
         where V: de::Visitor,
     {
+        self.key_only_enum_variant = false;
         de::Deserializer::deserialize(self, visitor)
     }
 
@@ -805,6 +824,7 @@ impl<Iter> de::VariantVisitor for Deserializer<Iter>
                        visitor: V) -> Result<V::Value>
         where V: de::Visitor,
     {
+        self.key_only_enum_variant = false;
         de::Deserializer::deserialize(self, visitor)
     }
 }

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -179,12 +179,7 @@ impl<W, F> ser::Serializer for Serializer<W, F>
                           _name: &str,
                           _variant_index: usize,
                           variant: &str) -> Result<()> {
-        try!(self.formatter.open(&mut self.writer, b'{'));
-        try!(self.formatter.comma(&mut self.writer, true));
-        try!(self.serialize_str(variant));
-        try!(self.formatter.colon(&mut self.writer));
-        try!(self.writer.write_all(b"[]"));
-        self.formatter.close(&mut self.writer, b'}')
+        self.serialize_str(variant)
     }
 
     #[inline]


### PR DESCRIPTION
Ref https://github.com/serde-rs/serde/issues/251. This is a rebase of #37 with more tests to ensure backward-compatibility with the current format.