### PR TITLE
Ensure value::Serializer emits Value::Null for non-finite floats

### DIFF
--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -643,7 +643,11 @@ impl ser::Serializer for Serializer {
 
     #[inline]
     fn serialize_f64(&mut self, value: f64) -> Result<(), Error> {
-        self.value = Value::F64(value);
+        self.value = if value.is_finite() {
+            Value::F64(value)
+        } else {
+            Value::Null
+        };
         Ok(())
     }
 

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -133,6 +133,21 @@ fn test_write_f64() {
 }
 
 #[test]
+fn test_encode_nonfinite_float_yields_null() {
+    let v = to_value(::std::f64::NAN);
+    assert!(v.is_null());
+
+    let v = to_value(::std::f64::INFINITY);
+    assert!(v.is_null());
+
+    let v = to_value(::std::f32::NAN);
+    assert!(v.is_null());
+
+    let v = to_value(::std::f32::INFINITY);
+    assert!(v.is_null());
+}
+
+#[test]
 fn test_write_str() {
     let tests = &[
         ("", "\"\""),


### PR DESCRIPTION
See https://tc39.github.io/ecma262/#sec-serializejsonproperty
Fixes #155 

--

As a heads up, I'm pretty new to rust so if I'm off-track with this PR I apologize! I ran the tests using the nightly compiler (as that was the only one that seemed to allow the given compiler features).