### PR TITLE
Allow char to be a MapKey

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1140,8 +1140,8 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_char(self, _value: char) -> Result<()> {
-        Err(key_must_be_a_string())
+    fn serialize_char(self, value: char) -> Result<()> {
+        self.ser.serialize_str(&value.to_string())
     }
 
     fn serialize_bytes(self, _value: &[u8]) -> Result<()> {


### PR DESCRIPTION
I think `char`s should be allowed to be `MapKey` or would that be in some way harmful?

I'm new to Rust and this repository seems really complex to me 😬.
Please let me know if and where I have to add/update tests – I'll be more than happy to do that!