### PR TITLE
Get rustup-init with curl to avoid tls failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
 install:
   # Install rust, x86_64-pc-windows-msvc host
-  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
   - rustup-init.exe -y --default-host x86_64-pc-windows-msvc --default-toolchain %APPVEYOR_RUST_CHANNEL%
   - set PATH=C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -vV


### PR DESCRIPTION
Fixes #308. This is copied from https://github.com/serde-rs/serde/pull/1135.