### PR TITLE
TT-muncher improvements

### DIFF
--- a/json/src/macros.rs
+++ b/json/src/macros.rs
@@ -216,14 +216,14 @@ macro_rules! json_within_object {
 
     // Misplaced colon. Trigger a reasonable error message by failing to match
     // the colon in the recursive call.
-    ($object:ident ($($key:tt)*) : $($rest:tt)*) => {
-        json_within_object!(:);
+    ($object:ident () : $($rest:tt)*) => {
+        json_within_object!($object [:] (:));
     };
 
     // Found a comma inside a key. Trigger a reasonable error message by failing
     // to match the comma in the recursive call.
     ($object:ident ($($key:tt)*) , $($rest:tt)*) => {
-        json_within_object!(,);
+        json_within_object!($object [,] (,));
     };
 
     // Munch a token into the current key.

--- a/json_tests/Cargo.toml
+++ b/json_tests/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 default = ["serde_derive"]
 with-syntex = ["syntex", "serde_codegen", "indoc/with-syntex"]
 unstable-testing = ["clippy", "serde_json/clippy"]
+trace-macros = []
 
 [build-dependencies]
 indoc = "*"

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -4,6 +4,10 @@
 #![cfg_attr(not(feature = "with-syntex"), feature(plugin))]
 #![cfg_attr(not(feature = "with-syntex"), plugin(indoc))]
 
+#![cfg_attr(feature = "trace-macros", feature(trace_macros))]
+#[cfg(feature = "trace-macros")]
+trace_macros!(true);
+
 #[cfg(not(feature = "with-syntex"))]
 #[macro_use]
 extern crate serde_derive;

--- a/json_tests/tests/test.rs.in
+++ b/json_tests/tests/test.rs.in
@@ -1778,5 +1778,14 @@ fn test_from_iter_unfused() {
 fn test_json_macro() {
     // This is tricky because the <...> is not a single TT and the comma inside
     // looks like an array element separator.
-    let _ = json!([ <Result<(), ()> as Clone>::clone(&Ok(())) ]);
+    let _ = json!([
+        <Result<(), ()> as Clone>::clone(&Ok(())),
+        <Result<(), ()> as Clone>::clone(&Err(()))
+    ]);
+
+    // Same thing but in the map values.
+    let _ = json!({
+        "ok": <Result<(), ()> as Clone>::clone(&Ok(())),
+        "err": <Result<(), ()> as Clone>::clone(&Err(()))
+    });
 }

--- a/json_tests/tests/test.rs.in
+++ b/json_tests/tests/test.rs.in
@@ -1773,3 +1773,10 @@ fn test_from_iter_unfused() {
     }).unwrap();
     assert_eq!(msg.key, 1337);
 }
+
+#[test]
+fn test_json_macro() {
+    // This is tricky because the <...> is not a single TT and the comma inside
+    // looks like an array element separator.
+    let _ = json!([ <Result<(), ()> as Clone>::clone(&Ok(())) ]);
+}

--- a/json_tests/tests/test.rs.in
+++ b/json_tests/tests/test.rs.in
@@ -1788,4 +1788,10 @@ fn test_json_macro() {
         "ok": <Result<(), ()> as Clone>::clone(&Ok(())),
         "err": <Result<(), ()> as Clone>::clone(&Err(()))
     });
+
+    // It works in map keys but only if they are parenthesized.
+    let _ = json!({
+        (<Result<&str, ()> as Clone>::clone(&Ok("")).unwrap()): "ok",
+        (<Result<(), &str> as Clone>::clone(&Err("")).unwrap_err()): "err"
+    });
 }


### PR DESCRIPTION
Two things:

- The vec![...] optimization pointed out by @bluetech in https://github.com/serde-rs/json/pull/207#issuecomment-274555826,
- Allow expressions inside an array or object to contain commas at what looks like the top level.

The second case is addressing expressions that look like `...<a , b>...`. Unlike () [] {}, the angle brackets are not a single token tree so the comma looks like an array element separator / map entry separator to the previous implementation. Here I rely on the $expr parser to fix this case.

Map keys are still broken with respect to commas inside <...> because follow-set rules prohibit parsing $expr followed by colon. I am not concerned about this because I expect interpolation inside map keys to be rare and simple. The error if it happens is "expected expression, found \`,\`" which is reasonable and you can fix it by parenthesizing the key.

Here are some cases that were broken before. I added these as tests.

```rust
json!([
    <Result<(), ()> as Clone>::clone(&Ok(())),
    <Result<(), ()> as Clone>::clone(&Err(()))
]);

json!({
    "ok": <Result<(), ()> as Clone>::clone(&Ok(())),
    "err": <Result<(), ()> as Clone>::clone(&Err(()))
});
```