### PR TITLE
Arbitrary precision numerics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ serde_derive = "1.0"
 
 [features]
 default = []
-
+arbitrary_precision = []
 # Use LinkedHashMap rather than BTreeMap as the map type of serde_json::Value.
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,13 +8,13 @@
 
 //! When serializing or deserializing JSON goes wrong.
 
+use serde::de;
+use serde::ser;
+
 use std::error;
 use std::fmt::{self, Debug, Display};
 use std::io;
 use std::result;
-
-use serde::de;
-use serde::ser;
 
 /// This type represents all possible errors that can occur when serializing or
 /// deserializing JSON data.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,19 @@ extern crate dtoa;
 #[cfg(feature = "preserve_order")]
 extern crate linked_hash_map;
 
+#[macro_use]
+mod macros;
+
+mod iter;
+mod number;
+mod read;
+
+pub mod de;
+pub mod error;
+pub mod map;
+pub mod ser;
+pub mod value;
+
 #[doc(inline)]
 pub use self::de::{Deserializer, StreamDeserializer, from_reader, from_slice, from_str};
 #[doc(inline)]
@@ -336,16 +349,3 @@ pub use self::ser::{Serializer, to_string, to_string_pretty, to_vec, to_vec_pret
                     to_writer_pretty};
 #[doc(inline)]
 pub use self::value::{Map, Number, Value, from_value, to_value};
-
-#[macro_use]
-mod macros;
-
-pub mod de;
-pub mod error;
-pub mod map;
-pub mod ser;
-pub mod value;
-
-mod iter;
-mod number;
-mod read;

--- a/src/map.rs
+++ b/src/map.rs
@@ -14,13 +14,16 @@
 //! [`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
 //! [`LinkedHashMap`]: https://docs.rs/linked-hash-map/*/linked_hash_map/struct.LinkedHashMap.html
 
-use serde::{ser, de};
+use serde::de;
+use serde::ser;
+
+use std::borrow::{Borrow};
 use std::fmt::{self, Debug};
-use value::Value;
-use std::hash::Hash;
-use std::iter::FromIterator;
-use std::borrow::Borrow;
+use std::hash::{Hash};
+use std::iter::{FromIterator};
 use std::ops;
+
+use value::{Value};
 
 #[cfg(not(feature = "preserve_order"))]
 use std::collections::{BTreeMap, btree_map};

--- a/src/number.rs
+++ b/src/number.rs
@@ -6,14 +6,48 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use error::Error;
-use num_traits::NumCast;
-use serde::de::{self, Visitor, Unexpected};
 use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use std::fmt::{self, Debug, Display};
-use std::i64;
+use serde::de::{self, Visitor, Unexpected};
+
+use std::{i64};
+use std::fmt::{self, Display};
+
+use error::{Error};
+
+#[cfg(not(feature = "arbitrary_precision"))]
+use num_traits::NumCast;
+
+#[cfg(feature = "arbitrary_precision")]
+use dtoa;
+
+#[cfg(feature = "arbitrary_precision")]
+use itoa;
+
+#[cfg(feature = "arbitrary_precision")]
+use serde::de::{IntoDeserializer, MapAccess};
+
+#[cfg(feature = "arbitrary_precision")]
+use std::borrow::{Cow};
+#[cfg(not(feature = "arbitrary_precision"))]
+use std::fmt::{Debug};
+
+#[cfg(feature = "arbitrary_precision")]
+use error::{ErrorCode};
+
+#[cfg(feature = "arbitrary_precision")]
+/// Not public API. Should be pub(crate). The deserializer specializes on this
+/// type.
+#[doc(hidden)]
+pub const SERDE_STRUCT_FIELD_NAME: &'static str = "$__toml_private_number";
+
+#[cfg(feature = "arbitrary_precision")]
+/// Not public API. Should be pub(crate). The deserializer specializes on this
+/// type.
+#[doc(hidden)]
+pub const SERDE_STRUCT_NAME: &'static str = "$__toml_private_Number";
 
 /// Represents a JSON number, whether integer or floating point.
+#[cfg_attr(feature = "arbitrary_precision", derive(Debug))]
 #[derive(Clone, PartialEq)]
 pub struct Number {
     n: N,
@@ -21,6 +55,7 @@ pub struct Number {
 
 // "N" is a prefix of "NegInt"... this is a false positive.
 // https://github.com/Manishearth/rust-clippy/issues/1241
+#[cfg(not(feature = "arbitrary_precision"))]
 #[cfg_attr(feature = "cargo-clippy", allow(enum_variant_names))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum N {
@@ -29,6 +64,28 @@ enum N {
     NegInt(i64),
     /// Always finite.
     Float(f64),
+}
+
+#[cfg(feature = "arbitrary_precision")]
+type N = String;
+
+#[cfg(not(feature = "arbitrary_precision"))]
+macro_rules! cast_methods {
+    ($(
+        #[doc = $doc:tt]
+        pub fn $method:ident(&self) -> Option<$ty:ident>;
+    )+) => {
+        $(
+            #[doc = $doc]
+            pub fn $method(&self) -> Option<$ty> {
+                match self.n {
+                    N::PosInt(n) => NumCast::from(n),
+                    N::NegInt(n) => NumCast::from(n),
+                    N::Float(n) => NumCast::from(n),
+                }
+            }
+        )*
+    };
 }
 
 impl Number {
@@ -53,17 +110,13 @@ impl Number {
     /// // Greater than i64::MAX.
     /// assert!(!v["b"].is_i64());
     ///
-    /// // Numbers with a decimal point are not considered integers.
-    /// assert!(!v["c"].is_i64());
+    /// // Can be converted to a signed integer.
+    /// assert!(v["c"].is_i64());
     /// # }
     /// ```
     #[inline]
     pub fn is_i64(&self) -> bool {
-        match self.n {
-            N::PosInt(v) => v <= i64::MAX as u64,
-            N::NegInt(_) => true,
-            N::Float(_) => false,
-        }
+        self.as_i64().is_some()
     }
 
     /// Returns true if the `Number` is an integer between zero and `u64::MAX`.
@@ -83,25 +136,19 @@ impl Number {
     /// // Negative integer.
     /// assert!(!v["b"].is_u64());
     ///
-    /// // Numbers with a decimal point are not considered integers.
-    /// assert!(!v["c"].is_u64());
+    /// // Can be converted to an unsigned integer.
+    /// assert!(v["c"].is_u64());
     /// # }
     /// ```
     #[inline]
     pub fn is_u64(&self) -> bool {
-        match self.n {
-            N::PosInt(_) => true,
-            N::NegInt(_) | N::Float(_) => false,
-        }
+        self.as_u64().is_some()
     }
 
     /// Returns true if the `Number` can be represented by f64.
     ///
     /// For any Number on which `is_f64` returns true, `as_f64` is guaranteed to
     /// return the floating point value.
-    ///
-    /// Currently this function returns true if and only if both `is_i64` and
-    /// `is_u64` return false but this is not a guarantee in the future.
     ///
     /// ```rust
     /// # #[macro_use]
@@ -113,90 +160,43 @@ impl Number {
     /// assert!(v["a"].is_f64());
     ///
     /// // Integers.
-    /// assert!(!v["b"].is_f64());
-    /// assert!(!v["c"].is_f64());
+    /// assert!(v["b"].is_f64());
+    /// assert!(v["c"].is_f64());
     /// # }
     /// ```
     #[inline]
     pub fn is_f64(&self) -> bool {
-        match self.n {
-            N::Float(_) => true,
-            N::PosInt(_) | N::NegInt(_) => false,
-        }
+        self.as_f64().is_some()
     }
 
-    /// If the `Number` is an integer, represent it as i64 if possible. Returns
-    /// None otherwise.
-    ///
-    /// ```rust
-    /// # #[macro_use]
-    /// # extern crate serde_json;
-    /// #
-    /// # use std::i64;
-    /// #
-    /// # fn main() {
-    /// let big = i64::MAX as u64 + 10;
-    /// let v = json!({ "a": 64, "b": big, "c": 256.0 });
-    ///
-    /// assert_eq!(v["a"].as_i64(), Some(64));
-    /// assert_eq!(v["b"].as_i64(), None);
-    /// assert_eq!(v["c"].as_i64(), None);
-    /// # }
-    /// ```
-    #[inline]
+    #[cfg(not(feature = "arbitrary_precision"))]
+    cast_methods! {
+        /// Returns the number represented as `i64` if possible, or else None.
+        pub fn as_i64(&self) -> Option<i64>;
+
+        /// Returns the number represented as `u64` if possible, or else None.
+        pub fn as_u64(&self) -> Option<u64>;
+
+        /// Returns the number represented as `f64` if possible, or else `None`.
+        pub fn as_f64(&self) -> Option<f64>;
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    /// Returns the number represented as `i64` if possible, or else `None`.
     pub fn as_i64(&self) -> Option<i64> {
-        match self.n {
-            N::PosInt(n) => NumCast::from(n),
-            N::NegInt(n) => Some(n),
-            N::Float(_) => None,
-        }
+        self.n.splitn(2, '.').next().and_then(|n| n.parse().ok())
     }
 
-    /// If the `Number` is an integer, represent it as u64 if possible. Returns
-    /// None otherwise.
-    ///
-    /// ```rust
-    /// # #[macro_use]
-    /// # extern crate serde_json;
-    /// #
-    /// # fn main() {
-    /// let v = json!({ "a": 64, "b": -64, "c": 256.0 });
-    ///
-    /// assert_eq!(v["a"].as_u64(), Some(64));
-    /// assert_eq!(v["b"].as_u64(), None);
-    /// assert_eq!(v["c"].as_u64(), None);
-    /// # }
-    /// ```
-    #[inline]
+    #[cfg(feature = "arbitrary_precision")]
+    /// Returns the number represented as `u64` if possible, or else `None`.
     pub fn as_u64(&self) -> Option<u64> {
-        match self.n {
-            N::PosInt(n) => Some(n),
-            N::NegInt(n) => NumCast::from(n),
-            N::Float(_) => None,
-        }
+        self.n.splitn(2, '.').next().and_then(|n| n.parse().ok())
     }
 
-    /// Represents the number as f64 if possible. Returns None otherwise.
-    ///
-    /// ```rust
-    /// # #[macro_use]
-    /// # extern crate serde_json;
-    /// #
-    /// # fn main() {
-    /// let v = json!({ "a": 256.0, "b": 64, "c": -64 });
-    ///
-    /// assert_eq!(v["a"].as_f64(), Some(256.0));
-    /// assert_eq!(v["b"].as_f64(), Some(64.0));
-    /// assert_eq!(v["c"].as_f64(), Some(-64.0));
-    /// # }
-    /// ```
-    #[inline]
+    #[cfg(feature = "arbitrary_precision")]
+    /// Returns the number represented as `f64` if possible, or else `None`.
     pub fn as_f64(&self) -> Option<f64> {
-        match self.n {
-            N::PosInt(n) => NumCast::from(n),
-            N::NegInt(n) => NumCast::from(n),
-            N::Float(n) => Some(n),
-        }
+        self.n.parse().ok()
     }
 
     /// Converts a finite `f64` to a `Number`. Infinite or NaN values are not JSON
@@ -214,23 +214,50 @@ impl Number {
     #[inline]
     pub fn from_f64(f: f64) -> Option<Number> {
         if f.is_finite() {
-            Some(Number { n: N::Float(f) })
+            Some(Number { n: n_from_finite_f64(f) })
         } else {
             None
         }
     }
+
+    /// Not public API. Should be pub(crate). The deserializer uses this.
+    #[cfg(feature = "arbitrary_precision")]
+    #[doc(hidden)]
+    #[inline]
+    pub fn from_string_unchecked(n: String) -> Self {
+        Number { n: n }
+    }
 }
 
-impl fmt::Display for Number {
+#[cfg(not(feature = "arbitrary_precision"))]
+fn n_from_finite_f64(f: f64) -> N {
+    N::Float(f)
+}
+
+#[cfg(feature = "arbitrary_precision")]
+fn n_from_finite_f64(f: f64) -> N {
+    let mut buf = Vec::new();
+    dtoa::write(&mut buf, f).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+impl Display for Number {
+    #[cfg(not(feature = "arbitrary_precision"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self.n {
-            N::PosInt(i) => Display::fmt(&i, formatter),
+            N::PosInt(u) => Display::fmt(&u, formatter),
             N::NegInt(i) => Display::fmt(&i, formatter),
             N::Float(f) => Display::fmt(&f, formatter),
         }
     }
+
+    #[cfg(feature = "arbitrary_precision")]
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(&self.n)
+    }
 }
 
+#[cfg(not(feature = "arbitrary_precision"))]
 impl Debug for Number {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         Debug::fmt(&self.n, formatter)
@@ -238,101 +265,388 @@ impl Debug for Number {
 }
 
 impl Serialize for Number {
+    #[cfg(not(feature = "arbitrary_precision"))]
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         match self.n {
-            N::PosInt(i) => serializer.serialize_u64(i),
+            N::PosInt(u) => serializer.serialize_u64(u),
             N::NegInt(i) => serializer.serialize_i64(i),
             N::Float(f) => serializer.serialize_f64(f),
         }
     }
+
+    #[cfg(feature = "arbitrary_precision")]
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut s = serializer.serialize_struct(SERDE_STRUCT_NAME, 1)?;
+        s.serialize_field(SERDE_STRUCT_FIELD_NAME, &self.to_string())?;
+        s.end()
+    }
+}
+
+/// Not public API. Should be pub(crate). The deserializer specializes on this
+/// type.
+#[doc(hidden)]
+pub struct NumberVisitor;
+
+impl<'de> de::Visitor<'de> for NumberVisitor {
+    type Value = Number;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a JSON number")
+    }
+
+    #[cfg(not(feature = "arbitrary_precision"))]
+    #[inline]
+    fn visit_i64<E>(self, value: i64) -> Result<Number, E> {
+        Ok(value.into())
+    }
+
+    #[cfg(not(feature = "arbitrary_precision"))]
+    #[inline]
+    fn visit_u64<E>(self, value: u64) -> Result<Number, E> {
+        Ok(value.into())
+    }
+
+    #[cfg(not(feature = "arbitrary_precision"))]
+    #[inline]
+    fn visit_f64<E>(self, value: f64) -> Result<Number, E>
+        where E: de::Error
+    {
+        Number::from_f64(value).ok_or_else(|| de::Error::custom("not a JSON number"))
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    #[inline]
+    fn visit_map<V>(self, mut visitor: V) -> Result<Number, V::Error>
+        where V: de::MapAccess<'de>
+    {
+        let value = visitor.next_key::<NumberKey>()?;
+        if value.is_none() {
+            return Err(de::Error::custom("number key not found"))
+        }
+        let v: NumberFromString = visitor.next_value()?;
+        Ok(v.value)
+    }
 }
 
 impl<'de> Deserialize<'de> for Number {
+    #[cfg(not(feature = "arbitrary_precision"))]
     #[inline]
     fn deserialize<D>(deserializer: D) -> Result<Number, D::Error>
-    where
-        D: Deserializer<'de>,
+        where D: de::Deserializer<'de>
     {
-        struct NumberVisitor;
+        deserializer.deserialize_any(NumberVisitor)
+    }
 
-        impl<'de> Visitor<'de> for NumberVisitor {
-            type Value = Number;
+    #[cfg(feature = "arbitrary_precision")]
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Number, D::Error>
+        where D: de::Deserializer<'de>
+    {
+        static FIELDS: [&'static str; 1] = [SERDE_STRUCT_FIELD_NAME];
+        deserializer.deserialize_struct(SERDE_STRUCT_NAME,
+                                        &FIELDS,
+                                        NumberVisitor)
+    }
+}
+
+#[cfg(feature = "arbitrary_precision")]
+struct NumberKey;
+
+#[cfg(feature = "arbitrary_precision")]
+impl<'de> de::Deserialize<'de> for NumberKey {
+    fn deserialize<D>(deserializer: D) -> Result<NumberKey, D::Error>
+        where D: de::Deserializer<'de>
+    {
+        struct FieldVisitor;
+
+        impl<'de> de::Visitor<'de> for FieldVisitor {
+            type Value = ();
 
             fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("a number")
+                formatter.write_str("a valid number field")
             }
 
-            #[inline]
-            fn visit_i64<E>(self, value: i64) -> Result<Number, E> {
-                Ok(value.into())
-            }
-
-            #[inline]
-            fn visit_u64<E>(self, value: u64) -> Result<Number, E> {
-                Ok(value.into())
-            }
-
-            #[inline]
-            fn visit_f64<E>(self, value: f64) -> Result<Number, E>
-            where
-                E: de::Error,
+            fn visit_str<E>(self, s: &str) -> Result<(), E>
+                where E: de::Error
             {
-                Number::from_f64(value).ok_or_else(|| de::Error::custom("not a JSON number"))
+                if s == SERDE_STRUCT_FIELD_NAME {
+                    Ok(())
+                } else {
+                    Err(de::Error::custom("expected field with custom name"))
+                }
             }
         }
 
-        deserializer.deserialize_any(NumberVisitor)
+        try!(deserializer.deserialize_identifier(FieldVisitor));
+        Ok(NumberKey)
+    }
+}
+
+#[cfg(feature = "arbitrary_precision")]
+pub struct NumberFromString {
+    pub value: Number,
+}
+
+#[cfg(feature = "arbitrary_precision")]
+impl<'de> de::Deserialize<'de> for NumberFromString {
+    fn deserialize<D>(deserializer: D) -> Result<NumberFromString, D::Error>
+        where D: de::Deserializer<'de>
+    {
+        struct Visitor;
+
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = NumberFromString;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("string containing a number")
+            }
+
+            fn visit_string<E>(self, s: String) -> Result<NumberFromString, E>
+                where E: de::Error,
+            {
+                Ok(NumberFromString { value: Number::from_string_unchecked(s) })
+            }
+        }
+
+        deserializer.deserialize_str(Visitor)
+    }
+}
+
+#[cfg(feature = "arbitrary_precision")]
+fn invalid_number() -> Error {
+    Error::syntax(ErrorCode::InvalidNumber, 0, 0)
+}
+
+macro_rules! deserialize_number {
+    ($deserialize:ident => $visit:ident) => {
+        #[cfg(not(feature = "arbitrary_precision"))]
+        fn $deserialize<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: Visitor<'de>,
+        {
+            self.deserialize_any(visitor)
+        }
+
+        #[cfg(feature = "arbitrary_precision")]
+        fn $deserialize<V>(self, visitor: V) -> Result<V::Value, Error>
+        where
+            V: de::Visitor<'de>,
+        {
+            visitor.$visit(try!(self.n.parse().map_err(|_| invalid_number())))
+        }
     }
 }
 
 impl<'de> Deserializer<'de> for Number {
     type Error = Error;
 
+    #[cfg(not(feature = "arbitrary_precision"))]
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
     where
         V: Visitor<'de>,
     {
         match self.n {
-            N::PosInt(i) => visitor.visit_u64(i),
+            N::PosInt(u) => visitor.visit_u64(u),
             N::NegInt(i) => visitor.visit_i64(i),
             N::Float(f) => visitor.visit_f64(f),
         }
     }
 
+    #[cfg(feature = "arbitrary_precision")]
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+        where V: Visitor<'de>
+    {
+        visitor.visit_map(NumberDeserializer {
+            visited: false,
+            number: self.n.into(),
+        })
+    }
+
+    deserialize_number!(deserialize_i8 => visit_i8);
+    deserialize_number!(deserialize_i16 => visit_i16);
+    deserialize_number!(deserialize_i32 => visit_i32);
+    deserialize_number!(deserialize_i64 => visit_i64);
+    deserialize_number!(deserialize_u8 => visit_u8);
+    deserialize_number!(deserialize_u16 => visit_u16);
+    deserialize_number!(deserialize_u32 => visit_u32);
+    deserialize_number!(deserialize_u64 => visit_u64);
+    deserialize_number!(deserialize_f32 => visit_f32);
+    deserialize_number!(deserialize_f64 => visit_f64);
+
+    #[cfg(not(feature = "arbitrary_precision"))]
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_string(self.n)
+    }
+
+    #[cfg(not(feature = "arbitrary_precision"))]
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_str(&self.n)
+    }
+
     forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
-        byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
+        bool char bytes byte_buf option unit unit_struct newtype_struct seq tuple tuple_struct map
+        struct enum identifier ignored_any
     }
 }
 
-impl<'de, 'a> Deserializer<'de> for &'a Number {
+impl<'de> Deserializer<'de> for &'de Number {
     type Error = Error;
 
+    #[cfg(not(feature = "arbitrary_precision"))]
     #[inline]
     fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
-    where
-        V: Visitor<'de>,
+        where V: Visitor<'de>
     {
         match self.n {
-            N::PosInt(i) => visitor.visit_u64(i),
+            N::PosInt(u) => visitor.visit_u64(u),
             N::NegInt(i) => visitor.visit_i64(i),
             N::Float(f) => visitor.visit_f64(f),
         }
     }
 
+    #[cfg(feature = "arbitrary_precision")]
+    #[inline]
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+        where V: Visitor<'de>
+    {
+        visitor.visit_map(NumberDeserializer {
+            visited: false,
+            number: (&self.n as &str).into(),
+        })
+    }
+
+    deserialize_number!(deserialize_i8 => visit_i8);
+    deserialize_number!(deserialize_i16 => visit_i16);
+    deserialize_number!(deserialize_i32 => visit_i32);
+    deserialize_number!(deserialize_i64 => visit_i64);
+    deserialize_number!(deserialize_u8 => visit_u8);
+    deserialize_number!(deserialize_u16 => visit_u16);
+    deserialize_number!(deserialize_u32 => visit_u32);
+    deserialize_number!(deserialize_u64 => visit_u64);
+    deserialize_number!(deserialize_f32 => visit_f32);
+    deserialize_number!(deserialize_f64 => visit_f64);
+
+    #[cfg(not(feature = "arbitrary_precision"))]
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_string(self.n.clone())
+    }
+
+    #[cfg(not(feature = "arbitrary_precision"))]
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        self.deserialize_any(visitor)
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Error>
+    where
+        V: de::Visitor<'de>,
+    {
+        visitor.visit_str(&self.n)
+    }
+
     forward_to_deserialize_any! {
-        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string bytes
-        byte_buf option unit unit_struct newtype_struct seq tuple
-        tuple_struct map struct enum identifier ignored_any
+        bool char bytes byte_buf option unit unit_struct newtype_struct seq tuple tuple_struct map
+        struct enum identifier ignored_any
     }
 }
 
+#[cfg(feature = "arbitrary_precision")]
+// Not public API. Should be pub(crate).
+#[doc(hidden)]
+pub struct NumberDeserializer<'a> {
+    pub visited: bool,
+    pub number: Cow<'a, str>,
+}
+
+#[cfg(feature = "arbitrary_precision")]
+impl<'de> MapAccess<'de> for NumberDeserializer<'de> {
+    type Error = Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Error>
+        where K: de::DeserializeSeed<'de>,
+    {
+        if self.visited {
+            return Ok(None)
+        }
+        self.visited = true;
+        seed.deserialize(NumberFieldDeserializer).map(Some)
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Error>
+        where V: de::DeserializeSeed<'de>,
+    {
+        seed.deserialize(self.number.to_owned().into_deserializer())
+    }
+}
+
+#[cfg(feature = "arbitrary_precision")]
+struct NumberFieldDeserializer;
+
+#[cfg(feature = "arbitrary_precision")]
+impl<'de> Deserializer<'de> for NumberFieldDeserializer {
+    type Error = Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Error>
+        where V: de::Visitor<'de>,
+    {
+        visitor.visit_borrowed_str(SERDE_STRUCT_FIELD_NAME)
+    }
+
+    forward_to_deserialize_any! {
+        bool u8 u16 u32 u64 i8 i16 i32 i64 f32 f64 char str string seq
+        bytes byte_buf map struct option unit newtype_struct
+        ignored_any unit_struct tuple_struct tuple enum identifier
+    }
+}
+
+#[cfg(not(feature = "arbitrary_precision"))]
 macro_rules! from_signed {
     ($($signed_ty:ident)*) => {
         $(
@@ -350,6 +664,7 @@ macro_rules! from_signed {
     };
 }
 
+#[cfg(not(feature = "arbitrary_precision"))]
 macro_rules! from_unsigned {
     ($($unsigned_ty:ident)*) => {
         $(
@@ -363,10 +678,32 @@ macro_rules! from_unsigned {
     };
 }
 
+#[cfg(not(feature = "arbitrary_precision"))]
 from_signed!(i8 i16 i32 i64 isize);
+#[cfg(not(feature = "arbitrary_precision"))]
 from_unsigned!(u8 u16 u32 u64 usize);
 
+#[cfg(feature = "arbitrary_precision")]
+macro_rules! from_primitive {
+    ($($ty:ident)*) => {
+        $(
+            impl From<$ty> for Number {
+                #[inline]
+                fn from(primitive: $ty) -> Self {
+                    let mut buf = Vec::new();
+                    itoa::write(&mut buf, primitive).unwrap();
+                    Number { n: String::from_utf8(buf).unwrap() }
+                }
+            }
+        )*
+    };
+}
+
+#[cfg(feature = "arbitrary_precision")]
+from_primitive!(i8 i16 i32 i64 isize u8 u16 u32 u64 usize);
+
 impl Number {
+    #[cfg(not(feature = "arbitrary_precision"))]
     // Not public API. Should be pub(crate).
     #[doc(hidden)]
     pub fn unexpected(&self) -> Unexpected {
@@ -375,5 +712,12 @@ impl Number {
             N::NegInt(i) => Unexpected::Signed(i),
             N::Float(f) => Unexpected::Float(f),
         }
+    }
+
+    #[cfg(feature = "arbitrary_precision")]
+    // Not public API. Should be pub(crate).
+    #[doc(hidden)]
+    pub fn unexpected(&self) -> Unexpected {
+        Unexpected::Other("number")
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -6,11 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::{char, cmp, io, str};
-use std::ops::Deref;
+use std::char;
+use std::cmp;
+use std::io;
+use std::ops::{Deref};
+use std::str;
 
-use iter::LineColIterator;
-
+use iter::{LineColIterator};
 use super::error::{Error, ErrorCode, Result};
 
 /// Trait used by the deserializer for iterating over input. This is manually

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -9,8 +9,8 @@
 use std::fmt;
 use std::ops;
 
-use super::Value;
 use map::Map;
+use super::Value;
 
 /// A type that can be used to index into a `serde_json::Value`. See the `get`
 /// and `get_mut` methods of `Value`.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -107,19 +107,18 @@
 //! [from_slice]: https://docs.serde.rs/serde_json/de/fn.from_slice.html
 //! [from_reader]: https://docs.serde.rs/serde_json/de/fn.from_reader.html
 
-use std::i64;
-use std::str;
+use serde::ser::{Serialize};
+use serde::de::{DeserializeOwned};
 
-use serde::ser::Serialize;
-use serde::de::DeserializeOwned;
+use std::{i64};
+use std::{str};
 
 use error::Error;
+use self::ser::Serializer;
+
 pub use map::Map;
 pub use number::Number;
-
 pub use self::index::Index;
-
-use self::ser::Serializer;
 
 /// Represents any valid JSON value.
 ///
@@ -512,8 +511,8 @@ impl Value {
     /// // Greater than i64::MAX.
     /// assert!(!v["b"].is_i64());
     ///
-    /// // Numbers with a decimal point are not considered integers.
-    /// assert!(!v["c"].is_i64());
+    /// // Can be converted to an unsigned integer.
+    /// assert!(v["c"].is_i64());
     /// # }
     /// ```
     pub fn is_i64(&self) -> bool {
@@ -540,8 +539,8 @@ impl Value {
     /// // Negative integer.
     /// assert!(!v["b"].is_u64());
     ///
-    /// // Numbers with a decimal point are not considered integers.
-    /// assert!(!v["c"].is_u64());
+    /// // Can be converted to an unsigned integer.
+    /// assert!(v["c"].is_u64());
     /// # }
     /// ```
     pub fn is_u64(&self) -> bool {
@@ -556,9 +555,6 @@ impl Value {
     /// For any Value on which `is_f64` returns true, `as_f64` is guaranteed to
     /// return the floating point value.
     ///
-    /// Currently this function returns true if and only if both `is_i64` and
-    /// `is_u64` return false but this is not a guarantee in the future.
-    ///
     /// ```rust
     /// # #[macro_use]
     /// # extern crate serde_json;
@@ -569,8 +565,8 @@ impl Value {
     /// assert!(v["a"].is_f64());
     ///
     /// // Integers.
-    /// assert!(!v["b"].is_f64());
-    /// assert!(!v["c"].is_f64());
+    /// assert!(v["b"].is_f64());
+    /// assert!(v["c"].is_f64());
     /// # }
     /// ```
     pub fn is_f64(&self) -> bool {
@@ -595,7 +591,7 @@ impl Value {
     ///
     /// assert_eq!(v["a"].as_i64(), Some(64));
     /// assert_eq!(v["b"].as_i64(), None);
-    /// assert_eq!(v["c"].as_i64(), None);
+    /// assert_eq!(v["c"].as_i64(), Some(256));
     /// # }
     /// ```
     pub fn as_i64(&self) -> Option<i64> {
@@ -617,7 +613,7 @@ impl Value {
     ///
     /// assert_eq!(v["a"].as_u64(), Some(64));
     /// assert_eq!(v["b"].as_u64(), None);
-    /// assert_eq!(v["c"].as_u64(), None);
+    /// assert_eq!(v["c"].as_u64(), Some(256));
     /// # }
     /// ```
     pub fn as_u64(&self) -> Option<u64> {

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -11,7 +11,7 @@ extern crate compiletest_rs as compiletest;
 use std::env;
 
 fn run_mode(mode: &'static str) {
-    let mut config = compiletest::default_config();
+    let mut config = compiletest::Config::default();
 
     config.mode = mode.parse().expect("invalid mode");
     config.target_rustcflags = Some("-L tests/deps/target/debug/deps".to_owned());

--- a/tests/deps/Cargo.toml
+++ b/tests/deps/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 authors = ["David Tolnay <dtolnay@gmail.com>"]
 publish = false
 
+[features]
+arbitrary_precision = ["serde_json/arbitrary_precision"]
+
 [workspace]
 
 [dependencies]

--- a/travis.sh
+++ b/travis.sh
@@ -36,6 +36,7 @@ else
     (cd "$DIR/tests/deps" && channel build)
     channel test
     channel test --features preserve_order
+    channel test --features arbitrary_precision
 
     for CHANNEL in stable 1.15.0 1.16.0 1.17.0 beta; do
         channel clean


### PR DESCRIPTION
This effort was based in part on the work of @dtolnay in #252 and @alexcrichton in https://github.com/alexcrichton/toml-rs.

Also updated test suite for `arbitrary_precision` feature.

Notes:
* I haven't yet benchmarked the library with `arbitrary_precision` enabled vs. disabled; this would surely be worthwhile.
* There's a fair bit of code duplication between `cfg(feature = "arbitrary_precision")` and `cfg(not(feature = "arbitrary_precision"))` functions, but I couldn't see a straightforward way around this.
* I noticed while going through the code that some of the inlining may not be consistent, but that's another task.
