### PR TITLE
Added Decimal support with the decimal crate, standarizes on a single Number value.

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["json", "serde", "serialization"]
 nightly-testing = ["clippy"]
 
 [dependencies]
-serde = "^0.7.0"
+serde = { path = "../../serde/serde" }
 num = { version = "~0.1.27", default-features = false }
 clippy = { version = "^0.*", optional = true }
+decimal = "0.4"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_json"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A JSON serialization file format"
@@ -13,7 +13,6 @@ keywords = ["json", "serde", "serialization"]
 nightly-testing = ["clippy"]
 
 [dependencies]
-serde = { path = "../../serde/serde" }
-#serde = "^0.7.0"
+serde = { version = "^0.8.0", git = "https://github.com/nubis/serde" }
 num-traits = "~0.1.32"
 clippy = { version = "^0.*", optional = true }

--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -204,7 +204,7 @@ impl<Iter> Deserializer<Iter>
               },
               _ => {
                 let whole = str::from_utf8(&buf).unwrap();
-                println!("{:?}", whole);
+                println!("Whole {:?}", whole);
                 let m = match d128::from_str(whole) {
                   Ok(d) => visitor.visit_d128(d),
                   _ => Err(self.error(ErrorCode::InvalidNumber))

--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -142,10 +142,7 @@ impl<Iter> Deserializer<Iter>
                 try!(self.parse_ident(b"alse"));
                 visitor.visit_bool(false)
             }
-            b'-' => {
-                self.parse_d128(visitor)
-            }
-            b'0' ... b'9' => {
+            b'-' | b'0' ... b'9' => {
                 self.parse_d128(visitor)
             }
             b'"' => {
@@ -188,241 +185,66 @@ impl<Iter> Deserializer<Iter>
         where V: de::Visitor,
     {
         // Do I really need a new buffer?
-        // Can I match more than one thing on a let arm.
+        // Can I match more than one thing on a let arm?
         // is let m and then return m the way to go? Can it be a oneliner?
         // Indentation is 2 spaces wtf.
         let mut buf = vec![];
+        let mut leading_zeros = 0; 
+        let mut trailing_chars = false;
         loop {
             match try!(self.peek_or_null()) {
-              ch @ b'0' ... b'9' => {
+              ch @ b'0' => {
+                trailing_chars = false;
+                match leading_zeros {
+                  1 => {
+                    println!("Leading zeros {:?}", buf);
+                    return Err(self.error(ErrorCode::InvalidNumber))
+                  },
+                  -1 => {
+                    self.eat_char();
+                    buf.push(ch)
+                  },
+                  _ => {
+                    leading_zeros += 1;
+                    self.eat_char();
+                    buf.push(ch)
+                  }
+                }
+              },
+              ch @ b'1' ... b'9' => {
+                leading_zeros = -1;
+                trailing_chars = false;
                 self.eat_char();
                 buf.push(ch)
               },
-              ch @ b'.' => {
+              ch @ b'.' | ch @ b'-' | ch @ b'e' | ch @ b'+' => {
+                leading_zeros = -1;
+                trailing_chars = true;
                 self.eat_char();
                 buf.push(ch)
               },
               _ => {
+                if trailing_chars {
+                  println!("Trailing chars {:?}", buf);
+                  return Err(self.error(ErrorCode::InvalidNumber))
+                };
                 let whole = str::from_utf8(&buf).unwrap();
-                println!("Whole {:?}", whole);
+                println!("Whole is {:?}", whole);
                 let m = match d128::from_str(whole) {
-                  Ok(d) => visitor.visit_d128(d),
+                  Ok(d) => {
+                    if !d.is_nan() && !d.is_infinite() {
+                      println!("Whole was {:?}, d128 was {:?}", whole, d);
+                      visitor.visit_d128(d)
+                    }else{
+                      println!("NaN or Inf {:?}", whole);
+                      Err(self.error(ErrorCode::InvalidNumber))
+                    }
+                  },
                   _ => Err(self.error(ErrorCode::InvalidNumber))
                 };
                 return m
               }
            }
-        }
-    }
-
-    fn parse_integer<V>(&mut self, pos: bool, visitor: V) -> Result<V::Value>
-        where V: de::Visitor,
-    {
-        match try!(self.next_char_or_null()) {
-            b'0' => {
-                // There can be only one leading '0'.
-                match try!(self.peek_or_null()) {
-                    b'0' ... b'9' => {
-                        Err(self.error(ErrorCode::InvalidNumber))
-                    }
-                    _ => {
-                        self.parse_number(pos, 0, visitor)
-                    }
-                }
-            },
-            c @ b'1' ... b'9' => {
-                let mut res: u64 = (c as u64) - ('0' as u64);
-
-                loop {
-                    match try!(self.peek_or_null()) {
-                        c @ b'0' ... b'9' => {
-                            self.eat_char();
-
-                            let digit = (c as u64) - ('0' as u64);
-
-                            // We need to be careful with overflow. If we can, try to keep the
-                            // number as a `u64` until we grow too large. At that point, switch to
-                            // parsing the value as a `f64`.
-                            match res.checked_mul(10).and_then(|val| val.checked_add(digit)) {
-                                Some(res_) => { res = res_; }
-                                None => {
-                                    return self.parse_float(
-                                        pos,
-                                        (res as f64) * 10.0 + (digit as f64),
-                                        visitor);
-                                }
-                            }
-                        }
-                        _ => {
-                            return self.parse_number(pos, res, visitor);
-                        }
-                    }
-                }
-            }
-            _ => {
-                Err(self.error(ErrorCode::InvalidNumber))
-            }
-        }
-    }
-
-    fn parse_float<V>(&mut self,
-                      pos: bool,
-                      mut res: f64,
-                      mut visitor: V) -> Result<V::Value>
-        where V: de::Visitor,
-    {
-        loop {
-            match try!(self.next_char_or_null()) {
-                c @ b'0' ... b'9' => {
-                    let digit = (c as u64) - ('0' as u64);
-
-                    res *= 10.0;
-                    res += digit as f64;
-                }
-                _ => {
-                    match try!(self.peek_or_null()) {
-                        b'.' => {
-                            return self.parse_decimal(pos, res, visitor);
-                        }
-                        b'e' | b'E' => {
-                            return self.parse_exponent(pos, res, visitor);
-                        }
-                        _ => {
-                            if !pos {
-                                res = -res;
-                            }
-
-                            return visitor.visit_f64(res);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn parse_number<V>(&mut self,
-                       pos: bool,
-                       res: u64,
-                       mut visitor: V) -> Result<V::Value>
-        where V: de::Visitor,
-    {
-        match try!(self.peek_or_null()) {
-            b'.' => {
-                self.parse_decimal(pos, res as f64, visitor)
-            }
-            b'e' | b'E' => {
-                self.parse_exponent(pos, res as f64, visitor)
-            }
-            _ => {
-                if pos {
-                    visitor.visit_u64(res)
-                } else {
-                    let res_i64 = (res as i64).wrapping_neg();
-
-                    // Convert into a float if we underflow.
-                    if res_i64 > 0 {
-                        visitor.visit_f64(-(res as f64))
-                    } else {
-                        visitor.visit_i64(res_i64)
-                    }
-                }
-            }
-        }
-    }
-
-    fn parse_decimal<V>(&mut self,
-                        pos: bool,
-                        mut res: f64,
-                        mut visitor: V) -> Result<V::Value>
-        where V: de::Visitor,
-    {
-        self.eat_char();
-
-        let mut dec = 0.1;
-
-        // Make sure a digit follows the decimal place.
-        match try!(self.next_char_or_null()) {
-            c @ b'0' ... b'9' => {
-                res += (((c as u64) - (b'0' as u64)) as f64) * dec;
-            }
-             _ => { return Err(self.error(ErrorCode::InvalidNumber)); }
-        }
-
-        loop {
-            match try!(self.peek_or_null()) {
-                c @ b'0' ... b'9' => {
-                    self.eat_char();
-
-                    dec /= 10.0;
-                    res += (((c as u64) - (b'0' as u64)) as f64) * dec;
-                }
-                _ => { break; }
-            }
-        }
-
-        match try!(self.peek_or_null()) {
-            b'e' | b'E' => {
-                self.parse_exponent(pos, res, visitor)
-            }
-            _ => {
-                if pos {
-                    visitor.visit_f64(res)
-                } else {
-                    visitor.visit_f64(-res)
-                }
-            }
-        }
-
-    }
-
-    fn parse_exponent<V>(&mut self,
-                         pos: bool,
-                         mut res: f64,
-                         mut visitor: V) -> Result<V::Value>
-        where V: de::Visitor,
-    {
-        self.eat_char();
-
-        let pos_exp = match try!(self.peek_or_null()) {
-            b'+' => { self.eat_char(); true }
-            b'-' => { self.eat_char(); false }
-            _ => { true }
-        };
-
-        // Make sure a digit follows the exponent place.
-        let mut exp = match try!(self.next_char_or_null()) {
-            c @ b'0' ... b'9' => { (c as u64) - (b'0' as u64) }
-            _ => { return Err(self.error(ErrorCode::InvalidNumber)); }
-        };
-
-        loop {
-            match try!(self.peek_or_null()) {
-                c @ b'0' ... b'9' => {
-                    self.eat_char();
-
-                    exp = try_or_invalid!(self, exp.checked_mul(10));
-                    exp = try_or_invalid!(self, exp.checked_add((c as u64) - (b'0' as u64)));
-                }
-                _ => { break; }
-            }
-        }
-
-        let exp = if exp <= i32::MAX as u64 {
-            10_f64.powi(exp as i32)
-        } else {
-            return Err(self.error(ErrorCode::InvalidNumber));
-        };
-
-        if pos_exp {
-            res *= exp;
-        } else {
-            res /= exp;
-        }
-
-        if pos {
-            visitor.visit_f64(res)
-        } else {
-            visitor.visit_f64(-res)
         }
     }
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -116,7 +116,6 @@
 extern crate num_traits;
 extern crate core;
 extern crate serde;
-extern crate decimal;
 
 pub use self::de::{
     Deserializer,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -119,6 +119,7 @@
 extern crate num;
 extern crate core;
 extern crate serde;
+extern crate decimal;
 
 pub use self::de::{
     Deserializer,

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -10,9 +10,7 @@
 //! details):
 //!
 //! * `Boolean`: equivalent to rust's `bool`
-//! * `I64`: equivalent to rust's `i64`
-//! * `U64`: equivalent to rust's `u64`
-//! * `F64`: equivalent to rust's `f64`
+//! * `Number`: represented as a `d128` from the decimal crate.
 //! * `String`: equivalent to rust's `String`
 //! * `Array`: equivalent to rust's `Vec<T>`, but also allowing objects of different types in the
 //!    same array
@@ -99,18 +97,17 @@
 //!
 //!     println!("array? {:?}", foo.as_array());
 //!     // array? None
-//!     println!("u64? {:?}", foo.as_u64());
-//!     // u64? Some(13u64)
+//!     println!("d128? {:?}", foo.as_d128());
 //!
 //!     for (key, value) in obj.iter() {
 //!         println!("{}: {}", key, match *value {
-//!             Value::U64(v) => format!("{} (u64)", v),
+//!             Value::Number(v) => format!("{} (d128)", v),
 //!             Value::String(ref v) => format!("{} (string)", v),
 //!             _ => format!("other")
 //!         });
 //!     }
 //!     // bar: baz (string)
-//!     // foo: 13 (u64)
+//!     // foo: 13 (d128)
 //! }
 //! ```
 

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -4,6 +4,7 @@
 
 use std::io;
 use std::num::FpCategory;
+use std::str::FromStr;
 
 use serde::ser;
 use serde::d128;
@@ -128,12 +129,12 @@ impl<W, F> ser::Serializer for Serializer<W, F>
 
     #[inline]
     fn serialize_f32(&mut self, value: f32) -> Result<()> {
-        fmt_f32_or_null(&mut self.writer, value).map_err(From::from)
+        self.serialize_d128(d128::from_str(&format!("{}", value)).unwrap())
     }
 
     #[inline]
     fn serialize_f64(&mut self, value: f64) -> Result<()> {
-        fmt_f64_or_null(&mut self.writer, value).map_err(From::from)
+        self.serialize_d128(d128::from_str(&format!("{}", value)).unwrap())
     }
 
     #[inline]
@@ -551,36 +552,6 @@ fn escape_char<W>(wr: &mut W, value: char) -> Result<()>
     let mut s = String::new();
     s.push(value);
     escape_bytes(wr, s.as_bytes())
-}
-
-fn fmt_f32_or_null<W>(wr: &mut W, value: f32) -> Result<()>
-    where W: io::Write
-{
-    match value.classify() {
-        FpCategory::Nan | FpCategory::Infinite => {
-            try!(wr.write_all(b"null"))
-        }
-        _ => {
-            try!(write!(wr, "{:?}", value))
-        }
-    }
-
-    Ok(())
-}
-
-fn fmt_f64_or_null<W>(wr: &mut W, value: f64) -> Result<()>
-    where W: io::Write
-{
-    match value.classify() {
-        FpCategory::Nan | FpCategory::Infinite => {
-            try!(wr.write_all(b"null"))
-        }
-        _ => {
-            try!(write!(wr, "{:?}", value))
-        }
-    }
-
-    Ok(())
 }
 
 /// Encode the specified struct into a json `[u8]` writer.

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -3,11 +3,10 @@
 //! This module provides for JSON serialization with the type `Serializer`.
 
 use std::io;
-use std::num::FpCategory;
-use std::str::FromStr;
 
 use serde::ser;
 use serde::d128;
+use serde::de::from_primitive::ToPrimitive;
 use super::error::{Error, ErrorCode, Result};
 
 /// A structure for serializing Rust values into JSON.
@@ -129,12 +128,12 @@ impl<W, F> ser::Serializer for Serializer<W, F>
 
     #[inline]
     fn serialize_f32(&mut self, value: f32) -> Result<()> {
-        self.serialize_d128(d128::from_str(&format!("{}", value)).unwrap())
+        self.serialize_d128(value.to_d128().unwrap())
     }
 
     #[inline]
     fn serialize_f64(&mut self, value: f64) -> Result<()> {
-        self.serialize_d128(d128::from_str(&format!("{}", value)).unwrap())
+        self.serialize_d128(value.to_d128().unwrap())
     }
 
     #[inline]

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -6,6 +6,7 @@ use std::io;
 use std::num::FpCategory;
 
 use serde::ser;
+use serde::d128;
 use super::error::{Error, ErrorCode, Result};
 
 /// A structure for serializing Rust values into JSON.
@@ -133,6 +134,11 @@ impl<W, F> ser::Serializer for Serializer<W, F>
     #[inline]
     fn serialize_f64(&mut self, value: f64) -> Result<()> {
         fmt_f64_or_null(&mut self.writer, value).map_err(From::from)
+    }
+
+    #[inline]
+    fn serialize_d128(&mut self, value: d128) -> Result<()> {
+        write!(&mut self.writer, "{}", value).map_err(From::from)
     }
 
     #[inline]
@@ -332,6 +338,10 @@ impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
     }
 
     fn serialize_f64(&mut self, _value: f64) -> Result<()> {
+        Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
+    }
+
+    fn serialize_d128(&mut self, _value: d128) -> Result<()> {
         Err(Error::Syntax(ErrorCode::KeyMustBeAString, 0, 0))
     }
 

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -210,7 +210,7 @@ impl Value {
     /// Returns true if the `Value` is a Number. Returns false otherwise.
     pub fn is_number(&self) -> bool {
         match *self {
-            Value::I64(_) | Value::U64(_) | Value::F64(_) => true,
+            Value::I64(_) | Value::U64(_) | Value::F64(_) | Value::D128(_) => true,
             _ => false,
         }
     }
@@ -235,6 +235,14 @@ impl Value {
     pub fn is_f64(&self) -> bool {
         match *self {
             Value::F64(_) => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the `Value` is a d128. Returns false otherwise.
+    pub fn is_d128(&self) -> bool {
+        match *self {
+            Value::D128(_) => true,
             _ => false,
         }
     }
@@ -266,6 +274,18 @@ impl Value {
             Value::I64(n) => NumCast::from(n),
             Value::U64(n) => NumCast::from(n),
             Value::F64(n) => Some(n),
+            _ => None
+        }
+    }
+
+    /// If the `Value` is a number, return or cast it to a d128.
+    /// Returns None otherwise.
+    pub fn as_d128(&self) -> Option<d128> {
+        match *self {
+            Value::I64(n) => Some(d128::from(0)),
+            Value::U64(n) => Some(d128::from(0)),
+            Value::F64(n) => Some(d128::from(0)),
+            Value::D128(n) => Some(n),
             _ => None
         }
     }
@@ -350,6 +370,11 @@ impl de::Deserialize for Value {
             #[inline]
             fn visit_f64<E>(&mut self, value: f64) -> Result<Value, E> {
                 Ok(Value::F64(value))
+            }
+
+            #[inline]
+            fn visit_d128<E>(&mut self, value: d128) -> Result<Value, E> {
+                Ok(Value::D128(value))
             }
 
             #[inline]
@@ -937,6 +962,7 @@ impl<'a> de::MapVisitor for MapDeserializer<'a> {
     fn visit_value<T>(&mut self) -> Result<T, Error>
         where T: de::Deserialize
     {
+        println!("IS THIS UNWRAP? {:?}", self.value.take());
         let value = self.value.take().unwrap();
         self.de.value = Some(value);
         Ok(try!(de::Deserialize::deserialize(self.de)))

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -18,9 +18,9 @@
 //! It is also possible to deserialize from a `Value` type:
 //!
 //! ```rust
-//! extern crate serde_json;
 //! #[macro_use]
-//! extern crate decimal;
+//! extern crate serde;
+//! extern crate serde_json;
 //!
 //! use serde_json::Value;
 //! use std::collections::BTreeMap;
@@ -41,12 +41,10 @@ use std::io;
 use std::str;
 use std::vec;
 
-use num_traits::NumCast;
-use decimal::d128;
-use core::str::FromStr;
-
 use serde::de;
 use serde::ser;
+use serde::d128;
+use serde::de::from_primitive::ToPrimitive;
 
 use error::Error;
 
@@ -454,7 +452,7 @@ impl ser::Serializer for Serializer {
     #[inline]
     fn serialize_i64(&mut self, value: i64) -> Result<(), Error> {
         self.state.push(State::Value(Value::Number(
-          d128::from_str(&format!("{:?}", value)).unwrap()
+            value.to_d128().unwrap()
         )));
         Ok(())
     }
@@ -462,7 +460,7 @@ impl ser::Serializer for Serializer {
     #[inline]
     fn serialize_u64(&mut self, value: u64) -> Result<(), Error> {
         self.state.push(State::Value(Value::Number(
-          d128::from_str(&format!("{:?}", value)).unwrap()
+            value.to_d128().unwrap()
         )));
         Ok(())
     }
@@ -470,7 +468,7 @@ impl ser::Serializer for Serializer {
     #[inline]
     fn serialize_f64(&mut self, value: f64) -> Result<(), Error> {
         self.state.push(State::Value(Value::Number(
-          d128::from_str(&format!("{:?}", value)).unwrap()
+            value.to_d128().unwrap()
         )));
         Ok(())
     }

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -40,6 +40,7 @@ use std::str;
 use std::vec;
 
 use num::NumCast;
+use decimal::d128;
 
 use serde::de;
 use serde::ser;
@@ -63,6 +64,9 @@ pub enum Value {
 
     /// Represents a JSON floating point number
     F64(f64),
+
+    /// Represents a JSON floating point number, but as a decimal.
+    D128(d128),
 
     /// Represents a JSON string
     String(String),
@@ -306,6 +310,7 @@ impl ser::Serialize for Value {
             Value::I64(v) => serializer.serialize_i64(v),
             Value::U64(v) => serializer.serialize_u64(v),
             Value::F64(v) => serializer.serialize_f64(v),
+            Value::D128(v) => serializer.serialize_d128(v),
             Value::String(ref v) => serializer.serialize_str(&v),
             Value::Array(ref v) => v.serialize(serializer),
             Value::Object(ref v) => v.serialize(serializer),
@@ -479,6 +484,12 @@ impl ser::Serializer for Serializer {
     #[inline]
     fn serialize_f64(&mut self, value: f64) -> Result<(), Error> {
         self.state.push(State::Value(Value::F64(value as f64)));
+        Ok(())
+    }
+
+    #[inline]
+    fn serialize_d128(&mut self, value: d128) -> Result<(), Error> {
+        self.state.push(State::Value(Value::D128(value as d128)));
         Ok(())
     }
 
@@ -710,6 +721,7 @@ impl de::Deserializer for Deserializer {
             Value::I64(v) => visitor.visit_i64(v),
             Value::U64(v) => visitor.visit_u64(v),
             Value::F64(v) => visitor.visit_f64(v),
+            Value::D128(v) => visitor.visit_d128(v),
             Value::String(v) => visitor.visit_string(v),
             Value::Array(v) => {
                 let len = v.len();

--- a/json_tests/Cargo.toml
+++ b/json_tests/Cargo.toml
@@ -18,10 +18,15 @@ skeptic = "^0.4.0"
 clippy = { version = "^0.*", optional = true }
 num = "*"
 rustc-serialize = "*"
-serde = "*"
+#serde = "*"
+serde = { path = "../../serde/serde" }
 serde_json = { version = "*", path = "../json" }
-serde_macros = { version = "*", optional = true }
+#serde_macros = { version = "*", optional = true }
+serde_macros = { path = "../../serde/serde_macros", optional = true }
 skeptic = "^0.4.0"
+
+[dev-dependencies]
+decimal = "*"
 
 [[test]]
 name = "test"

--- a/json_tests/Cargo.toml
+++ b/json_tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_json_tests"
-version = "0.7.1"
+version = "0.8.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 build = "build.rs"
 
@@ -11,7 +11,7 @@ nightly-testing = ["clippy", "serde_json/clippy"]
 
 [build-dependencies]
 indoc = "*"
-serde_codegen = { version = "*", optional = true }
+serde_codegen = { version = "^0.8.0", optional = true, git = "https://github.com/nubis/serde" }
 skeptic = "^0.4.0"
 syntex = { version = "*", optional = true }
 
@@ -20,15 +20,10 @@ clippy = { version = "^0.*", optional = true }
 indoc = "*"
 num-traits = "*"
 rustc-serialize = "*"
-#serde = "*"
-serde = { path = "../../serde/serde" }
-serde_json = { version = "*", path = "../json" }
-#serde_macros = { version = "*", optional = true }
-serde_macros = { path = "../../serde/serde_macros", optional = true }
+serde = { version = "^0.8.0", git = "https://github.com/nubis/serde" }
+serde_json = { version = "^0.8.0", path = "../json" }
+serde_macros = { version = "^0.8.0", optional = true, git = "https://github.com/nubis/serde" }
 skeptic = "^0.4.0"
-
-[dev-dependencies]
-decimal = "*"
 
 [[test]]
 name = "test"

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -4,9 +4,11 @@
 #![cfg_attr(not(feature = "with-syntex"), feature(custom_attribute, custom_derive, plugin))]
 #![cfg_attr(not(feature = "with-syntex"), plugin(serde_macros))]
 
+#[macro_use(d128)]
 extern crate serde;
 extern crate serde_json;
 extern crate skeptic;
+
 
 #[cfg(feature = "with-syntex")]
 include!(concat!(env!("OUT_DIR"), "/test.rs"));

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -1,7 +1,6 @@
 use std::collections::BTreeMap;
 use std::f64;
 use std::fmt::Debug;
-use std::str::FromStr;
 use std::i64;
 use std::marker::PhantomData;
 use std::u64;
@@ -10,7 +9,6 @@ use serde::de;
 use serde::ser;
 use serde::bytes::{ByteBuf, Bytes};
 use serde::de::from_primitive::ToPrimitive;
-use serde::d128;
 
 use serde_json::{
     self,
@@ -1494,15 +1492,15 @@ fn test_json_pointer() {
                            Value::String("baz".to_owned())]));
     assert_eq!(data.pointer("/foo/0").unwrap(),
         &Value::String("bar".to_owned()));
-    assert_eq!(data.pointer("/").unwrap(), &Value::U64(0));
-    assert_eq!(data.pointer("/a~1b").unwrap(), &Value::U64(1));
-    assert_eq!(data.pointer("/c%d").unwrap(), &Value::U64(2));
-    assert_eq!(data.pointer("/e^f").unwrap(), &Value::U64(3));
-    assert_eq!(data.pointer("/g|h").unwrap(), &Value::U64(4));
-    assert_eq!(data.pointer("/i\\j").unwrap(), &Value::U64(5));
-    assert_eq!(data.pointer("/k\"l").unwrap(), &Value::U64(6));
-    assert_eq!(data.pointer("/ ").unwrap(), &Value::U64(7));
-    assert_eq!(data.pointer("/m~0n").unwrap(), &Value::U64(8));
+    assert_eq!(data.pointer("/").unwrap(), &Value::Number(d128!(0)));
+    assert_eq!(data.pointer("/a~1b").unwrap(), &Value::Number(d128!(1)));
+    assert_eq!(data.pointer("/c%d").unwrap(), &Value::Number(d128!(2)));
+    assert_eq!(data.pointer("/e^f").unwrap(), &Value::Number(d128!(3)));
+    assert_eq!(data.pointer("/g|h").unwrap(), &Value::Number(d128!(4)));
+    assert_eq!(data.pointer("/i\\j").unwrap(), &Value::Number(d128!(5)));
+    assert_eq!(data.pointer("/k\"l").unwrap(), &Value::Number(d128!(6)));
+    assert_eq!(data.pointer("/ ").unwrap(), &Value::Number(d128!(7)));
+    assert_eq!(data.pointer("/m~0n").unwrap(), &Value::Number(d128!(8)));
     // Invalid pointers
     assert!(data.pointer("/unknown").is_none());
     assert!(data.pointer("/e^f/ertz").is_none());

--- a/json_tests/tests/test_json_builder.rs
+++ b/json_tests/tests/test_json_builder.rs
@@ -13,12 +13,12 @@ fn test_array_builder() {
         .push(2)
         .push(3)
         .unwrap();
-    assert_eq!(value, Value::Array(vec!(Value::U64(1), Value::U64(2), Value::U64(3))));
+    assert_eq!(value, Value::Array(vec!(Value::Number(d128!(1)), Value::Number(d128!(2)), Value::Number(d128!(3)))));
 
     let value = ArrayBuilder::new()
         .push_array(|bld| bld.push(1).push(2).push(3))
         .unwrap();
-    assert_eq!(value, Value::Array(vec!(Value::Array(vec!(Value::U64(1), Value::U64(2), Value::U64(3))))));
+    assert_eq!(value, Value::Array(vec!(Value::Array(vec!(Value::Number(d128!(1)), Value::Number(d128!(2)), Value::Number(d128!(3)))))));
 
     let value = ArrayBuilder::new()
         .push_object(|bld|
@@ -28,8 +28,8 @@ fn test_array_builder() {
         .unwrap();
 
     let mut map = BTreeMap::new();
-    map.insert("a".to_string(), Value::U64(1));
-    map.insert("b".to_string(), Value::U64(2));
+    map.insert("a".to_string(), Value::Number(d128!(1)));
+    map.insert("b".to_string(), Value::Number(d128!(2)));
     assert_eq!(value, Value::Array(vec!(Value::Object(map))));
 }
 
@@ -44,7 +44,7 @@ fn test_object_builder() {
         .unwrap();
 
     let mut map = BTreeMap::new();
-    map.insert("a".to_string(), Value::U64(1));
-    map.insert("b".to_string(), Value::U64(2));
+    map.insert("a".to_string(), Value::Number(d128!(1)));
+    map.insert("b".to_string(), Value::Number(d128!(2)));
     assert_eq!(value, Value::Object(map));
 }


### PR DESCRIPTION
Hi, this is my proposal for adding decimal support. Some important things to notice:

- This depends on https://github.com/serde-rs/serde/pull/375 getting merged first.
- It merges all numeric Values into a single Value::Number, that wraps a d128.
- Most of all the actual number parsing is delegated to the decimal crate. (decimal places, exponents, etc)
- Numbers are also serialized using d128 format, you'll notice some specs were changed to reflect that.
- It proposes a bump to 0.8.0 because it adds the dependency and changes the serialization format of long numbers.