### PR TITLE
Speed up integer printing

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -18,3 +18,4 @@ serde = "^0.7.0"
 num-traits = "~0.1.32"
 clippy = { version = "^0.*", optional = true }
 linked-hash-map = { version = "0.0.11", optional = true }
+itoa = "0.1"

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -120,6 +120,7 @@
 extern crate num_traits;
 extern crate core;
 extern crate serde;
+extern crate itoa;
 #[cfg(feature = "preserve_order")]
 extern crate linked_hash_map;
 

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -8,6 +8,8 @@ use std::num::FpCategory;
 use serde::ser;
 use super::error::{Error, ErrorCode, Result};
 
+use itoa;
+
 /// A structure for serializing Rust values into JSON.
 pub struct Serializer<W, F=CompactFormatter> {
     writer: W,
@@ -77,52 +79,52 @@ impl<W, F> ser::Serializer for Serializer<W, F>
 
     #[inline]
     fn serialize_isize(&mut self, value: isize) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_i8(&mut self, value: i8) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_i16(&mut self, value: i16) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_i32(&mut self, value: i32) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_i64(&mut self, value: i64) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_usize(&mut self, value: usize) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_u8(&mut self, value: u8) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_u16(&mut self, value: u16) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_u32(&mut self, value: u32) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]
     fn serialize_u64(&mut self, value: u64) -> Result<()> {
-        write!(&mut self.writer, "{}", value).map_err(From::from)
+        itoa::write(&mut self.writer, value).map_err(From::from)
     }
 
     #[inline]


### PR DESCRIPTION
Just the non-user-visible integer part of #86. The floating-point part needs to wait until 0.8.