### PR TITLE
Add as_borrow() generic method for Value

### DIFF
--- a/json/src/error.rs
+++ b/json/src/error.rs
@@ -11,6 +11,8 @@ use std::result;
 use serde::de;
 use serde::ser;
 
+use value::ValueType;
+
 /// The errors that can arise while parsing a JSON stream.
 #[derive(Clone, PartialEq, Debug)]
 pub enum ErrorCode {
@@ -256,3 +258,25 @@ impl ser::Error for Error {
 
 /// Helper alias for `Result` objects that return a JSON `Error`.
 pub type Result<T> = result::Result<T, Error>;
+
+/// Represents type mismatch
+#[derive(Debug)]
+pub struct TypeError {
+    /// Type which was required
+    pub expected: ValueType,
+
+    /// Type which was found in Json
+    pub provided: ValueType,
+}
+
+impl error::Error for TypeError {
+    fn description(&self) -> &str {
+        "type mismatch"
+    }
+}
+
+impl fmt::Display for TypeError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "expected type: {} found type: {}", self.expected, self.provided)
+    }
+}

--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -473,6 +473,99 @@ impl de::Deserialize for Value {
     }
 }
 
+/// Represents type of a JSON value
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum ValueType {
+    /// Represents a JSON null value type
+    Null,
+
+    /// Represents a JSON Boolean type
+    Bool,
+
+    /// Represents a JSON signed integer type
+    I64,
+
+    /// Represents a JSON unsigned integer type
+    U64,
+
+    /// Represents a JSON floating point number type
+    F64,
+
+    /// Represents a JSON string type
+    String,
+
+    /// Represents a JSON array type
+    Array,
+
+    /// Represents a JSON object type
+    Object,
+}
+
+impl ValueType {
+
+    /// Returns type of a value
+    /// 
+    /// # Example
+    ///
+    /// ```rust
+    /// extern crate serde_json;
+    ///
+    /// use serde_json::to_value;
+    /// use serde_json::value::ValueType;
+    /// use std::collections::BTreeMap;
+    ///
+    /// fn main() {
+    ///     let null = to_value(());
+    ///     let boolean = to_value(true);
+    ///     let int64 = to_value(-42i64);
+    ///     let uint64 = to_value(18446744073709551337u64);
+    ///     let float = to_value(3.1415926535f64);
+    ///     let string = to_value("Hello world!");
+    ///     let array = to_value(&[1, 2, 3, 4, 5]);
+    ///     let mut map = BTreeMap::new();
+    ///     map.insert("foo", to_value("bar"));
+    ///     let map = to_value(&map);
+    ///
+    ///     assert_eq!(ValueType::of(&null), ValueType::Null);
+    ///     assert_eq!(ValueType::of(&boolean), ValueType::Bool);
+    ///     assert_eq!(ValueType::of(&int64), ValueType::I64);
+    ///     assert_eq!(ValueType::of(&uint64), ValueType::U64);
+    ///     assert_eq!(ValueType::of(&float), ValueType::F64);
+    ///     assert_eq!(ValueType::of(&string), ValueType::String);
+    ///     assert_eq!(ValueType::of(&array), ValueType::Array);
+    ///     assert_eq!(ValueType::of(&map), ValueType::Object);
+    /// }
+    pub fn of(val: &Value) -> Self {
+        match *val {
+            Value::Null => ValueType::Null,
+            Value::Bool(_) => ValueType::Bool,
+            Value::I64(_) => ValueType::I64,
+            Value::U64(_) => ValueType::U64,
+            Value::F64(_) => ValueType::F64,
+            Value::String(_) => ValueType::String,
+            Value::Array(_) => ValueType::Array,
+            Value::Object(_) => ValueType::Object,
+        }
+    }
+}
+
+impl fmt::Display for ValueType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        use self::ValueType::*;
+
+        write!(f, "{}", match *self {
+            Null => "Null",
+            Bool => "Bool",
+            I64 => "I64",
+            U64 => "U64",
+            F64 => "F64",
+            String => "String",
+            Array => "Array",
+            Object => "Object",
+        })
+    }
+}
+
 struct WriterFormatter<'a, 'b: 'a> {
     inner: &'a mut fmt::Formatter<'b>,
 }


### PR DESCRIPTION
This change adds as_borrow() generic method for Value. It allows users to use e.g. `some_fn(try!(value.as_borrow()))` instead of `some_fn(try!(value.as_string().ok_or(SomeCustomError)))`

Ability to borrow mutably may be even more interesting.

It also defines nice error type for situations when types don't match as well as representation of value type. Those things create dependency chain.
