### PR TITLE
Make json macro compatible with deny(unused_results)

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -161,7 +161,7 @@ macro_rules! json_internal {
 
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
-        $object.insert(($($key)+).into(), $value);
+        let _ = $object.insert(($($key)+).into(), $value);
         json_internal!(@object $object () ($($rest)*) ($($rest)*));
     };
 
@@ -172,7 +172,7 @@ macro_rules! json_internal {
 
     // Insert the last entry without trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr)) => {
-        $object.insert(($($key)+).into(), $value);
+        let _ = $object.insert(($($key)+).into(), $value);
     };
 
     // Next value is `null`.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1847,6 +1847,9 @@ fn test_json_macro() {
         (<Result<&str, ()> as Clone>::clone(&Ok("")).unwrap()): "ok",
         (<Result<(), &str> as Clone>::clone(&Err("")).unwrap_err()): "err"
     });
+
+    #[deny(unused_results)]
+    let _ = json!({ "architecture": [true, null] });
 }
 
 #[test]


### PR DESCRIPTION
The `unused_results` lint triggers on any function call returning anything other than `()` or `!` that is not used. The `Map::insert` function returns `Option<Value>` of the previous value of the inserted key.

Fixes #461.