### PR TITLE
Remove pre-allocation in Deserializer construction

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -50,7 +50,7 @@ where
     pub fn new(read: R) -> Self {
         Deserializer {
             read: read,
-            str_buf: Vec::with_capacity(128),
+            str_buf: Vec::new(),
             remaining_depth: 128,
         }
     }


### PR DESCRIPTION
This allocation dates back four years to:

- https://github.com/serde-rs/serde/commit/475fd5056460d2dcd5286a85ef0f7d748b3a9665#diff-9530295b7f43bb8787aa9fc51b4fba3dR1711

(subsequently touched in:

- https://github.com/serde-rs/serde/commit/20e642420ea346d9cac1c94c1cc6374a6851c3b9#diff-9530295b7f43bb8787aa9fc51b4fba3dR1711
- https://github.com/serde-rs/serde/commit/38dc9aaf72f85f4c1cb42da6d19b6d68839d28b8#diff-0058fb37bfb3827d38defff20282a80dR93

). That was back when *every* string, including map keys, was parsed one character at a time and accumulated into that pre-allocated buffer. So practically every input would require use of the buffer.

Nowadays with the serde_json::from_str optimization done in #105, strings are parsed in efficient fragments at a time and only require a side buffer in the case that a string contains escape sequences. So for the reasonably common case of input containing no escape sequences this change will avoid allocating memory entirely.