### PR TITLE
Improve error when json strings contain control characters

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,7 @@ impl Error {
             ErrorCode::InvalidNumber |
             ErrorCode::NumberOutOfRange |
             ErrorCode::InvalidUnicodeCodePoint |
+            ErrorCode::ControlCharacterWhileParsingString |
             ErrorCode::KeyMustBeAString |
             ErrorCode::LoneLeadingSurrogateInHexEscape |
             ErrorCode::TrailingComma |
@@ -240,6 +241,9 @@ pub enum ErrorCode {
     /// Invalid unicode code point.
     InvalidUnicodeCodePoint,
 
+    /// Control character found while parsing a string.
+    ControlCharacterWhileParsingString,
+
     /// Object key is not a string.
     KeyMustBeAString,
 
@@ -324,6 +328,9 @@ impl Display for ErrorCode {
             ErrorCode::InvalidNumber => f.write_str("invalid number"),
             ErrorCode::NumberOutOfRange => f.write_str("number out of range"),
             ErrorCode::InvalidUnicodeCodePoint => f.write_str("invalid unicode code point"),
+            ErrorCode::ControlCharacterWhileParsingString => {
+                f.write_str("control character (\\u0000-\\u001F) found while parsing a string")
+            }
             ErrorCode::KeyMustBeAString => f.write_str("key must be a string"),
             ErrorCode::LoneLeadingSurrogateInHexEscape => {
                 f.write_str("lone leading surrogate in hex escape")

--- a/src/read.rs
+++ b/src/read.rs
@@ -181,7 +181,7 @@ where
                 }
                 _ => {
                     if validate {
-                        return error(self, ErrorCode::InvalidUnicodeCodePoint);
+                        return error(self, ErrorCode::ControlCharacterWhileParsingString);
                     }
                     scratch.push(ch);
                 }
@@ -277,7 +277,7 @@ where
                     try!(ignore_escape(self));
                 }
                 _ => {
-                    return error(self, ErrorCode::InvalidUnicodeCodePoint);
+                    return error(self, ErrorCode::ControlCharacterWhileParsingString);
                 }
             }
         }
@@ -358,7 +358,7 @@ impl<'a> SliceRead<'a> {
                 }
                 _ => {
                     if validate {
-                        return error(self, ErrorCode::InvalidUnicodeCodePoint);
+                        return error(self, ErrorCode::ControlCharacterWhileParsingString);
                     }
                     self.index += 1;
                 }
@@ -446,7 +446,7 @@ impl<'a> Read<'a> for SliceRead<'a> {
                     try!(ignore_escape(self));
                 }
                 _ => {
-                    return error(self, ErrorCode::InvalidUnicodeCodePoint);
+                    return error(self, ErrorCode::ControlCharacterWhileParsingString);
                 }
             }
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -858,6 +858,8 @@ fn test_parse_string() {
             ("\"lol", "EOF while parsing a string at line 1 column 4"),
             ("\"lol\"a", "trailing characters at line 1 column 6"),
             ("\"\\uD83C\\uFFFF\"", "lone leading surrogate in hex escape at line 1 column 13"),
+            ("\"\n\"", "control character (\\u0000-\\u001F) found while parsing a string at line 1 column 1"),
+            ("\"\x1F\"", "control character (\\u0000-\\u001F) found while parsing a string at line 1 column 1"),
         ],
     );
 
@@ -866,6 +868,10 @@ fn test_parse_string() {
             (&[b'"', 159, 146, 150, b'"'], "invalid unicode code point at line 1 column 5"),
             (&[b'"', b'\\', b'n', 159, 146, 150, b'"'],
              "invalid unicode code point at line 1 column 7"),
+            (&[b'"', b'\n',b'"'],
+             "control character (\\u0000-\\u001F) found while parsing a string at line 1 column 1"),
+            (&[b'"', b'\x1F', b'"'],
+             "control character (\\u0000-\\u001F) found while parsing a string at line 1 column 1"),
         ],
     );
 


### PR DESCRIPTION
A first pass at resolving #364.  Comments are welcome.

This patch checks specifically for control characters (ASCII 0x00 - 0x1F) in a JSON string and reports a more relevant error message:

```
control character (\u0000-\u001F) found while parsing a string at line 1 column 1"
```

Points of concern:

- There may be a better (i.e. shorter) error name than `ErrorCode::ControlCharacterWhileParsingString`.
- User confusion with error message.  Will a user suspect that escaped control characters caused the error because I mention the ASCII range formatted as escaped control characters?  Perhaps instead, I should say:

  - `control character (ASCII 0x00 - 0x1F) found while parsing a string at line 1 column 1`, or
  - `unescaped control character (\u0000-\u001F) found while parsing a string at line 1 column 1`, or
  - `raw control character (\u0000-\u001F) found while parsing a string at line 1 column 1`, or
  - some combination of the above.