### PR TITLE
Implement RawValue type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ pub use self::ser::{
     to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer,
 };
 #[doc(inline)]
-pub use self::value::{from_value, to_value, Map, Number, Value};
+pub use self::value::{from_value, to_value, Map, Number, RawValue, Value};
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
@@ -388,4 +388,5 @@ pub mod value;
 
 mod iter;
 mod number;
+mod raw;
 mod read;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,93 @@
+use std::borrow::Cow;
+use std::fmt;
+
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Represents any valid JSON value as a series of raw bytes.
+///
+/// This type can be used to defer parsing parts of a payload until later,
+/// or to embed it verbatim into another JSON payload.
+///
+/// When serializing, a value of this type will retain its original formatting
+/// and will not be minified or pretty-printed.
+///
+/// When deserializing, this type can not be used with the `#[serde(flatten)]` attribute,
+/// as it relies on the original input buffer.
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawValue<'a>(Cow<'a, str>);
+
+impl<'a> AsRef<str> for RawValue<'a> {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'a> fmt::Display for RawValue<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Not public API. Should be pub(crate).
+#[doc(hidden)]
+pub const SERDE_STRUCT_NAME: &'static str = "$__serde_private_RawValue";
+
+impl<'a> Serialize for RawValue<'a> {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_newtype_struct(SERDE_STRUCT_NAME, &self.0)
+    }
+}
+
+impl<'a, 'de> Deserialize<'de> for RawValue<'a>
+where
+    'de: 'a,
+{
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RawValueVisitor;
+
+        impl<'de> Visitor<'de> for RawValueVisitor {
+            type Value = RawValue<'de>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a deserializable RawValue")
+            }
+
+            fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+            where
+                E: ::serde::de::Error,
+            {
+                Ok(RawValue(Cow::Owned(s)))
+            }
+
+            fn visit_byte_buf<E>(self, b: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: ::serde::de::Error,
+            {
+                String::from_utf8(b)
+                    .map(|s| RawValue(Cow::Owned(s)))
+                    .map_err(|err| ::serde::de::Error::custom(err))
+            }
+
+            fn visit_borrowed_bytes<E>(self, b: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: ::serde::de::Error,
+            {
+                ::std::str::from_utf8(b)
+                    .map(|s| RawValue(Cow::Borrowed(s)))
+                    .map_err(|err| ::serde::de::Error::custom(err))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct(SERDE_STRUCT_NAME, RawValueVisitor)
+    }
+}

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -14,13 +14,10 @@ use std::num::FpCategory;
 use std::str;
 
 use super::error::{Error, ErrorCode, Result};
-use serde::ser::{self, Impossible};
+use serde::ser::{self, Impossible, Serialize};
 
 use itoa;
 use ryu;
-
-#[cfg(feature = "arbitrary_precision")]
-use serde::Serialize;
 
 /// A structure for serializing Rust values into JSON.
 pub struct Serializer<W, F = CompactFormatter> {
@@ -286,10 +283,14 @@ where
 
     /// Serialize newtypes without an object wrapper.
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<()>
+    fn serialize_newtype_struct<T: ?Sized>(self, name: &'static str, value: &T) -> Result<()>
     where
         T: ser::Serialize,
     {
+        if name == ::raw::SERDE_STRUCT_NAME {
+            return value.serialize(RawValueStrEmitter(self));
+        }
+
         value.serialize(self)
     }
 
@@ -1400,6 +1401,189 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
     }
 }
 
+struct RawValueStrEmitter<'a, W: 'a + io::Write, F: 'a + Formatter>(&'a mut Serializer<W, F>);
+
+impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, W, F> {
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = Impossible<(), Error>;
+    type SerializeTuple = Impossible<(), Error>;
+    type SerializeTupleStruct = Impossible<(), Error>;
+    type SerializeTupleVariant = Impossible<(), Error>;
+    type SerializeMap = Impossible<(), Error>;
+    type SerializeStruct = Impossible<(), Error>;
+    type SerializeStructVariant = Impossible<(), Error>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_i128(self, _v: i128) -> Result<Self::Ok> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_u128(self, _v: u128) -> Result<Self::Ok> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok> {
+        let RawValueStrEmitter(serializer) = self;
+        serializer
+            .formatter
+            .write_raw_fragment(&mut serializer.writer, value)
+            .map_err(Error::io)
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+}
+
 /// Represents a character escape code in a type-safe manner.
 pub enum CharEscape {
     /// An escaped quote `"`
@@ -1742,6 +1926,16 @@ pub trait Formatter {
         W: io::Write,
     {
         Ok(())
+    }
+
+    /// Writes a raw  json fragment that doesn't need any escaping to the
+    /// specified writer.
+    #[inline]
+    fn write_raw_fragment<W: ?Sized>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        writer.write_all(fragment.as_bytes())
     }
 }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -300,12 +300,16 @@ impl<'de> serde::Deserializer<'de> for Value {
     #[inline]
     fn deserialize_newtype_struct<V>(
         self,
-        _name: &'static str,
+        name: &'static str,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
+        if name == ::raw::SERDE_STRUCT_NAME {
+            return visitor.visit_string(self.to_string());
+        }
+
         visitor.visit_newtype_struct(self)
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -118,6 +118,7 @@ use serde::ser::Serialize;
 use error::Error;
 pub use map::Map;
 pub use number::Number;
+pub use raw::RawValue;
 
 pub use self::index::Index;
 

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -6,16 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use serde::ser::Impossible;
+use serde::ser::{self, Impossible};
 use serde::{self, Serialize};
 
 use error::{Error, ErrorCode};
 use map::Map;
 use number::Number;
 use value::{to_value, Value};
-
-#[cfg(feature = "arbitrary_precision")]
-use serde::ser;
 
 impl Serialize for Value {
     #[inline]
@@ -150,12 +147,16 @@ impl serde::Serializer for Serializer {
     #[inline]
     fn serialize_newtype_struct<T: ?Sized>(
         self,
-        _name: &'static str,
+        name: &'static str,
         value: &T,
     ) -> Result<Value, Error>
     where
         T: Serialize,
     {
+        if name == ::raw::SERDE_STRUCT_NAME {
+            return value.serialize(RawValueEmitter);
+        }
+
         value.serialize(self)
     }
 
@@ -810,5 +811,188 @@ impl ser::Serializer for NumberValueEmitter {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(invalid_number())
+    }
+}
+
+struct RawValueEmitter;
+
+impl ser::Serializer for RawValueEmitter {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<Value, Error>;
+    type SerializeTuple = Impossible<Value, Error>;
+    type SerializeTupleStruct = Impossible<Value, Error>;
+    type SerializeTupleVariant = Impossible<Value, Error>;
+    type SerializeMap = Impossible<Value, Error>;
+    type SerializeStruct = Impossible<Value, Error>;
+    type SerializeStructVariant = Impossible<Value, Error>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        ::from_str(value)
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 }


### PR DESCRIPTION
Implements the `RawValue` type described in #355. On [this benchmark](https://gist.github.com/srijs/7fe21b43c2cf5d2ceeb593ae4591c6f5), using the `RawValue` type instead of deserializing/serializing via `Value` results in a 3-4x speed-up.

```
test deserialize_and_serialize_raw_value ... bench:       1,759 ns/iter (+/- 354)
test deserialize_and_serialize_value     ... bench:       6,091 ns/iter (+/- 1,776)
```

I did not adhere fully to the way that the existing arbitrary precision feature is implemented, because I found it easier to use newtypes rather than structs to pass the raw data back and forth. If you want, I'm happy to either change it so that it uses the same approach as the arbitrary precision feature, or to change the arbitrary precision feature to use this (imo) simpler approach.

In the documentation for `RawValue` I mentioned two important caveats which apply for this implementation:

1. When serializing, a `RawValue` will retain its original formatting and will not be minified or pretty-printed.
2. When deserializing, `RawValue` can not be used with the `#[serde(flatten)]` attribute, as it relies on the original input buffer.

What you described in #323 might be a cleaner solution to these problems, but it also sounds more complex and resource hungry (using 4x-8x the amount of memory).

Let me know what you think!
