### PR TITLE
Speed up float printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ fn main() {
     map.insert("y".to_string(), 2.0);
 
     let s = serde_json::to_string(&map).unwrap();
-    assert_eq!(s, "{\"x\":1,\"y\":2}");
+    assert_eq!(s, "{\"x\":1.0,\"y\":2.0}");
 
     let deserialized_map: Map<String, f64> = serde_json::from_str(&s).unwrap();
     assert_eq!(map, deserialized_map);
@@ -78,7 +78,7 @@ fn main() {
     let point = Point { x: 1.0, y: 2.0 };
 
     let s = serde_json::to_string(&point).unwrap();
-    assert_eq!(s, "{\"x\":1,\"y\":2}");
+    assert_eq!(s, "{\"x\":1.0,\"y\":2.0}");
 
     let deserialized_point: Point = serde_json::from_str(&s).unwrap();
     assert_eq!(point, deserialized_point);

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -19,3 +19,4 @@ num-traits = "~0.1.32"
 clippy = { version = "^0.*", optional = true }
 linked-hash-map = { version = "0.0.11", optional = true }
 itoa = "0.1"
+dtoa = "0.1"

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -121,6 +121,7 @@ extern crate num_traits;
 extern crate core;
 extern crate serde;
 extern crate itoa;
+extern crate dtoa;
 #[cfg(feature = "preserve_order")]
 extern crate linked_hash_map;
 

--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -9,6 +9,7 @@ use serde::ser;
 use super::error::{Error, ErrorCode, Result};
 
 use itoa;
+use dtoa;
 
 /// A structure for serializing Rust values into JSON.
 pub struct Serializer<W, F=CompactFormatter> {
@@ -588,7 +589,7 @@ fn fmt_f32_or_null<W>(wr: &mut W, value: f32) -> Result<()>
             try!(wr.write_all(b"null"))
         }
         _ => {
-            try!(write!(wr, "{:?}", value))
+            try!(dtoa::write(wr, value))
         }
     }
 
@@ -603,7 +604,7 @@ fn fmt_f64_or_null<W>(wr: &mut W, value: f64) -> Result<()>
             try!(wr.write_all(b"null"))
         }
         _ => {
-            try!(write!(wr, "{:?}", value))
+            try!(dtoa::write(wr, value))
         }
     }
 

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -117,18 +117,14 @@ fn test_write_i64() {
 
 #[test]
 fn test_write_f64() {
-    let min_string = format!("{:?}", f64::MIN);
-    let max_string = format!("{:?}", f64::MAX);
-    let epsilon_string = format!("{:?}", f64::EPSILON);
-
     let tests = &[
-        (3.0, "3"),
+        (3.0, "3.0"),
         (3.1, "3.1"),
         (-1.5, "-1.5"),
         (0.5, "0.5"),
-        (f64::MIN, &min_string),
-        (f64::MAX, &max_string),
-        (f64::EPSILON, &epsilon_string),
+        (f64::MIN, "-1.7976931348623157e308"),
+        (f64::MAX, "1.7976931348623157e308"),
+        (f64::EPSILON, "2.220446049250313e-16"),
     ];
     test_encode_ok(tests);
     test_pretty_encode_ok(tests);


### PR DESCRIPTION
The floating point parts of #86 which need to wait until 0.8.