### PR TITLE
Stop instantiating parse_value in MapKey::deserialize_any

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1236,7 +1236,12 @@ where
     where
         V: de::Visitor<'de>,
     {
-        self.de.parse_value(visitor)
+        self.de.eat_char();
+        self.de.str_buf.clear();
+        match try!(self.de.read.parse_str(&mut self.de.str_buf)) {
+            Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
+            Reference::Copied(s) => visitor.visit_str(s),
+        }
     }
 
     deserialize_integer_key!(deserialize_i8 => visit_i8);


### PR DESCRIPTION
The parse_value method is the most expensive method in serde_json in terms of compile time. Before this change, we were instantiating it twice for every derive(Deserialize) struct because every struct has two different Visitor impls -- one for the key type and one for the struct overall -- see https://serde.rs/deserialize-struct.html.

This improves compile time of [json-benchmark](https://github.com/serde-rs/json-benchmark) in release mode by 20%. #313