### PR TITLE
test value -> string -> value roundtripping with quickcheck

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -20,3 +20,4 @@ clippy = { version = "^0.*", optional = true }
 linked-hash-map = { version = "0.3", optional = true }
 itoa = "0.1"
 dtoa = "0.2"
+quickcheck = { version = "0.3.1", optional = true }

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -1436,3 +1436,49 @@ impl<T: ?Sized> ToJson for T
         to_value(&self)
     }
 }
+
+#[cfg(feature="quickcheck")]
+mod qc {
+    extern crate quickcheck;
+    use super::Value;
+    impl quickcheck::Arbitrary for Value {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            gen_value(g, 10)
+        }
+
+        fn shrink(&self) -> Box<Iterator<Item=Self>> {
+            match *self {
+                Value::Null => quickcheck::empty_shrinker(),
+                Value::Bool(b) => Box::new(b.shrink().map(Value::Bool)),
+                Value::I64(i) => Box::new(i.shrink().map(Value::I64)),
+                Value::U64(u) => Box::new(u.shrink().map(Value::U64)),
+                Value::F64(f) => Box::new(f.shrink().map(Value::F64)),
+                Value::String(ref s) => Box::new(s.shrink().map(Value::String)),
+                Value::Array(ref v) => Box::new(v.shrink().map(Value::Array).chain(v.clone().into_iter())),
+                Value::Object(ref m) => Box::new(m.shrink().map(Value::Object).chain(m.clone().into_iter().map(|(_, v)| v))),
+            }
+        }
+    }
+
+    fn gen_value<G: quickcheck::Gen>(g: &mut G, n: usize) -> Value {
+        match g.gen_range(0, if n != 0 { 8 } else { 6 }) {
+            0 => Value::Null,
+            1 => Value::Bool(g.gen()),
+            2 => Value::I64(g.gen()),
+            3 => Value::U64(g.gen()),
+            4 => Value::F64(g.gen()),
+            5 => Value::String(<String as quickcheck::Arbitrary>::arbitrary(g)),
+            6 => Value::Array(gen_array(g, n - 1)),
+            7 => Value::Object(gen_map(g, n - 1)),
+            _ => unreachable!(),
+        }
+    }
+
+    fn gen_array<G: quickcheck::Gen>(g: &mut G, n: usize) -> Vec<Value> {
+        (0..g.gen_range(2, 20)).map(|_| gen_value(g, n)).collect()
+    }
+
+    fn gen_map<G: quickcheck::Gen>(g: &mut G, n: usize) -> ::std::collections::BTreeMap<String, Value> {
+        (0..g.gen_range(2, 20)).map(|_| (<String as quickcheck::Arbitrary>::arbitrary(g), gen_value(g, n))).collect()
+    }
+}

--- a/json_tests/Cargo.toml
+++ b/json_tests/Cargo.toml
@@ -21,9 +21,10 @@ indoc = "*"
 num-traits = "*"
 rustc-serialize = "*"
 serde = "0.8.0"
-serde_json = { path = "../json" }
+serde_json = { path = "../json", features = ["quickcheck"] }
 serde_macros = { version = "0.8.0", optional = true }
 skeptic = "^0.4.0"
+quickcheck = "0.3.1"
 
 [[test]]
 name = "test"

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -7,6 +7,8 @@
 extern crate serde;
 extern crate serde_json;
 extern crate skeptic;
+#[macro_use]
+extern crate quickcheck;
 
 #[cfg(feature = "with-syntex")]
 include!(concat!(env!("OUT_DIR"), "/test.rs"));

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -1617,3 +1617,11 @@ fn test_json_pointer() {
     assert!(data.pointer("/foo/00").is_none());
     assert!(data.pointer("/foo/01").is_none());
 }
+
+quickcheck! {
+    fn ident(val: Value) -> bool {
+        let val2 = serde_json::from_str(&serde_json::to_string(&val).unwrap()).unwrap();
+        println!("{:?} == {:?}", val, val2);
+        val == val2
+    }
+}


### PR DESCRIPTION
so quickcheck found out 2 things:
1. roundtripping with floats is borked #128 
2. roundtripping with `Value::I64` will end up with a `Value::U64` if the value is positive #146
