### PR TITLE
Propagate EOF found while checking trailing whitespace

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -113,7 +113,6 @@ impl<R: Read> DeserializerImpl<R> {
     }
 
     fn end(&mut self) -> Result<()> {
-        try!(self.parse_whitespace());
         if try!(self.eof()) {
             Ok(())
         } else {
@@ -122,7 +121,7 @@ impl<R: Read> DeserializerImpl<R> {
     }
 
     fn eof(&mut self) -> Result<bool> {
-        Ok(try!(self.peek()).is_none())
+        Ok(try!(self.parse_whitespace()) || try!(self.peek()).is_none())
     }
 
     fn peek(&mut self) -> Result<Option<u8>> {
@@ -157,15 +156,21 @@ impl<R: Read> DeserializerImpl<R> {
         Error::Syntax(reason, pos.line, pos.column)
     }
 
-    fn parse_whitespace(&mut self) -> Result<()> {
+    /// Consume whitespace until the next non-whitespace character.
+    ///
+    /// Return `Ok(true)` if EOF was encountered in the process and `Ok(false)` otherwise.
+    fn parse_whitespace(&mut self) -> Result<bool> {
         loop {
-            match try!(self.peek_or_null()) {
-                b' ' | b'\n' | b'\t' | b'\r' => {
-                    self.eat_char();
-                }
-                _ => {
-                    return Ok(());
-                }
+            match try!(self.peek()) {
+                Some(b) => match b {
+                    b' ' | b'\n' | b'\t' | b'\r' => {
+                        self.eat_char();
+                    }
+                    _ => {
+                        return Ok(false);
+                    }
+                },
+                None => return Ok(true),
             }
         }
     }
@@ -173,8 +178,6 @@ impl<R: Read> DeserializerImpl<R> {
     fn parse_value<V>(&mut self, visitor: V) -> Result<V::Value>
         where V: de::Visitor,
     {
-        try!(self.parse_whitespace());
-
         if try!(self.eof()) {
             return Err(self.peek_error(ErrorCode::EOFWhileParsingValue));
         }
@@ -978,10 +981,6 @@ impl<T, Iter> Iterator for StreamDeserializer<T, Iter>
         // skip whitespaces, if any
         // this helps with trailing whitespaces, since whitespaces between
         // values are handled for us.
-        if let Err(e) = self.deser.parse_whitespace() {
-            return Some(Err(e));
-        };
-
         match self.deser.eof() {
             Ok(true) => None,
             Ok(false) => {

--- a/json_tests/tests/test_json.rs
+++ b/json_tests/tests/test_json.rs
@@ -1767,3 +1767,49 @@ fn test_allow_de_integers_as_map_keys(){
     }"#;
     serde_json::from_str::<HashMap<i8, u8>>(&json);
 }*/ // Not implemented
+
+#[test]
+fn test_from_iter_unfused() {
+    // Test that iterator isn't called after EOF.
+
+    use std;
+
+    struct Source<I: Iterator<Item = u8>> {
+        iter: I,
+        finished: bool,
+    }
+
+    impl<I: Iterator<Item = u8>> Iterator for Source<I> {
+        type Item = std::io::Result<u8>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            assert!(!self.finished, "next() called after iterator EOF");
+
+            match self.iter.next() {
+                Some(b) => Some(Ok(b)),
+                None => {
+                    self.finished = true;
+                    None
+                },
+            }
+        }
+    }
+
+    #[derive(Deserialize)]
+    struct Message {
+        key: u32,
+    }
+
+    let msg: Message = serde_json::from_iter(Source {
+        iter: b"{\"key\": 1337}".iter().cloned(),
+        finished: false,
+    }).unwrap();
+    assert_eq!(msg.key, 1337);
+
+    let msg: Message = serde_json::from_iter(Source {
+        iter: b"{\"key\": 1337}  \t\t ".iter().cloned(),
+        finished: false,
+    }).unwrap();
+    assert_eq!(msg.key, 1337);
+
+}


### PR DESCRIPTION
Currently, if the source iterator returns `None` while the parser is checking for whitespace before EOF, that `None` is ignored and the iterator is expected to continue returning `None` after the whitespace check, i.e., the iterator is expected to be fused. 

In general, the iterator may not be fused, and calling `next()` after the terminating `None` may lead to, for example, an unnecessary read from blocking IO that hangs indefinitely while waiting for more data.

This change makes the EOF check aware if the iterator returns `None` in the trailing whitespace check. Since all uses of `eof()` are preceded by a call to `parse_whitespace()`, that call is moved into `eof()` and checked there.

I ran into this while working on an HTTP chunked transfer decoder/iterator, where after indicating EOF to the parser, the parser tries to peek at another byte, which causes a read from a blocking TCP stream that hangs the process. 