### PR TITLE
Resolves #334 - Extend Serializer's default recursion limit to 255

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -26,7 +26,7 @@ pub use read::{Read, IoRead, SliceRead, StrRead};
 pub struct Deserializer<R> {
     read: R,
     str_buf: Vec<u8>,
-    remaining_depth: u8,
+    remaining_depth: usize,
 }
 
 impl<'de, R> Deserializer<R>
@@ -34,7 +34,7 @@ where
     R: read::Read<'de>,
 {
     /// Create a JSON deserializer from one of the possible serde_json input
-    /// sources.
+    /// sources. By default, it has a recursion limit of 255.
     ///
     /// Typically it is more convenient to use one of these methods instead:
     ///
@@ -45,7 +45,7 @@ where
         Deserializer {
             read: read,
             str_buf: Vec::with_capacity(128),
-            remaining_depth: 128,
+            remaining_depth: 255,
         }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1612,13 +1612,13 @@ fn test_json_pointer_mut() {
 #[test]
 fn test_stack_overflow() {
     let brackets: String = iter::repeat('[')
-        .take(127)
-        .chain(iter::repeat(']').take(127))
+        .take(254)
+        .chain(iter::repeat(']').take(254))
         .collect();
     let _: Value = from_str(&brackets).unwrap();
 
-    let brackets: String = iter::repeat('[').take(128).collect();
-    test_parse_err::<Value>(&[(&brackets, "recursion limit exceeded at line 1 column 128")],);
+    let brackets: String = iter::repeat('[').take(256).collect();
+    test_parse_err::<Value>(&[(&brackets, "recursion limit exceeded at line 1 column 255")],);
 }
 
 #[test]


### PR DESCRIPTION
By opposition to https://github.com/serde-rs/json/pull/346, this doesn't break the stack.

Also, as discussed in https://github.com/serde-rs/json/pull/346, `remaining_depth` becomes a `usize`.