### PR TITLE
Zero copy deserialization

### DIFF
--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -18,12 +18,11 @@ travis-ci = { repository = "serde-rs/json" }
 preserve_order = ["linked-hash-map"]
 
 [dependencies]
-#serde = "0.9.11"
-serde = { path = "../../serde/serde" }
+serde = { git = "https://github.com/serde-rs/serde", branch = "1.0" }
 num-traits = "0.1.32"
 linked-hash-map = { version = "0.4.1", optional = true }
 itoa = "0.3"
 dtoa = "0.4"
 
 [dev-dependencies]
-serde_derive = "0.9"
+serde_derive = { git = "https://github.com/serde-rs/serde", branch = "1.0" }

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -18,7 +18,8 @@ travis-ci = { repository = "serde-rs/json" }
 preserve_order = ["linked-hash-map"]
 
 [dependencies]
-serde = "0.9.11"
+#serde = "0.9.11"
+serde = { path = "../../serde/serde" }
 num-traits = "0.1.32"
 linked-hash-map = { version = "0.4.1", optional = true }
 itoa = "0.3"

--- a/json/src/de.rs
+++ b/json/src/de.rs
@@ -1076,8 +1076,8 @@ pub fn from_reader<R, T>(rdr: R) -> Result<T>
 /// is wrong with the data, for example required struct fields are missing from
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
-pub fn from_slice<T>(v: &[u8]) -> Result<T>
-    where T: de::DeserializeOwned,
+pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
+    where T: de::Deserialize<'a>,
 {
     from_trait(read::SliceRead::new(v))
 }

--- a/json/src/map.rs
+++ b/json/src/map.rs
@@ -281,14 +281,14 @@ impl ser::Serialize for Map<String, Value> {
     }
 }
 
-impl de::Deserialize for Map<String, Value> {
+impl<'de> de::Deserialize<'de> for Map<String, Value> {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-        where D: de::Deserializer
+        where D: de::Deserializer<'de>
     {
         struct Visitor;
 
-        impl de::Visitor for Visitor {
+        impl<'de> de::Visitor<'de> for Visitor {
             type Value = Map<String, Value>;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -304,7 +304,7 @@ impl de::Deserialize for Map<String, Value> {
 
             #[inline]
             fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
-                where V: de::MapVisitor
+                where V: de::MapVisitor<'de>
             {
                 let mut values = Map::with_capacity(visitor.size_hint().0);
 

--- a/json/src/number.rs
+++ b/json/src/number.rs
@@ -123,14 +123,14 @@ impl Serialize for Number {
     }
 }
 
-impl Deserialize for Number {
+impl<'de> Deserialize<'de> for Number {
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Number, D::Error>
-        where D: Deserializer
+        where D: Deserializer<'de>
     {
         struct NumberVisitor;
 
-        impl Visitor for NumberVisitor {
+        impl<'de> Visitor<'de> for NumberVisitor {
             type Value = Number;
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -159,12 +159,12 @@ impl Deserialize for Number {
     }
 }
 
-impl Deserializer for Number {
+impl<'de> Deserializer<'de> for Number {
     type Error = Error;
 
     #[inline]
     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor
+        where V: Visitor<'de>
     {
         match self.n {
             N::PosInt(i) => visitor.visit_u64(i),
@@ -180,12 +180,12 @@ impl Deserializer for Number {
     }
 }
 
-impl<'a> Deserializer for &'a Number {
+impl<'de, 'a> Deserializer<'de> for &'a Number {
     type Error = Error;
 
     #[inline]
     fn deserialize<V>(self, visitor: V) -> Result<V::Value, Error>
-        where V: Visitor
+        where V: Visitor<'de>
     {
         match self.n {
             N::PosInt(i) => visitor.visit_u64(i),

--- a/json_tests/Cargo.toml
+++ b/json_tests/Cargo.toml
@@ -9,12 +9,9 @@ trace-macros = []
 unstable-testing = ["compiletest_rs"]
 
 [dev-dependencies]
-#serde = "0.9.11"
+serde = { git = "https://github.com/serde-rs/serde", branch = "1.0" }
 serde_json = { path = "../json" }
-#serde_derive = "0.9"
-
-serde = { path = "../../serde/serde" }
-serde_derive = { path = "../../serde/serde_derive" }
+serde_derive = { git = "https://github.com/serde-rs/serde", branch = "1.0" }
 
 [dependencies]
 compiletest_rs = { version = "0.2", optional = true }

--- a/json_tests/Cargo.toml
+++ b/json_tests/Cargo.toml
@@ -9,9 +9,12 @@ trace-macros = []
 unstable-testing = ["compiletest_rs"]
 
 [dev-dependencies]
-serde = "0.9.11"
+#serde = "0.9.11"
 serde_json = { path = "../json" }
-serde_derive = "0.9"
+#serde_derive = "0.9"
+
+serde = { path = "../../serde/serde" }
+serde_derive = { path = "../../serde/serde_derive" }
 
 [dependencies]
 compiletest_rs = { version = "0.2", optional = true }

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -1934,7 +1934,10 @@ fn test_category() {
 }
 
 #[test]
-fn test_str() {
+fn test_borrow() {
     let s: &str = from_str("\"borrowed\"").unwrap();
+    assert_eq!("borrowed", s);
+
+    let s: &str = from_slice(b"\"borrowed\"").unwrap();
     assert_eq!("borrowed", s);
 }

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -714,7 +714,7 @@ fn test_write_map_with_integer_keys_issue_221() {
 }
 
 fn test_parse_ok<T>(tests: Vec<(&str, T)>)
-    where T: Clone + Debug + PartialEq + ser::Serialize + de::Deserialize,
+    where T: Clone + Debug + PartialEq + ser::Serialize + de::DeserializeOwned,
 {
     for (s, value) in tests {
         let v: T = from_str(s).unwrap();
@@ -747,7 +747,7 @@ fn test_parse_ok<T>(tests: Vec<(&str, T)>)
 // For testing representations that the deserializer accepts but the serializer
 // never generates. These do not survive a round-trip through Value.
 fn test_parse_unusual_ok<T>(tests: Vec<(&str, T)>)
-    where T: Clone + Debug + PartialEq + ser::Serialize + de::Deserialize,
+    where T: Clone + Debug + PartialEq + ser::Serialize + de::DeserializeOwned,
 {
     for (s, value) in tests {
         let v: T = from_str(s).unwrap();
@@ -769,7 +769,7 @@ macro_rules! test_parse_err {
 }
 
 fn test_parse_err<T>(errors: &[(&str, &'static str)])
-    where T: Debug + PartialEq + de::Deserialize,
+    where T: Debug + PartialEq + de::DeserializeOwned,
 {
     for &(s, err) in errors {
         test_parse_err!(from_str::<T>(s) => err);
@@ -779,7 +779,7 @@ fn test_parse_err<T>(errors: &[(&str, &'static str)])
 }
 
 fn test_parse_slice_err<T>(errors: &[(&[u8], &'static str)])
-    where T: Debug + PartialEq + de::Deserialize,
+    where T: Debug + PartialEq + de::DeserializeOwned,
 {
     for &(s, err) in errors {
         test_parse_err!(from_slice::<T>(s) => err);
@@ -1364,8 +1364,8 @@ fn test_serialize_seq_with_no_len() {
         marker: PhantomData<MyVec<T>>,
     }
 
-    impl<T> de::Visitor for Visitor<T>
-        where T: de::Deserialize,
+    impl<'de, T> de::Visitor<'de> for Visitor<T>
+        where T: de::Deserialize<'de>,
     {
         type Value = MyVec<T>;
 
@@ -1382,7 +1382,7 @@ fn test_serialize_seq_with_no_len() {
 
         #[inline]
         fn visit_seq<V>(self, mut visitor: V) -> Result<MyVec<T>, V::Error>
-            where V: de::SeqVisitor,
+            where V: de::SeqVisitor<'de>,
         {
             let mut values = Vec::new();
 
@@ -1394,11 +1394,11 @@ fn test_serialize_seq_with_no_len() {
         }
     }
 
-    impl<T> de::Deserialize for MyVec<T>
-        where T: de::Deserialize,
+    impl<'de, T> de::Deserialize<'de> for MyVec<T>
+        where T: de::Deserialize<'de>,
     {
         fn deserialize<D>(deserializer: D) -> Result<MyVec<T>, D::Error>
-            where D: de::Deserializer,
+            where D: de::Deserializer<'de>,
         {
             deserializer.deserialize_map(Visitor { marker: PhantomData })
         }
@@ -1451,9 +1451,9 @@ fn test_serialize_map_with_no_len() {
         marker: PhantomData<MyMap<K, V>>,
     }
 
-    impl<K, V> de::Visitor for Visitor<K, V>
-        where K: de::Deserialize + Eq + Ord,
-              V: de::Deserialize,
+    impl<'de, K, V> de::Visitor<'de> for Visitor<K, V>
+        where K: de::Deserialize<'de> + Eq + Ord,
+              V: de::Deserialize<'de>,
     {
         type Value = MyMap<K, V>;
 
@@ -1470,7 +1470,7 @@ fn test_serialize_map_with_no_len() {
 
         #[inline]
         fn visit_map<Visitor>(self, mut visitor: Visitor) -> Result<MyMap<K, V>, Visitor::Error>
-            where Visitor: de::MapVisitor,
+            where Visitor: de::MapVisitor<'de>,
         {
             let mut values = BTreeMap::new();
 
@@ -1482,12 +1482,12 @@ fn test_serialize_map_with_no_len() {
         }
     }
 
-    impl<K, V> de::Deserialize for MyMap<K, V>
-        where K: de::Deserialize + Eq + Ord,
-              V: de::Deserialize,
+    impl<'de, K, V> de::Deserialize<'de> for MyMap<K, V>
+        where K: de::Deserialize<'de> + Eq + Ord,
+              V: de::Deserialize<'de>,
     {
         fn deserialize<D>(deserializer: D) -> Result<MyMap<K, V>, D::Error>
-            where D: de::Deserializer,
+            where D: de::Deserializer<'de>,
         {
             deserializer.deserialize_map(Visitor { marker: PhantomData })
         }

--- a/json_tests/tests/test.rs
+++ b/json_tests/tests/test.rs
@@ -1932,3 +1932,9 @@ fn test_category() {
     assert!(from_str::<BTreeMap<String, usize>>("{\"k\":0").unwrap_err().is_eof());
     assert!(from_str::<BTreeMap<String, usize>>("{\"k\":0,").unwrap_err().is_eof());
 }
+
+#[test]
+fn test_str() {
+    let s: &str = from_str("\"borrowed\"").unwrap();
+    assert_eq!("borrowed", s);
+}


### PR DESCRIPTION
This PR enables serde_json to deserialize data structures that borrow from the input &str or &[u8].

Requires https://github.com/serde-rs/serde/pull/826.