### PR TITLE
Typo fixed: it's called Bool, not Boolean

### DIFF
--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -9,7 +9,7 @@
 //! Data types that can be encoded are JavaScript types (see the `serde_json:Value` enum for more
 //! details):
 //!
-//! * `Boolean`: equivalent to rust's `bool`
+//! * `Bool`: equivalent to rust's `bool`
 //! * `I64`: equivalent to rust's `i64`
 //! * `U64`: equivalent to rust's `u64`
 //! * `F64`: equivalent to rust's `f64`


### PR DESCRIPTION
cf https://docs.serde.rs/serde_json/value/enum.Value.html