### PR TITLE
add preserve_order feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ Using Serde JSON
 extern crate serde;
 extern crate serde_json;
 
-use std::collections::BTreeMap;
+use serde_json::Map;
 
 fn main() {
-    let mut map = BTreeMap::new();
+    let mut map = Map::new();
     map.insert("x".to_string(), 1.0);
     map.insert("y".to_string(), 2.0);
 
     let s = serde_json::to_string(&map).unwrap();
     assert_eq!(s, "{\"x\":1,\"y\":2}");
 
-    let deserialized_map: BTreeMap<String, f64> = serde_json::from_str(&s).unwrap();
+    let deserialized_map: Map<String, f64> = serde_json::from_str(&s).unwrap();
     assert_eq!(map, deserialized_map);
 }
 ```

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -18,5 +18,4 @@ preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]
 serde = "^0.7.0"
 num-traits = "~0.1.32"
 clippy = { version = "^0.*", optional = true }
-#linked-hash-map = { version = "0.0.11" }
-linked-hash-map = { git = "https://github.com/contain-rs/linked-hash-map.git", optional = true }
+linked-hash-map = { version = "0.0.11", optional = true }

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -10,9 +10,13 @@ readme = "../README.md"
 keywords = ["json", "serde", "serialization"]
 
 [features]
+#default = ["preserve_order"]
 nightly-testing = ["clippy"]
+preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]
 
 [dependencies]
 serde = "^0.7.0"
 num-traits = "~0.1.32"
 clippy = { version = "^0.*", optional = true }
+#linked-hash-map = { version = "0.0.11" }
+linked-hash-map = { git = "https://github.com/contain-rs/linked-hash-map.git", optional = true }

--- a/json/src/builder.rs
+++ b/json/src/builder.rs
@@ -33,11 +33,9 @@
 //!     .unwrap();
 //! ```
 
-use std::collections::BTreeMap;
-
 use serde::ser;
 
-use value::{self, Value};
+use value::{self, Value, Map};
 
 /// This structure provides a simple interface for constructing a JSON array.
 pub struct ArrayBuilder {
@@ -84,13 +82,14 @@ impl ArrayBuilder {
 
 /// This structure provides a simple interface for constructing a JSON object.
 pub struct ObjectBuilder {
-    object: BTreeMap<String, Value>,
+    object: Map<String, Value>,
 }
 
 impl ObjectBuilder {
+
     /// Construct an `ObjectBuilder`.
     pub fn new() -> ObjectBuilder {
-        ObjectBuilder { object: BTreeMap::new() }
+        ObjectBuilder { object: Map::new() }
     }
 
     /// Return the constructed `Value`.

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -16,7 +16,7 @@
 //! * `String`: equivalent to rust's `String`
 //! * `Array`: equivalent to rust's `Vec<T>`, but also allowing objects of different types in the
 //!    same array
-//! * `Object`: equivalent to rust's `BTreeMap<String, serde_json::Value>`
+//! * `Object`: equivalent to rust's `serde_json::Map<String, serde_json::Value>`
 //! * `Null`
 //!
 //! An object is a series of string keys mapping to values, in `"key": value` format.  Arrays are
@@ -119,6 +119,8 @@
 extern crate num_traits;
 extern crate core;
 extern crate serde;
+#[cfg(feature = "preserve_order")]
+extern crate linked_hash_map;
 
 pub use self::de::{
     Deserializer,
@@ -139,7 +141,7 @@ pub use self::ser::{
     to_string_pretty,
     escape_str,
 };
-pub use self::value::{Value, to_value, from_value};
+pub use self::value::{Value, Map, to_value, from_value};
 
 pub mod builder;
 pub mod de;

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -54,9 +54,17 @@ use error::Error;
 #[cfg(not(feature = "preserve_order"))]
 pub type Map<K, V> = BTreeMap<K, V>;
 
+/// Represents the IntoIter type.
+#[cfg(not(feature = "preserve_order"))]
+pub type MapIntoIter<K, V> = btree_map::IntoIter<K, V>;
+
 /// Represents a key/value type.
 #[cfg(feature = "preserve_order")]
 pub type Map<K, V> = linked_hash_map::LinkedHashMap<K, V>;
+
+/// Represents the IntoIter type.
+#[cfg(feature = "preserve_order")]
+pub type MapIntoIter<K, V> = linked_hash_map::IntoIter<K, V>;
 
 /// Represents a JSON value
 #[derive(Clone, PartialEq)]
@@ -979,18 +987,9 @@ impl<'a> de::SeqVisitor for SeqDeserializer<'a> {
     }
 }
 
-#[cfg(not(feature = "preserve_order"))]
 struct MapDeserializer<'a> {
     de: &'a mut Deserializer,
-    iter: btree_map::IntoIter<String, Value>,
-    value: Option<Value>,
-    len: usize,
-}
-
-#[cfg(feature = "preserve_order")]
-struct MapDeserializer<'a> {
-    de: &'a mut Deserializer,
-    iter: linked_hash_map::Iter<'a, String, Value>,
+    iter: MapIntoIter<String, Value>,
     value: Option<Value>,
     len: usize,
 }

--- a/json_tests/tests/test_json_builder.rs
+++ b/json_tests/tests/test_json_builder.rs
@@ -1,6 +1,5 @@
-use std::collections::BTreeMap;
 
-use serde_json::value::Value;
+use serde_json::value::{Value, Map};
 use serde_json::builder::{ArrayBuilder, ObjectBuilder};
 
 #[test]
@@ -27,7 +26,7 @@ fn test_array_builder() {
                 .insert("b".to_string(), 2))
         .unwrap();
 
-    let mut map = BTreeMap::new();
+    let mut map = Map::new();
     map.insert("a".to_string(), Value::U64(1));
     map.insert("b".to_string(), Value::U64(2));
     assert_eq!(value, Value::Array(vec!(Value::Object(map))));
@@ -36,14 +35,14 @@ fn test_array_builder() {
 #[test]
 fn test_object_builder() {
     let value = ObjectBuilder::new().unwrap();
-    assert_eq!(value, Value::Object(BTreeMap::new()));
+    assert_eq!(value, Value::Object(Map::new()));
 
     let value = ObjectBuilder::new()
         .insert("a".to_string(), 1)
         .insert("b".to_string(), 2)
         .unwrap();
 
-    let mut map = BTreeMap::new();
+    let mut map = Map::new();
     map.insert("a".to_string(), Value::U64(1));
     map.insert("b".to_string(), Value::U64(2));
     assert_eq!(value, Value::Object(map));


### PR DESCRIPTION
I've added a PR for #54 

linked-hash-map needs to be released (probably version = "0.0.11") before this can be merged.

I had to use `linked_hash_map::Iter<'a, String, Value>` as a replacement for `btree_map::IntoIter<String, Value>`. This in turn required me to clone keys/values in `deserialize_enum` and `visit_key`. I'm not sure this is the best solution.

Also since I'm new to Rust and this is my very first PR please check my code thoroughly :)