### PR TITLE
Fix regressions introduced by #256 fix

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -706,6 +706,7 @@ impl<'a, R: Read> de::Deserializer for &'a mut Deserializer<R> {
         match try!(self.peek_or_null()) {
             b'"' => {
                 self.eat_char();
+                self.str_buf.clear();
                 let slice = try!(self.read.parse_str_raw(&mut self.str_buf));
                 visitor.visit_bytes(slice)
             }

--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -699,9 +699,7 @@ impl<'a, R: Read> de::Deserializer for &'a mut Deserializer<R> {
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>
         where V: de::Visitor
     {
-        if try!(self.parse_whitespace()) { // true if eof
-            return Err(self.peek_error(ErrorCode::EOFWhileParsingValue));
-        }
+        try!(self.parse_whitespace());
 
         match try!(self.peek_or_null()) {
             b'"' => {

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -1586,6 +1586,14 @@ fn test_byte_buf_de() {
 }
 
 #[test]
+fn test_byte_buf_de_multiple() {
+    let s: Vec<ByteBuf> = from_str(r#"["ab\nc", "cd\ne"]"#).unwrap();
+    let a = ByteBuf::from(b"ab\nc".to_vec());
+    let b =  ByteBuf::from(b"cd\ne".to_vec());
+    assert_eq!(vec![a, b], s);
+}
+
+#[test]
 fn test_json_stream_newlines() {
     let data = "{\"x\":39} {\"x\":40}{\"x\":41}\n{\"x\":42}";
     let mut parsed = Deserializer::from_str(data).into_iter::<Value>();


### PR DESCRIPTION
I'm sorry, my fix for #256 had two errors:

* I forgot to clear the str_buf before parsing bytes. This results in incorrect parses.
* Somehow, my patch regressed performance by a lot. I'm not sure why this is the case, but using `peek_or_null` instead of `peek` fixes the issue.

The release with the previous PR should probably be yanked at crates.io. I apologize for the trouble, I should have verified my code better.

I also added a test for this particular failure case.