### PR TITLE
Require newline to be written successfully

### DIFF
--- a/json/src/ser.rs
+++ b/json/src/ser.rs
@@ -835,7 +835,7 @@ impl<'a> Formatter for PrettyFormatter<'a> {
         where W: io::Write,
     {
         self.current_indent -= 1;
-        try!(writer.write(b"\n"));
+        try!(writer.write_all(b"\n"));
         try!(indent(writer, self.current_indent, self.indent));
 
         writer.write_all(&[ch]).map_err(From::from)


### PR DESCRIPTION
Maybe we should run unit tests against an io::Write that returns Ok(0) on every other call...