### PR TITLE
Monospace format &[u8] in value module docs

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -68,7 +68,7 @@
 //!
 //! A string of JSON data can be parsed into a `serde_json::Value` by the
 //! [`serde_json::from_str`][from_str] function. There is also
-//! [`from_slice`][from_slice] for parsing from a byte slice &[u8] and
+//! [`from_slice`][from_slice] for parsing from a byte slice `&[u8]` and
 //! [`from_reader`][from_reader] for parsing from any `io::Read` like a File or
 //! a TCP stream.
 //!


### PR DESCRIPTION
When building the documentation of `serde_json` with CommonMark (the default in Rust 2018), `rustdoc` will complain about a bare byte slice statement [u8]:

```
warning: `[u8]` cannot be resolved, ignoring it...
  --> src/value/mod.rs:71:64
   |
71 | //! [`from_slice`][from_slice] for parsing from a byte slice &[u8] and
   |                                                                ^^ cannot be resolved, ignoring
   |
   = help: to escape `[` and `]` characters, just add '\' before them like `\[` or `\]`
```

And ultimately resolving it to an erroneous HTML (the square brackets are gone):

```html
 for parsing from a byte slice &<a href="https://doc.rust-lang.org/nightly/std/primitive.u8.html" title="u8">u8</a> and
```

I feel that backticks around the `&[u8]` should be enough to fix this.
