### PR TITLE
Implement issue #68 - add pointer_mut

### DIFF
--- a/json_tests/benches/bench_json.rs
+++ b/json_tests/benches/bench_json.rs
@@ -98,3 +98,27 @@ fn bench_deserializer_unicode(b: &mut Bencher) {
         let _s: String = serde_json::from_str(&s).unwrap();
     });
 }
+
+#[bench]
+fn bench_pointer(b: &mut Bencher) {
+    use serde_json::{self, Value};
+
+    let data: Value = serde_json::from_str(r#"{
+        "foo": ["bar", "baz"],
+        "": 0,
+        "a/b": 1,
+        "c%d": 2,
+        "e^f": 3,
+        "g|h": 4,
+        "i\\j": 5,
+        "k\"l": 6,
+        " ": 7,
+        "m~n": 8
+    }"#).unwrap();
+
+    b.iter(|| {
+        let _ = data.pointer("").unwrap();
+        let _ = data.pointer("/foo/0").unwrap();
+        let _ = data.pointer("/unknown");
+    });
+}


### PR DESCRIPTION
I was thinking that JSON Patch support would be useful, and saw the Issues for that and for `pointer_mut` support. #68 `pointer_mut` seemed necessary for implementing Patch, so I took a swing at it! This is my first open-source Rust PR so criticism is welcome but be gentle, haha!

I moved `pointer` into a new trait (`Pointer`) and added `pointer_mut` to it as well.  To maintain symmetry I also added a `pointer_owned` method that consumes the `Value` and returns an owned `Value`. Because of the new trait this is a breaking change (you need to import the trait for `pointer` to work now.)

Unit tests were added and all pass, documentation was added but is mostly just copy-paste from the existing code. I also wrote a benchmark to verify that the changes I made to `pointer` weren't slower than the existing code, but left out the change to the `.rs.in` file I made to run the bench. On my machine, the new and old `pointer` methods were very close in performance. The new one actually seems slightly faster but they were within deviation range of each other so I'm making no claims except that my refactors shouldn't have negatively affected the method.