### PR TITLE
Allow trait objects in the to_writer function.

### DIFF
--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -950,7 +950,7 @@ fn fmt_f64_or_null<W>(wr: &mut W, value: f64) -> Result<()>
 
 /// Encode the specified struct into a json `[u8]` writer.
 #[inline]
-pub fn to_writer<W, T>(writer: &mut W, value: &T) -> Result<()>
+pub fn to_writer<W: ?Sized, T>(writer: &mut W, value: &T) -> Result<()>
     where W: io::Write,
           T: ser::Serialize,
 {
@@ -961,7 +961,7 @@ pub fn to_writer<W, T>(writer: &mut W, value: &T) -> Result<()>
 
 /// Encode the specified struct into a json `[u8]` writer.
 #[inline]
-pub fn to_writer_pretty<W, T>(writer: &mut W, value: &T) -> Result<()>
+pub fn to_writer_pretty<W: ?Sized, T>(writer: &mut W, value: &T) -> Result<()>
     where W: io::Write,
           T: ser::Serialize,
 {


### PR DESCRIPTION
Write is an object safe trait, so users can construct an `&mut Write`
object. However, the `to_writer` and `to_writer_pretty` functions take an
`&mut W: Write`. In order to allow users to pass `&mut Write` objects to
these functions, their `W` parameter is now constrained `?Sized`, to allow
it to be a dynamically sized type (such as a trait object).