### PR TITLE
Speed up float parsing

### DIFF
--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -750,11 +750,14 @@ fn test_parse_number_errors() {
         (".", Error::Syntax(ErrorCode::ExpectedSomeValue, 1, 1)),
         ("-", Error::Syntax(ErrorCode::InvalidNumber, 1, 1)),
         ("00", Error::Syntax(ErrorCode::InvalidNumber, 1, 2)),
+        ("0x80", Error::Syntax(ErrorCode::TrailingCharacters, 1, 2)),
+        ("\\0", Error::Syntax(ErrorCode::ExpectedSomeValue, 1, 1)),
         ("1.", Error::Syntax(ErrorCode::InvalidNumber, 1, 2)),
+        ("1.a", Error::Syntax(ErrorCode::InvalidNumber, 1, 3)),
+        ("1.e1", Error::Syntax(ErrorCode::InvalidNumber, 1, 3)),
         ("1e", Error::Syntax(ErrorCode::InvalidNumber, 1, 2)),
         ("1e+", Error::Syntax(ErrorCode::InvalidNumber, 1, 3)),
         ("1a", Error::Syntax(ErrorCode::TrailingCharacters, 1, 2)),
-        ("1e777777777777777777777777777", Error::Syntax(ErrorCode::InvalidNumber, 1, 22)),
     ]);
 }
 
@@ -781,10 +784,16 @@ fn test_parse_u64() {
 
 #[test]
 fn test_parse_negative_zero() {
-    assert_eq!(0, from_str::<u32>("-0").unwrap());
-    assert_eq!(0, from_str::<u32>("-0.0").unwrap());
-    assert_eq!(0, from_str::<u32>("-0e2").unwrap());
-    assert_eq!(0, from_str::<u32>("-0.0e2").unwrap());
+    for negative_zero in &[
+        "-0.0",
+        "-0e2",
+        "-0.0e2",
+        "-1e-400",
+    ] {
+        assert_eq!(0, from_str::<u32>(negative_zero).unwrap());
+        assert!(from_str::<f64>(negative_zero).unwrap().is_sign_negative(),
+            "should have been negative: {:?}", negative_zero);
+    }
 }
 
 #[test]
@@ -810,6 +819,12 @@ fn test_parse_f64() {
         (&format!("{:?}", (i64::MIN as f64) - 1.0), (i64::MIN as f64) - 1.0),
         (&format!("{:?}", (u64::MAX as f64) + 1.0), (u64::MAX as f64) + 1.0),
         (&format!("{:?}", f64::EPSILON), f64::EPSILON),
+        ("0.0000000000000000000000000000000000000000000000000123e50", 1.23),
+        ("100e777777777777777777777777777", f64::INFINITY),
+        ("-100e777777777777777777777777777", f64::NEG_INFINITY),
+        ("100e-777777777777777777777777777", 0.0),
+        ("1010101010101010101010101010101010101010", 10101010101010101010e20),
+        ("0.1010101010101010101010101010101010101010", 0.1010101010101010101),
     ]);
 }
 


### PR DESCRIPTION
Fixes #108 and fixes #109.

Parse floats as a u64 until the end, then use a lookup table to scale by the correct power of 10. This is faster and also more accurate. The old code used repeated division by 10 which is so inaccurate that `1.0 / 10.0 / 10.0 / 10.0 / 10.0 / 10.0 / 10.0 != 1e-6`.

This is about 40% improvement on the [Canada benchmark](https://github.com/serde-rs/json-benchmark) (almost twice as fast).