### PR TITLE
Document the fact that json! can panic.

### DIFF
--- a/json/src/macros.rs
+++ b/json/src/macros.rs
@@ -20,7 +20,9 @@
 /// Variables or expressions can be interpolated into the JSON literal. Any type
 /// interpolated into an array element or object value must implement Serde's
 /// `Serialize` trait, while any type interpolated into a object key must
-/// implement `Into<String>`.
+/// implement `Into<String>`. If the `Serialize` implementation of the
+/// interpolated type decides to fail, or if the interpolated type contains a
+/// map with non-string keys, the `json!` macro will panic.
 ///
 /// ```rust
 /// # #![allow(unused_variables)]


### PR DESCRIPTION
If serialization fails, the ``json!`` macro can panic.  This is presumably intended (there is an explicit unwrap of ``serde_json::value::to_json()`` in ``macros.rs``), but the documentation at https://docs.serde.rs/serde_json/macro.json.html does not mention that a panic is possible.  If this macro is meant to panic in such a case, I think it makes sense to document this.

Panic example:

```rust
extern crate serde;
#[macro_use]
extern crate serde_json;

use serde::ser::Error;

struct Foo {
    foo: usize,
}

impl serde::Serialize for Foo {
    fn serialize<S: serde::Serializer>(&self, _: S) -> Result<S::Ok, S::Error> {
        Err(S::Error::custom("error"))
    }
}

fn main() {
    let foo = Foo { foo: 0 };
    // Prints out an error message.
    println!("{:?}", serde_json::to_string(&foo));
    // Panics.
    json!([foo]);
}
```
This is with serde 0.9.10 and serde_json 0.9.8.