### PR TITLE
Switch from dtoa to ryu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "serde-rs/json" }
 serde = "1.0.60"
 indexmap = { version = "1.0", optional = true }
 itoa = "0.4"
-dtoa = "0.4"
+ryu = "0.2"
 
 [dev-dependencies]
 compiletest_rs = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,7 +350,7 @@
 
 #[macro_use]
 extern crate serde;
-extern crate dtoa;
+extern crate ryu;
 #[cfg(feature = "preserve_order")]
 extern crate indexmap;
 extern crate itoa;

--- a/src/number.rs
+++ b/src/number.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::{self, Debug, Display};
 
 #[cfg(feature = "arbitrary_precision")]
-use dtoa;
+use ryu;
 #[cfg(feature = "arbitrary_precision")]
 use itoa;
 #[cfg(feature = "arbitrary_precision")]
@@ -266,9 +266,7 @@ impl Number {
                 }
                 #[cfg(feature = "arbitrary_precision")]
                 {
-                    let mut buf = Vec::new();
-                    dtoa::write(&mut buf, f).unwrap();
-                    String::from_utf8(buf).unwrap()
+                    ryu::Buffer::new().format(f).to_owned()
                 }
             };
             Some(Number { n: n })

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -16,8 +16,8 @@ use std::str;
 use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible};
 
-use dtoa;
 use itoa;
+use ryu;
 
 #[cfg(feature = "arbitrary_precision")]
 use serde::Serialize;
@@ -1554,7 +1554,9 @@ pub trait Formatter {
     where
         W: io::Write,
     {
-        dtoa::write(writer, value).map(drop)
+        let mut buffer = ryu::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
@@ -1563,7 +1565,9 @@ pub trait Formatter {
     where
         W: io::Write,
     {
-        dtoa::write(writer, value).map(drop)
+        let mut buffer = ryu::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
     }
 
     /// Writes a number that has already been rendered to a string.


### PR DESCRIPTION
This is a 35% improvement in the canada.json stringify-struct benchmark in [serde-rs/json-benchmark](https://github.com/serde-rs/json-benchmark) which involves serializing lots of f32. That benchmark time drops from 6.4 milliseconds with dtoa to 4.1 milliseconds with ryu.

cc @m-ou-se :heart: