### PR TITLE
Extend the Error API with line, column, category

### DIFF
--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -159,7 +159,7 @@ impl<R: Read> Deserializer<R> {
         where V: de::Visitor,
     {
         if try!(self.parse_whitespace()) { // true if eof
-            return Err(self.peek_error(ErrorCode::EOFWhileParsingValue));
+            return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
         }
 
         let value = match try!(self.peek_or_null()) {
@@ -526,7 +526,7 @@ impl<R: Read> Deserializer<R> {
                 Ok(())
             }
             Some(_) => Err(self.peek_error(ErrorCode::ExpectedColon)),
-            None => Err(self.peek_error(ErrorCode::EOFWhileParsingObject)),
+            None => Err(self.peek_error(ErrorCode::EofWhileParsingObject)),
         }
     }
 
@@ -536,7 +536,7 @@ impl<R: Read> Deserializer<R> {
         match try!(self.next_char()) {
             Some(b']') => Ok(()),
             Some(_) => Err(self.error(ErrorCode::TrailingCharacters)),
-            None => Err(self.error(ErrorCode::EOFWhileParsingList)),
+            None => Err(self.error(ErrorCode::EofWhileParsingList)),
         }
     }
 
@@ -546,7 +546,7 @@ impl<R: Read> Deserializer<R> {
         match try!(self.next_char()) {
             Some(b'}') => Ok(()),
             Some(_) => Err(self.error(ErrorCode::TrailingCharacters)),
-            None => Err(self.error(ErrorCode::EOFWhileParsingObject)),
+            None => Err(self.error(ErrorCode::EofWhileParsingObject)),
         }
     }
 }
@@ -765,7 +765,7 @@ impl<'a, R: Read + 'a> de::SeqVisitor for SeqVisitor<'a, R> {
                 }
             }
             None => {
-                return Err(self.de.peek_error(ErrorCode::EOFWhileParsingList));
+                return Err(self.de.peek_error(ErrorCode::EofWhileParsingList));
             }
         }
 
@@ -814,14 +814,14 @@ impl<'a, R: Read + 'a> de::MapVisitor for MapVisitor<'a, R> {
             }
             None => {
                 return Err(self.de
-                    .peek_error(ErrorCode::EOFWhileParsingObject));
+                    .peek_error(ErrorCode::EofWhileParsingObject));
             }
         }
 
         match try!(self.de.peek()) {
             Some(b'"') => Ok(Some(try!(seed.deserialize(&mut *self.de)))),
             Some(_) => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
-            None => Err(self.de.peek_error(ErrorCode::EOFWhileParsingValue)),
+            None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
         }
     }
 

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -1907,3 +1907,28 @@ fn test_partialeq_string() {
     assert_eq!(v, String::from("42"));
     assert_eq!(String::from("42"), v);
 }
+
+#[test]
+fn test_category() {
+    assert!(from_str::<String>("123").unwrap_err().is_data());
+
+    assert!(from_str::<String>("]").unwrap_err().is_syntax());
+
+    assert!(from_str::<String>("").unwrap_err().is_eof());
+    assert!(from_str::<String>("\"").unwrap_err().is_eof());
+    assert!(from_str::<String>("\"\\").unwrap_err().is_eof());
+    assert!(from_str::<String>("\"\\u").unwrap_err().is_eof());
+    assert!(from_str::<String>("\"\\u0").unwrap_err().is_eof());
+    assert!(from_str::<String>("\"\\u00").unwrap_err().is_eof());
+    assert!(from_str::<String>("\"\\u000").unwrap_err().is_eof());
+
+    assert!(from_str::<Vec<usize>>("[").unwrap_err().is_eof());
+    assert!(from_str::<Vec<usize>>("[0").unwrap_err().is_eof());
+    assert!(from_str::<Vec<usize>>("[0,").unwrap_err().is_eof());
+
+    assert!(from_str::<BTreeMap<String, usize>>("{").unwrap_err().is_eof());
+    assert!(from_str::<BTreeMap<String, usize>>("{\"k\"").unwrap_err().is_eof());
+    assert!(from_str::<BTreeMap<String, usize>>("{\"k\":").unwrap_err().is_eof());
+    assert!(from_str::<BTreeMap<String, usize>>("{\"k\":0").unwrap_err().is_eof());
+    assert!(from_str::<BTreeMap<String, usize>>("{\"k\":0,").unwrap_err().is_eof());
+}


### PR DESCRIPTION
Fixes #245. @vorner, @kixunil who were interested in that ticket and @mitsuhiko who was interested in line and column, does this look like it would work for your use cases?

---

![selection_026](https://cloud.githubusercontent.com/assets/1940490/23835821/27a488fe-072b-11e7-8ee3-6d4a0be403d8.png)

---

![selection_027](https://cloud.githubusercontent.com/assets/1940490/23835823/2acf5356-072b-11e7-84da-37f3447631ce.png)