### PR TITLE
Update to num-traits 0.2 with no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
 serde = "1.0"
-num-traits = "0.1.32"
+num-traits = { version = "0.2", default-features = false }
 linked-hash-map = { version = "0.5", optional = true }
 itoa = "0.3"
 dtoa = "0.4"


### PR DESCRIPTION
It now has a `std` feature, and uses `#![no_std]` otherwise.

cc #362