### PR TITLE
take argument to `Value::to_value` by value

### DIFF
--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -1304,7 +1304,7 @@ impl<'a> de::Deserializer for MapDeserializer<'a> {
 /// let val = to_value("foo");
 /// assert_eq!(val.as_str(), Some("foo"))
 /// ```
-pub fn to_value<T: ?Sized>(value: &T) -> Value
+pub fn to_value<T>(value: T) -> Value
     where T: ser::Serialize,
 {
     let mut ser = Serializer::new();


### PR DESCRIPTION
This is backwards compatible as there exists an implementation of Serializable for `&'a T` where T: Serializable.

It makes the function a lot more friendly to use in iterator adaptors, option and result consumers, etc.