### PR TITLE
Remove Value::lookup

### DIFF
--- a/json/src/value.rs
+++ b/json/src/value.rs
@@ -126,32 +126,6 @@ impl Value {
         Some(target)
     }
 
-    /// **Deprecated**: Use `Value.pointer()` and pointer syntax instead.
-    ///
-    /// Looks up a value by path.
-    ///
-    /// This is a convenience method that splits the path by `'.'`
-    /// and then feeds the sequence of keys into the `find_path`
-    /// method.
-    ///
-    /// ``` ignore
-    /// let obj: Value = json::from_str(r#"{"x": {"a": 1}}"#).unwrap();
-    ///
-    /// assert!(obj.lookup("x.a").unwrap() == &Value::U64(1));
-    /// ```
-    pub fn lookup<'a>(&'a self, path: &str) -> Option<&'a Value> {
-        let mut target = self;
-        for key in path.split('.') {
-            match target.find(key) {
-                Some(t) => {
-                    target = t;
-                }
-                None => return None,
-            }
-        }
-        Some(target)
-    }
-
     /// Looks up a value by a JSON Pointer.
     ///
     /// JSON Pointer defines a string syntax for identifying a specific value

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -1281,15 +1281,6 @@ fn test_find_path() {
 }
 
 #[test]
-fn test_lookup() {
-    let obj: Value = serde_json::from_str(r#"{"x": {"a": 1}, "y": 2}"#).unwrap();
-
-    assert!(obj.lookup("x.a").unwrap() == &Value::U64(1));
-    assert!(obj.lookup("y").unwrap() == &Value::U64(2));
-    assert!(obj.lookup("z").is_none());
-}
-
-#[test]
 fn test_serialize_seq_with_no_len() {
     #[derive(Clone, Debug, PartialEq)]
     struct MyVec<T>(Vec<T>);
@@ -1586,13 +1577,13 @@ fn test_json_stream_newlines() {
         stream.as_bytes().iter().map(|byte| Ok(*byte))
     );
 
-    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(),
                &Value::U64(39));
-    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(),
                &Value::U64(40));
-    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(),
                &Value::U64(41));
-    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(),
                &Value::U64(42));
     assert!(parsed.next().is_none());
 }
@@ -1604,7 +1595,7 @@ fn test_json_stream_trailing_whitespaces() {
         stream.as_bytes().iter().map(|byte| Ok(*byte))
     );
 
-    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(),
                &Value::U64(42));
     assert!(parsed.next().is_none());
 }
@@ -1616,7 +1607,7 @@ fn test_json_stream_truncated() {
         stream.as_bytes().iter().map(|byte| Ok(*byte))
     );
 
-    assert_eq!(parsed.next().unwrap().ok().unwrap().lookup("x").unwrap(),
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(),
                &Value::U64(40));
     assert!(parsed.next().unwrap().is_err());
     assert!(parsed.next().is_none());


### PR DESCRIPTION
Fixes #189. This has been deprecated since serde_json 0.7.1.