### PR TITLE
Specialize parse_string for Iter=&str

### DIFF
--- a/json/src/read.rs
+++ b/json/src/read.rs
@@ -204,7 +204,8 @@ impl<'a> SliceRead<'a> {
                         &self.slice[start .. self.index]
                     } else {
                         scratch.extend_from_slice(&self.slice[start .. self.index]);
-                        scratch
+                        // "as &[u8]" is required for rustc 1.8.0
+                        scratch as &[u8]
                     };
                     self.index += 1;
                     return result(self, string);


### PR DESCRIPTION
When deserializing from a `&str`, we can assume that the input is valid UTF-8 so don't need to do additional checks.

This makes the [Twitter benchmark](https://github.com/serde-rs/json-benchmark) about 15% faster because it is heavy on strings.