### PR TITLE
Fix unexpected brackets in to_value of a newtype struct

### DIFF
--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -612,6 +612,15 @@ impl ser::Serializer for Serializer {
     }
 
     #[inline]
+    fn serialize_newtype_struct<T>(&mut self,
+                                   _name: &'static str,
+                                   value: T) -> Result<(), Self::Error>
+        where T: ser::Serialize,
+    {
+        value.serialize(self)
+    }
+
+    #[inline]
     fn serialize_newtype_variant<T>(&mut self,
                                 _name: &str,
                                 _variant_index: usize,

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -644,6 +644,23 @@ fn test_write_option() {
     ]);
 }
 
+#[test]
+fn test_write_newtype_struct() {
+    #[derive(Serialize, PartialEq, Debug)]
+    struct Newtype(Map<String, i32>);
+
+    let inner = Newtype(treemap!(String::from("inner") => 123));
+    let outer = treemap!(String::from("outer") => to_value(&inner));
+
+    test_encode_ok(&[
+        (inner, r#"{"inner":123}"#),
+    ]);
+
+    test_encode_ok(&[
+        (outer, r#"{"outer":{"inner":123}}"#),
+    ]);
+}
+
 fn test_parse_ok<T>(tests: Vec<(&str, T)>)
     where T: Clone + Debug + PartialEq + ser::Serialize + de::Deserialize,
 {


### PR DESCRIPTION
Fixes #77.