### PR TITLE
Warn about enum_variant_names violations in enum N

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -19,9 +19,6 @@ pub struct Number {
     n: N,
 }
 
-// "N" is a prefix of "NegInt"... this is a false positive.
-// https://github.com/Manishearth/rust-clippy/issues/1241
-#[cfg_attr(feature = "cargo-clippy", allow(enum_variant_names))]
 #[derive(Copy, Clone, Debug, PartialEq)]
 enum N {
     PosInt(u64),


### PR DESCRIPTION
Clippy fixed the bug in question.