### PR TITLE
Update to match the serialize_object PR

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -14,7 +14,7 @@ unstable-testing = ["clippy"]
 preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]
 
 [dependencies]
-serde = "0.9.0" 
+serde = { git = "https://github.com/withoutboats/serde", branch = "serializeable_objects" }
 num-traits = "~0.1.32"
 clippy = { version = "^0.*", optional = true }
 linked-hash-map = { version = "0.3", optional = true }

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_json"
-version = "0.8.3"
+version = "0.9.0"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>"]
 license = "MIT/Apache-2.0"
 description = "A JSON serialization file format"
@@ -14,7 +14,7 @@ unstable-testing = ["clippy"]
 preserve_order = ["linked-hash-map", "linked-hash-map/serde_impl"]
 
 [dependencies]
-serde = "0.8.13"
+serde = "0.9.0" 
 num-traits = "~0.1.32"
 clippy = { version = "^0.*", optional = true }
 linked-hash-map = { version = "0.3", optional = true }

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -112,6 +112,7 @@
 //! }
 //! ```
 
+#![feature(specialization)]
 #![cfg_attr(feature = "clippy", feature(plugin))]
 #![cfg_attr(feature = "clippy", plugin(clippy))]
 #![cfg_attr(feature = "clippy", deny(clippy, clippy_pedantic))]


### PR DESCRIPTION
This updates json to use the definition of `Serializer` provided by [serde#602](https://github.com/serde-rs/serde/pull/602).

This results in some significant changes:
## to_value changes

The `to_value` method now takes types by reference again, because of the requirements to be able to `to_value` trait objects (having to do with how the chain of blanket impls are provided). This is a reversion of #149. This could be fixed with overlapping impl specialization, or possibly just with some cleverness I haven't thought of.
## Changes to serializing keys

This changes which values can be serialized as JSON keys.

The current definition allows any value which only calls `serialize_str` during its serialization to be used as a key. The new definition uses a specialization hierarchy to specify which types can be serialized as keys. The current hierarchy allows any types which implement `ToString` _or_ `ToString + AsRef<str>`. The exact hierarchy can be debated (for example, accepting `ToString` types may not be the preferred behavior).

A big difference between the two implementations is that the current implementation has a sort of untyped element to it. Currently, some values of the same type can be used as keys, while others can't (because the serialize impl could conditionally call only `serialize_str`). This would be a rare occurrence, but it is possible. In contrast, the new impl will guarantee the same behavior for all values of the same type.

For every 'reasonable' key type, the behavior should be unchanged. All of the string types in the standard library could also have fully specialized impls as well.
## This is nightly only

Specialization is currently unstable.
