### PR TITLE
Add from_async_reader to simplify integration with tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ num-traits = "0.1.32"
 linked-hash-map = { version = "0.4.1", optional = true }
 itoa = "0.3"
 dtoa = "0.4"
+futures = { version = "0.1.14", optional = true }
+tokio-io = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 compiletest_rs = "0.2"
@@ -37,3 +39,6 @@ default = []
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.
 preserve_order = ["linked-hash-map"]
+
+# Integrate with tokio-io to add serde_json::from_async_reader
+tokio = ["futures", "tokio-io"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,10 @@ extern crate itoa;
 extern crate dtoa;
 #[cfg(feature = "preserve_order")]
 extern crate linked_hash_map;
+#[cfg(feature = "tokio")]
+extern crate futures;
+#[cfg(feature = "tokio")]
+extern crate tokio_io;
 
 #[doc(inline)]
 pub use self::de::{Deserializer, StreamDeserializer, from_reader, from_slice, from_str};
@@ -336,6 +340,10 @@ pub use self::ser::{Serializer, to_string, to_string_pretty, to_vec, to_vec_pret
                     to_writer_pretty};
 #[doc(inline)]
 pub use self::value::{Map, Number, Value, from_value, to_value};
+
+#[cfg(feature = "tokio")]
+#[doc(inline)]
+pub use self::de::from_async_reader;
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
I'm working on an asynchronous web framework for Rust, [Salt](https://github.com/mehcode/salt-rs), and one of my current tasks is to make consuming and producing JSON ergonomic.

Currently, I have this:

https://github.com/mehcode/salt-rs/blob/69cd12b27953f8b602023d8884ceede5dc628535/examples/json.rs#L40-L51

```rust
fn index(ctx: Context) -> impl Future<Item = Response, Error = Error> {
    io::read_to_end(ctx, Vec::new()).from_err().and_then(|(_, buffer)| {
        future::done(serde_json::from_slice(&buffer)).from_err()
    }).and_then(|body: RequestBody| {
        future::done(serde_json::to_string(&json!({
            "id": 20u8,
            "name": body.name,
        }))).from_err()
    }).map(|s| {
        Response::with(s).with_header(header::ContentType::json())
    })
}
```

It'd be very convenient if `serde_json` could parse JSON from an `tokio_io::AsyncRead` (in addition to a `Read` as it currently does).

Here's an example of the improvement possible with this PR:

https://github.com/mehcode/salt-rs/blob/ad4eaada4107f6f496f722a906d670a4afa3a97c/examples/json.rs#L22-L31

```rust
fn index<'a>(ctx: Context) -> impl Future<Item = Response> + 'a {
    serde_json::from_async_reader(ctx).and_then(|(_, body): (_, RequestBody)| {
        future::done(serde_json::to_string(&json!({
            "id": 20u8,
            "name": body.name,
        })))
    }).map(|s| {
        Response::with(s).with_header(header::ContentType::json())
    })
}
```