### PR TITLE
Switch to using char::encode_utf8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ cache: cargo
 rust:
   - stable
   - nightly
-  - 1.12.0
-  - 1.13.0
+  - 1.16.0
+  - 1.17.0
   - beta
 
 matrix:


### PR DESCRIPTION
Now that Rust 1.18 has come out, and according to our policy of supporting
the past 3 versions of rust, we can finally switch to using
`char::encode_utf8` to encode a character into a string.

Closes #270.