### PR TITLE
Rename is_{string,boolean} to is_{str,bool}

### DIFF
--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -262,7 +262,7 @@ impl Value {
     }
 
     /// Returns true if the `Value` is a String. Returns false otherwise.
-    pub fn is_string(&self) -> bool {
+    pub fn is_str(&self) -> bool {
         self.as_str().is_some()
     }
 
@@ -339,7 +339,7 @@ impl Value {
     }
 
     /// Returns true if the `Value` is a Boolean. Returns false otherwise.
-    pub fn is_boolean(&self) -> bool {
+    pub fn is_bool(&self) -> bool {
         self.as_bool().is_some()
     }
 


### PR DESCRIPTION
This matches the rename of as_{string,boolean} to as_{str,bool}. Fixes
issue #126
