### PR TITLE
change error type for trailing commas, fixes #352

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1029,8 +1029,6 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
             Some(_) => Ok(Some(try!(seed.deserialize(&mut *self.de)))),
             None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
         }
-        //let value = try!(seed.deserialize(&mut *self.de));
-        //Ok(Some(value))
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1062,6 +1062,7 @@ impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
 
         match peek {
             Some(b'"') => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
+            Some(b'}') => Err(self.de.peek_error(ErrorCode::TrailingCharacters)),
             Some(_) => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
             None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -75,6 +75,7 @@ impl Error {
             ErrorCode::InvalidUnicodeCodePoint |
             ErrorCode::KeyMustBeAString |
             ErrorCode::LoneLeadingSurrogateInHexEscape |
+            ErrorCode::TrailingComma |
             ErrorCode::TrailingCharacters |
             ErrorCode::UnexpectedEndOfHexEscape |
             ErrorCode::RecursionLimitExceeded => Category::Syntax,
@@ -244,6 +245,9 @@ pub enum ErrorCode {
     /// Lone leading surrogate in hex escape.
     LoneLeadingSurrogateInHexEscape,
 
+    /// JSON has a comma after the last value in an array or map.
+    TrailingComma,
+
     /// JSON has non-whitespace trailing characters after the value.
     TrailingCharacters,
 
@@ -321,6 +325,7 @@ impl Display for ErrorCode {
             ErrorCode::LoneLeadingSurrogateInHexEscape => {
                 f.write_str("lone leading surrogate in hex escape")
             }
+            ErrorCode::TrailingComma => f.write_str("trailing comma"),
             ErrorCode::TrailingCharacters => f.write_str("trailing characters"),
             ErrorCode::UnexpectedEndOfHexEscape => f.write_str("unexpected end of hex escape"),
             ErrorCode::RecursionLimitExceeded => f.write_str("recursion limit exceeded"),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1114,6 +1114,11 @@ fn test_parse_enum_errors() {
             ("{\"Cat\":[0, \"\", 2]}", "trailing characters at line 1 column 14"),
             ("{\"Cat\":{\"age\": 5, \"name\": \"Kate\", \"foo\":\"bar\"}",
              "unknown field `foo`, expected `age` or `name` at line 1 column 39"),
+
+            // JSON does not allow trailing commas in data structures
+            ("{\"Cat\":[0, \"Kate\",]}", "trailing characters at line 1 column 18"),
+            ("{\"Cat\":{\"age\": 2, \"name\": \"Kate\",}}",
+             "trailing characters at line 1 column 34"),
         ],
     );
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -894,7 +894,7 @@ fn test_parse_list() {
             ("[ ", "EOF while parsing a list at line 1 column 2"),
             ("[1", "EOF while parsing a list at line 1 column 2"),
             ("[1,", "EOF while parsing a value at line 1 column 3"),
-            ("[1,]", "expected value at line 1 column 4"),
+            ("[1,]", "trailing comma at line 1 column 4"),
             ("[1 2]", "expected `,` or `]` at line 1 column 4"),
             ("[]a", "trailing characters at line 1 column 3"),
         ],
@@ -1111,14 +1111,14 @@ fn test_parse_enum_errors() {
              "invalid type: map, expected tuple variant Animal::Frog at line 1 column 10"),
             ("{\"Cat\":[]}", "invalid length 0, expected tuple of 2 elements at line 1 column 9"),
             ("{\"Cat\":[0]}", "invalid length 1, expected tuple of 2 elements at line 1 column 10"),
-            ("{\"Cat\":[0, \"\", 2]}", "trailing characters at line 1 column 14"),
+            ("{\"Cat\":[0, \"\", 2]}", "trailing characters at line 1 column 16"),
             ("{\"Cat\":{\"age\": 5, \"name\": \"Kate\", \"foo\":\"bar\"}",
              "unknown field `foo`, expected `age` or `name` at line 1 column 39"),
 
             // JSON does not allow trailing commas in data structures
-            ("{\"Cat\":[0, \"Kate\",]}", "trailing characters at line 1 column 18"),
+            ("{\"Cat\":[0, \"Kate\",]}", "trailing comma at line 1 column 19"),
             ("{\"Cat\":{\"age\": 2, \"name\": \"Kate\",}}",
-             "trailing characters at line 1 column 34"),
+             "trailing comma at line 1 column 34"),
         ],
     );
 }


### PR DESCRIPTION
**NOTE:** There is one small defect with this patch. The line and column numbers that the error message reports match the position of the closing brace after the trailing comma and not the position of the trailing comma.

I plant to continue searching for the logic that determines the line and column numbers. If someone wants to speed things up and point me towards the relevant code it would be much appreciated.