### PR TITLE
Remove unnecessary allow(needless_pass_by_value)

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -985,7 +985,6 @@ mod de;
 ///     println!("{}", serde_json::to_value(map).unwrap_err());
 /// }
 /// ```
-#[cfg_attr(feature = "cargo-clippy", allow(needless_pass_by_value))]
 // Taking by value is more friendly to iterator adapters, option and result
 // consumers, etc. See https://github.com/serde-rs/json/pull/149.
 pub fn to_value<T>(value: T) -> Result<Value, Error>


### PR DESCRIPTION
Clippy 0.0.166 doesn't trigger needless_pass_by_value lint when a trait bound satisfies both `T` and `&T` (so the caller can choose between them).