### PR TITLE
Expose number of bytes processed by StreamDeserializer

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1067,6 +1067,13 @@ impl<'de, R, T> StreamDeserializer<'de, R, T>
     /// // If err.is_eof(), can join the remaining data to new data and continue.
     /// let remaining = &data[stream.byte_offset()..];
     /// ```
+    ///
+    /// *Note:* In the future this method may be changed to return the number of
+    /// bytes so far deserialized into a successful T *or* syntactically valid
+    /// JSON skipped over due to a type error. See [serde-rs/json#70] for an
+    /// example illustrating this.
+    ///
+    /// [serde-rs/json#70]: https://github.com/serde-rs/json/issues/70
     pub fn byte_offset(&self) -> usize {
         self.offset
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -97,8 +97,10 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     {
         // This cannot be an implementation of std::iter::IntoIterator because
         // we need the caller to choose what T is.
+        let offset = self.read.byte_offset();
         StreamDeserializer {
             de: self,
+            offset: offset,
             output: PhantomData,
             lifetime: PhantomData,
         }
@@ -1013,6 +1015,7 @@ impl<'de, 'a, R: Read<'de> + 'a> de::VariantVisitor<'de> for UnitVariantVisitor<
 /// ```
 pub struct StreamDeserializer<'de, R, T> {
     de: Deserializer<R>,
+    offset: usize,
     output: PhantomData<T>,
     lifetime: PhantomData<&'de ()>,
 }
@@ -1031,11 +1034,41 @@ impl<'de, R, T> StreamDeserializer<'de, R, T>
     ///   - Deserializer::from_iter(...).into_iter()
     ///   - Deserializer::from_reader(...).into_iter()
     pub fn new(read: R) -> Self {
+        let offset = read.byte_offset();
         StreamDeserializer {
             de: Deserializer::new(read),
+            offset: offset,
             output: PhantomData,
             lifetime: PhantomData,
         }
+    }
+
+    /// Returns the number of bytes so far deserialized into a successful `T`.
+    ///
+    /// If a stream deserializer returns an EOF error, new data can be joined to
+    /// `old_data[stream.byte_offset()..]` to try again.
+    ///
+    /// ```rust
+    /// let data = b"[0] [1] [";
+    ///
+    /// let de = serde_json::Deserializer::from_slice(data);
+    /// let mut stream = de.into_iter::<Vec<i32>>();
+    /// assert_eq!(0, stream.byte_offset());
+    ///
+    /// println!("{:?}", stream.next()); // [0]
+    /// assert_eq!(3, stream.byte_offset());
+    ///
+    /// println!("{:?}", stream.next()); // [1]
+    /// assert_eq!(7, stream.byte_offset());
+    ///
+    /// println!("{:?}", stream.next()); // error
+    /// assert_eq!(8, stream.byte_offset());
+    ///
+    /// // If err.is_eof(), can join the remaining data to new data and continue.
+    /// let remaining = &data[stream.byte_offset()..];
+    /// ```
+    pub fn byte_offset(&self) -> usize {
+        self.offset
     }
 }
 
@@ -1050,9 +1083,17 @@ impl<'de, R, T> Iterator for StreamDeserializer<'de, R, T>
         // this helps with trailing whitespaces, since whitespaces between
         // values are handled for us.
         match self.de.parse_whitespace() {
-            Ok(None) => None,
+            Ok(None) => {
+                self.offset = self.de.read.byte_offset();
+                None
+            }
             Ok(Some(b'{')) | Ok(Some(b'[')) => {
-                Some(de::Deserialize::deserialize(&mut self.de))
+                self.offset = self.de.read.byte_offset();
+                let result = de::Deserialize::deserialize(&mut self.de);
+                if result.is_ok() {
+                    self.offset = self.de.read.byte_offset();
+                }
+                Some(result)
             }
             Ok(Some(_)) => {
                 Some(Err(self.de.peek_error(ErrorCode::ExpectedObjectOrArray)))

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -5,53 +5,84 @@ extern crate serde_json;
 
 use serde_json::{Deserializer, Map, Value};
 
+macro_rules! test_stream {
+    ($data:expr, $ty:ty, |$stream:ident| $test:block) => {
+        {
+            let de = Deserializer::from_str($data);
+            let mut $stream = de.into_iter::<$ty>();
+            $test
+        }
+        {
+            let de = Deserializer::from_slice($data.as_bytes());
+            let mut $stream = de.into_iter::<$ty>();
+            $test
+        }
+        {
+            let de = Deserializer::from_iter($data.bytes().map(Ok));
+            let mut $stream = de.into_iter::<$ty>();
+            $test
+        }
+        {
+            let mut bytes = $data.as_bytes();
+            let de = Deserializer::from_reader(&mut bytes);
+            let mut $stream = de.into_iter::<$ty>();
+            $test
+        }
+    }
+}
+
 #[test]
 fn test_json_stream_newlines() {
     let data = "{\"x\":39} {\"x\":40}{\"x\":41}\n{\"x\":42}";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
 
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 39);
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 41);
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
-    assert!(parsed.next().is_none());
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 39);
+        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
+        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 41);
+        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
+        assert!(stream.next().is_none());
+    });
 }
 
 #[test]
 fn test_json_stream_trailing_whitespaces() {
     let data = "{\"x\":42} \t\n";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
 
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
-    assert!(parsed.next().is_none());
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
+        assert!(stream.next().is_none());
+    });
 }
 
 #[test]
 fn test_json_stream_truncated() {
     let data = "{\"x\":40}\n{\"x\":";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
 
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
-    assert!(parsed.next().unwrap().is_err());
-    assert!(parsed.next().is_none());
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
+        assert!(stream.next().unwrap().is_err());
+        assert!(stream.next().is_none());
+    });
 }
 
 #[test]
 fn test_json_stream_empty() {
     let data = "";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
 
-    assert!(parsed.next().is_none());
+    test_stream!(data, Value, |stream| {
+        assert!(stream.next().is_none());
+    });
 }
 
 #[test]
 fn test_json_stream_primitive() {
     let data = "{} true";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
 
-    let first = parsed.next().unwrap().unwrap();
-    assert_eq!(first, Value::Object(Map::new()));
+    test_stream!(data, Value, |stream| {
+        let first = stream.next().unwrap().unwrap();
+        assert_eq!(first, Value::Object(Map::new()));
 
-    let second = parsed.next().unwrap().unwrap_err();
-    assert_eq!(second.to_string(), "expected `{` or `[` at line 1 column 4");
+        let second = stream.next().unwrap().unwrap_err();
+        assert_eq!(second.to_string(), "expected `{` or `[` at line 1 column 4");
+    });
 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,0 +1,57 @@
+#![cfg(not(feature = "preserve_order"))]
+
+extern crate serde;
+extern crate serde_json;
+
+use serde_json::{Deserializer, Map, Value};
+
+#[test]
+fn test_json_stream_newlines() {
+    let data = "{\"x\":39} {\"x\":40}{\"x\":41}\n{\"x\":42}";
+    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
+
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 39);
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 41);
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
+    assert!(parsed.next().is_none());
+}
+
+#[test]
+fn test_json_stream_trailing_whitespaces() {
+    let data = "{\"x\":42} \t\n";
+    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
+
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
+    assert!(parsed.next().is_none());
+}
+
+#[test]
+fn test_json_stream_truncated() {
+    let data = "{\"x\":40}\n{\"x\":";
+    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
+
+    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
+    assert!(parsed.next().unwrap().is_err());
+    assert!(parsed.next().is_none());
+}
+
+#[test]
+fn test_json_stream_empty() {
+    let data = "";
+    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
+
+    assert!(parsed.next().is_none());
+}
+
+#[test]
+fn test_json_stream_primitive() {
+    let data = "{} true";
+    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
+
+    let first = parsed.next().unwrap().unwrap();
+    assert_eq!(first, Value::Object(Map::new()));
+
+    let second = parsed.next().unwrap().unwrap_err();
+    assert_eq!(second.to_string(), "expected `{` or `[` at line 1 column 4");
+}

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -1,31 +1,37 @@
 #![cfg(not(feature = "preserve_order"))]
 
 extern crate serde;
+
+#[macro_use]
 extern crate serde_json;
 
-use serde_json::{Deserializer, Map, Value};
+use serde_json::{Deserializer, Value};
 
 macro_rules! test_stream {
     ($data:expr, $ty:ty, |$stream:ident| $test:block) => {
         {
             let de = Deserializer::from_str($data);
             let mut $stream = de.into_iter::<$ty>();
+            assert_eq!($stream.byte_offset(), 0);
             $test
         }
         {
             let de = Deserializer::from_slice($data.as_bytes());
             let mut $stream = de.into_iter::<$ty>();
+            assert_eq!($stream.byte_offset(), 0);
             $test
         }
         {
             let de = Deserializer::from_iter($data.bytes().map(Ok));
             let mut $stream = de.into_iter::<$ty>();
+            assert_eq!($stream.byte_offset(), 0);
             $test
         }
         {
             let mut bytes = $data.as_bytes();
             let de = Deserializer::from_reader(&mut bytes);
             let mut $stream = de.into_iter::<$ty>();
+            assert_eq!($stream.byte_offset(), 0);
             $test
         }
     }
@@ -36,11 +42,20 @@ fn test_json_stream_newlines() {
     let data = "{\"x\":39} {\"x\":40}{\"x\":41}\n{\"x\":42}";
 
     test_stream!(data, Value, |stream| {
-        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 39);
-        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
-        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 41);
-        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 39);
+        assert_eq!(stream.byte_offset(), 8);
+
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 40);
+        assert_eq!(stream.byte_offset(), 17);
+
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 41);
+        assert_eq!(stream.byte_offset(), 25);
+
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 42);
+        assert_eq!(stream.byte_offset(), 34);
+
         assert!(stream.next().is_none());
+        assert_eq!(stream.byte_offset(), 34);
     });
 }
 
@@ -49,8 +64,11 @@ fn test_json_stream_trailing_whitespaces() {
     let data = "{\"x\":42} \t\n";
 
     test_stream!(data, Value, |stream| {
-        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 42);
+        assert_eq!(stream.byte_offset(), 8);
+
         assert!(stream.next().is_none());
+        assert_eq!(stream.byte_offset(), 11);
     });
 }
 
@@ -59,9 +77,11 @@ fn test_json_stream_truncated() {
     let data = "{\"x\":40}\n{\"x\":";
 
     test_stream!(data, Value, |stream| {
-        assert_eq!(stream.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
-        assert!(stream.next().unwrap().is_err());
-        assert!(stream.next().is_none());
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 40);
+        assert_eq!(stream.byte_offset(), 8);
+
+        assert!(stream.next().unwrap().unwrap_err().is_eof());
+        assert_eq!(stream.byte_offset(), 9);
     });
 }
 
@@ -71,6 +91,7 @@ fn test_json_stream_empty() {
 
     test_stream!(data, Value, |stream| {
         assert!(stream.next().is_none());
+        assert_eq!(stream.byte_offset(), 0);
     });
 }
 
@@ -79,8 +100,8 @@ fn test_json_stream_primitive() {
     let data = "{} true";
 
     test_stream!(data, Value, |stream| {
-        let first = stream.next().unwrap().unwrap();
-        assert_eq!(first, Value::Object(Map::new()));
+        assert_eq!(stream.next().unwrap().unwrap(), json!({}));
+        assert_eq!(stream.byte_offset(), 2);
 
         let second = stream.next().unwrap().unwrap_err();
         assert_eq!(second.to_string(), "expected `{` or `[` at line 1 column 4");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,7 +33,6 @@ use serde_bytes::{ByteBuf, Bytes};
 
 use serde_json::{
     Deserializer,
-    Map,
     Value,
     from_iter,
     from_reader,
@@ -1632,57 +1631,6 @@ fn test_byte_buf_de_multiple() {
     let a = ByteBuf::from(b"ab\nc".to_vec());
     let b =  ByteBuf::from(b"cd\ne".to_vec());
     assert_eq!(vec![a, b], s);
-}
-
-#[test]
-fn test_json_stream_newlines() {
-    let data = "{\"x\":39} {\"x\":40}{\"x\":41}\n{\"x\":42}";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
-
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 39);
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 41);
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
-    assert!(parsed.next().is_none());
-}
-
-#[test]
-fn test_json_stream_trailing_whitespaces() {
-    let data = "{\"x\":42} \t\n";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
-
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 42);
-    assert!(parsed.next().is_none());
-}
-
-#[test]
-fn test_json_stream_truncated() {
-    let data = "{\"x\":40}\n{\"x\":";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
-
-    assert_eq!(parsed.next().unwrap().ok().unwrap().pointer("/x").unwrap(), 40);
-    assert!(parsed.next().unwrap().is_err());
-    assert!(parsed.next().is_none());
-}
-
-#[test]
-fn test_json_stream_empty() {
-    let data = "";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
-
-    assert!(parsed.next().is_none());
-}
-
-#[test]
-fn test_json_stream_primitive() {
-    let data = "{} true";
-    let mut parsed = Deserializer::from_str(data).into_iter::<Value>();
-
-    let first = parsed.next().unwrap().unwrap();
-    assert_eq!(first, Value::Object(Map::new()));
-
-    let second = parsed.next().unwrap().unwrap_err();
-    assert_eq!(second.to_string(), "expected `{` or `[` at line 1 column 4");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #183.

The byte offset is the number of bytes so far deserialized into a successful `T`. If a stream deserializer returns an EOF error, new data can be joined to `old_data[stream.byte_offset()..]` to try again.

```rust
let data = b"[0] [1] [";

let de = serde_json::Deserializer::from_slice(data);
let mut stream = de.into_iter::<Vec<i32>>();
assert_eq!(0, stream.byte_offset());

println!("{:?}", stream.next()); // [0]
assert_eq!(3, stream.byte_offset());

println!("{:?}", stream.next()); // [1]
assert_eq!(7, stream.byte_offset());

println!("{:?}", stream.next()); // error
assert_eq!(8, stream.byte_offset());

// If err.is_eof(), can join the remaining data to new data and continue.
let remaining = &data[stream.byte_offset()..];
```

cc @vorner @ShepMaster who were interested in #212.