### PR TITLE
Fewer instantiations of Option::map_or

### DIFF
--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -8,67 +8,87 @@
 
 use super::Value;
 
+fn eq_i64(value: &Value, other: i64) -> bool {
+    value.as_i64().map_or(false, |i| i == other)
+}
+
+fn eq_u64(value: &Value, other: u64) -> bool {
+    value.as_u64().map_or(false, |i| i == other)
+}
+
+fn eq_f64(value: &Value, other: f64) -> bool {
+    value.as_f64().map_or(false, |i| i == other)
+}
+
+fn eq_bool(value: &Value, other: bool) -> bool {
+    value.as_bool().map_or(false, |i| i == other)
+}
+
+fn eq_str(value: &Value, other: &str) -> bool {
+    value.as_str().map_or(false, |i| i == other)
+}
+
 impl PartialEq<str> for Value {
     fn eq(&self, other: &str) -> bool {
-        self.as_str().map_or(false, |s| s == other)
+        eq_str(self, other)
     }
 }
 
 impl<'a> PartialEq<&'a str> for Value {
     fn eq(&self, other: &&str) -> bool {
-        self.as_str().map_or(false, |s| s == *other)
+        eq_str(self, *other)
     }
 }
 
 impl PartialEq<Value> for str {
     fn eq(&self, other: &Value) -> bool {
-        other.as_str().map_or(false, |s| s == self)
+        eq_str(other, self)
     }
 }
 
 impl<'a> PartialEq<Value> for &'a str {
     fn eq(&self, other: &Value) -> bool {
-        other.as_str().map_or(false, |s| s == *self)
+        eq_str(other, *self)
     }
 }
 
 impl PartialEq<String> for Value {
     fn eq(&self, other: &String) -> bool {
-        self.as_str().map_or(false, |s| s == other)
+        eq_str(self, other.as_str())
     }
 }
 
 
 impl PartialEq<Value> for String {
     fn eq(&self, other: &Value) -> bool {
-        other.as_str().map_or(false, |s| s == self)
+        eq_str(other, self.as_str())
     }
 }
 
 macro_rules! partialeq_numeric {
-    ($([$($ty:ty)*], $conversion:ident, $base:ty)*) => {
+    ($($eq:ident [$($ty:ty)*])*) => {
         $($(
             impl PartialEq<$ty> for Value {
                 fn eq(&self, other: &$ty) -> bool {
-                    self.$conversion().map_or(false, |i| i == (*other as $base))
+                    $eq(self, *other as _)
                 }
             }
 
             impl PartialEq<Value> for $ty {
                 fn eq(&self, other: &Value) -> bool {
-                    other.$conversion().map_or(false, |i| i == (*self as $base))
+                    $eq(other, *self as _)
                 }
             }
 
             impl<'a> PartialEq<$ty> for &'a Value {
                 fn eq(&self, other: &$ty) -> bool {
-                    self.$conversion().map_or(false, |i| i == (*other as $base))
+                    $eq(*self, *other as _)
                 }
             }
 
             impl<'a> PartialEq<$ty> for &'a mut Value {
                 fn eq(&self, other: &$ty) -> bool {
-                    self.$conversion().map_or(false, |i| i == (*other as $base))
+                    $eq(*self, *other as _)
                 }
             }
         )*)*
@@ -76,8 +96,8 @@ macro_rules! partialeq_numeric {
 }
 
 partialeq_numeric! {
-    [i8 i16 i32 i64 isize], as_i64, i64
-    [u8 u16 u32 u64 usize], as_u64, u64
-    [f32 f64], as_f64, f64
-    [bool], as_bool, bool
+    eq_i64[i8 i16 i32 i64 isize]
+    eq_u64[u8 u16 u32 u64 usize]
+    eq_f64[f32 f64]
+    eq_bool[bool]
 }


### PR DESCRIPTION
This lowers us from 59 instantiations of Option::map_or to just 6. On my computer this improves serde_json compile time by about 5%. Pretty wild!

Fixes #391. Hopefully the real fix will be https://github.com/rust-lang/rust/issues/46758.