### PR TITLE
Disambiguate `pos` meaning both "position" and "positive"

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -168,15 +168,15 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     /// Error caused by a byte from next_char().
     #[cold]
     fn error(&self, reason: ErrorCode) -> Error {
-        let pos = self.read.position();
-        Error::syntax(reason, pos.line, pos.column)
+        let position = self.read.position();
+        Error::syntax(reason, position.line, position.column)
     }
 
     /// Error caused by a byte from peek().
     #[cold]
     fn peek_error(&self, reason: ErrorCode) -> Error {
-        let pos = self.read.peek_position();
-        Error::syntax(reason, pos.line, pos.column)
+        let position = self.read.peek_position();
+        Error::syntax(reason, position.line, position.column)
     }
 
     /// Returns the first non-whitespace byte without consuming it, or `None` if
@@ -1936,11 +1936,11 @@ where
             Some(b' ') | Some(b'\n') | Some(b'\t') | Some(b'\r') | Some(b'"') | Some(b'[')
             | Some(b']') | Some(b'{') | Some(b'}') | Some(b',') | Some(b':') | None => Ok(()),
             Some(_) => {
-                let pos = self.de.read.peek_position();
+                let position = self.de.read.peek_position();
                 Err(Error::syntax(
                     ErrorCode::TrailingCharacters,
-                    pos.line,
-                    pos.column,
+                    position.line,
+                    position.column,
                 ))
             }
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -517,14 +517,14 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     }
 
     #[cfg(not(feature = "arbitrary_precision"))]
-    fn parse_any_number(&mut self, pos: bool) -> Result<Number> {
-        self.parse_integer(pos)
+    fn parse_any_number(&mut self, positive: bool) -> Result<Number> {
+        self.parse_integer(positive)
     }
 
     #[cfg(feature = "arbitrary_precision")]
-    fn parse_any_number(&mut self, pos: bool) -> Result<Number> {
+    fn parse_any_number(&mut self, positive: bool) -> Result<Number> {
         let mut buf = String::with_capacity(16);
-        if !pos {
+        if !positive {
             buf.push('-');
         }
         self.scan_integer(&mut buf)?;

--- a/src/read.rs
+++ b/src/read.rs
@@ -292,19 +292,19 @@ impl<'a> SliceRead<'a> {
     }
 
     fn position_of_index(&self, i: usize) -> Position {
-        let mut pos = Position { line: 1, column: 0 };
+        let mut position = Position { line: 1, column: 0 };
         for ch in &self.slice[..i] {
             match *ch {
                 b'\n' => {
-                    pos.line += 1;
-                    pos.column = 0;
+                    position.line += 1;
+                    position.column = 0;
                 }
                 _ => {
-                    pos.column += 1;
+                    position.column += 1;
                 }
             }
         }
-        pos
+        position
     }
 
     /// The big optimization here over IoRead is that if the string contains no
@@ -544,8 +544,8 @@ fn next_or_eof<'de, R: ?Sized + Read<'de>>(read: &mut R) -> Result<u8> {
 }
 
 fn error<'de, R: ?Sized + Read<'de>, T>(read: &R, reason: ErrorCode) -> Result<T> {
-    let pos = read.position();
-    Err(Error::syntax(reason, pos.line, pos.column))
+    let position = read.position();
+    Err(Error::syntax(reason, position.line, position.column))
 }
 
 fn as_str<'de, 's, R: Read<'de>>(read: &R, slice: &'s [u8]) -> Result<&'s str> {


### PR DESCRIPTION
Fixes #420.