### PR TITLE
Implement RawValue type (alternative)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ compiletest_rs = "0.3"
 serde_bytes = "0.10"
 serde_derive = "1.0"
 
+[package.metadata.docs.rs]
+features = ["raw_value"]
+
+[package.metadata.playground]
+features = ["raw_value"]
+
 
 ### FEATURES #################################################################
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ preserve_order = ["indexmap"]
 # allows JSON numbers of arbitrary size/precision to be read into a Number and
 # written back to a JSON string without loss of precision.
 arbitrary_precision = []
+
+# Provide a RawValue type that can hold unprocessed JSON during deserialization.
+raw_value = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -947,6 +947,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    #[cfg(feature = "raw_value")]
     fn deserialize_raw_value<V>(&mut self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -1426,10 +1427,14 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        if name == ::raw::SERDE_STRUCT_NAME {
-            return self.deserialize_raw_value(visitor);
+        #[cfg(feature = "raw_value")]
+        {
+            if name == ::raw::SERDE_STRUCT_NAME {
+                return self.deserialize_raw_value(visitor);
+            }
         }
 
+        let _ = name;
         visitor.visit_newtype_struct(self)
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1429,7 +1429,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     {
         #[cfg(feature = "raw_value")]
         {
-            if name == ::raw::SERDE_STRUCT_NAME {
+            if name == ::raw::TOKEN {
                 return self.deserialize_raw_value(visitor);
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,11 @@ pub use self::ser::{
     to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer,
 };
 #[doc(inline)]
-pub use self::value::{from_value, to_value, Map, Number, RawValue, Value};
+pub use self::value::{from_value, to_value, Map, Number, Value};
+
+#[cfg(feature = "raw_value")]
+#[doc(inline)]
+pub use self::value::RawValue;
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
@@ -388,5 +392,7 @@ pub mod value;
 
 mod iter;
 mod number;
-mod raw;
 mod read;
+
+#[cfg(feature = "raw_value")]
+mod raw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -364,7 +364,7 @@ pub use self::ser::{
     to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer,
 };
 #[doc(inline)]
-pub use self::value::{from_value, to_value, Map, Number, Value};
+pub use self::value::{from_value, to_value, Map, Number, RawValue, Value};
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
@@ -388,4 +388,5 @@ pub mod value;
 
 mod iter;
 mod number;
+mod raw;
 mod read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -366,10 +366,6 @@ pub use self::ser::{
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
 
-#[cfg(feature = "raw_value")]
-#[doc(inline)]
-pub use self::value::RawValue;
-
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
 macro_rules! try {

--- a/src/number.rs
+++ b/src/number.rs
@@ -26,12 +26,7 @@ use error::ErrorCode;
 #[cfg(feature = "arbitrary_precision")]
 /// Not public API. Should be pub(crate).
 #[doc(hidden)]
-pub const SERDE_STRUCT_FIELD_NAME: &'static str = "$__serde_private_number";
-
-#[cfg(feature = "arbitrary_precision")]
-/// Not public API. Should be pub(crate).
-#[doc(hidden)]
-pub const SERDE_STRUCT_NAME: &'static str = "$__serde_private_Number";
+pub const TOKEN: &'static str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
 #[derive(Clone, PartialEq)]
@@ -346,8 +341,8 @@ impl Serialize for Number {
     {
         use serde::ser::SerializeStruct;
 
-        let mut s = serializer.serialize_struct(SERDE_STRUCT_NAME, 1)?;
-        s.serialize_field(SERDE_STRUCT_FIELD_NAME, &self.n)?;
+        let mut s = serializer.serialize_struct(TOKEN, 1)?;
+        s.serialize_field(TOKEN, &self.n)?;
         s.end()
     }
 }
@@ -426,7 +421,7 @@ impl<'de> de::Deserialize<'de> for NumberKey {
             where
                 E: de::Error,
             {
-                if s == SERDE_STRUCT_FIELD_NAME {
+                if s == TOKEN {
                     Ok(())
                 } else {
                     Err(de::Error::custom("expected field with custom name"))
@@ -638,7 +633,7 @@ impl<'de> Deserializer<'de> for NumberFieldDeserializer {
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_borrowed_str(SERDE_STRUCT_FIELD_NAME)
+        visitor.visit_borrowed_str(TOKEN)
     }
 
     forward_to_deserialize_any! {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -62,29 +62,18 @@ where
                 write!(formatter, "a deserializable RawValue")
             }
 
+            fn visit_borrowed_str<E>(self, s: &'de str) -> Result<Self::Value, E>
+            where
+                E: ::serde::de::Error,
+            {
+                Ok(RawValue(Cow::Borrowed(s)))
+            }
+
             fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
             where
                 E: ::serde::de::Error,
             {
                 Ok(RawValue(Cow::Owned(s)))
-            }
-
-            fn visit_byte_buf<E>(self, b: Vec<u8>) -> Result<Self::Value, E>
-            where
-                E: ::serde::de::Error,
-            {
-                String::from_utf8(b)
-                    .map(|s| RawValue(Cow::Owned(s)))
-                    .map_err(|err| ::serde::de::Error::custom(err))
-            }
-
-            fn visit_borrowed_bytes<E>(self, b: &'de [u8]) -> Result<Self::Value, E>
-            where
-                E: ::serde::de::Error,
-            {
-                ::std::str::from_utf8(b)
-                    .map(|s| RawValue(Cow::Borrowed(s)))
-                    .map_err(|err| ::serde::de::Error::custom(err))
             }
         }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -44,8 +44,7 @@ impl<'a> fmt::Display for RawValue<'a> {
     }
 }
 
-pub const SERDE_STRUCT_NAME: &'static str = "$serde_json::RawValue";
-pub const SERDE_STRUCT_FIELD_NAME: &'static str = "$serde_json::RawValue::id";
+pub const TOKEN: &'static str = "$serde_json::private::RawValue";
 
 impl<'a> Serialize for RawValue<'a> {
     #[inline]
@@ -53,8 +52,8 @@ impl<'a> Serialize for RawValue<'a> {
     where
         S: Serializer,
     {
-        let mut s = serializer.serialize_struct(SERDE_STRUCT_NAME, 1)?;
-        s.serialize_field(SERDE_STRUCT_FIELD_NAME, &self.cow)?;
+        let mut s = serializer.serialize_struct(TOKEN, 1)?;
+        s.serialize_field(TOKEN, &self.cow)?;
         s.end()
     }
 }
@@ -86,7 +85,7 @@ impl<'a, 'de: 'a> Deserialize<'de> for RawValue<'a> {
             }
         }
 
-        deserializer.deserialize_newtype_struct(SERDE_STRUCT_NAME, RawValueVisitor)
+        deserializer.deserialize_newtype_struct(TOKEN, RawValueVisitor)
     }
 }
 
@@ -110,7 +109,7 @@ impl<'de> Deserialize<'de> for RawKey {
             where
                 E: de::Error,
             {
-                if s == SERDE_STRUCT_FIELD_NAME {
+                if s == TOKEN {
                     Ok(())
                 } else {
                     Err(de::Error::custom("unexpected raw value"))
@@ -167,7 +166,7 @@ impl<'de> Deserializer<'de> for RawKeyDeserializer {
     where
         V: de::Visitor<'de>,
     {
-        visitor.visit_borrowed_str(SERDE_STRUCT_FIELD_NAME)
+        visitor.visit_borrowed_str(TOKEN)
     }
 
     forward_to_deserialize_any! {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -64,6 +64,53 @@ use error::Error;
 /// }
 /// ```
 ///
+/// # Ownership
+///
+/// The typical usage of `RawValue` will be in the borrowed form:
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// # extern crate serde_json;
+/// #
+/// # use serde_json::value::RawValue;
+/// #
+/// #[derive(Deserialize)]
+/// struct SomeStruct<'a> {
+///     #[serde(borrow)]
+///     raw_value: &'a RawValue,
+/// }
+/// #
+/// # fn main() {}
+/// ```
+///
+/// The borrowed form is suitable when deserializing through
+/// [`serde_json::from_str`] and [`serde_json::from_slice`] which support
+/// borrowing from the input data without memory allocation.
+///
+/// When deserializing through [`serde_json::from_reader`] you will need to use
+/// the boxed form of `RawValue` instead. This is almost as efficient but
+/// involves buffering the raw value from the I/O stream into memory.
+///
+/// [`serde_json::from_str`]: ../fn.from_str.html
+/// [`serde_json::from_slice`]: ../fn.from_slice.html
+/// [`serde_json::from_reader`]: ../fn.from_reader.html
+///
+/// ```
+/// # #[macro_use]
+/// # extern crate serde_derive;
+/// # extern crate serde_json;
+/// #
+/// # use serde_json::value::RawValue;
+/// #
+/// #[derive(Deserialize)]
+/// struct SomeStruct {
+///     raw_value: Box<RawValue>,
+/// }
+/// #
+/// # fn main() {}
+/// ```
+///
 /// # Note
 ///
 /// `RawValue` is only available if serde\_json is built with the `"raw_value"`

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,93 @@
+use std::borrow::Cow;
+use std::fmt;
+
+use serde::de::Visitor;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Represents any valid JSON value as a series of raw bytes.
+///
+/// This type can be used to defer parsing parts of a payload until later,
+/// or to embed it verbatim into another JSON payload.
+///
+/// When serializing, a value of this type will retain its original formatting
+/// and will not be minified or pretty-printed.
+///
+/// When deserializing, this type can not be used with the `#[serde(flatten)]` attribute,
+/// as it relies on the original input buffer.
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawValue<'a>(Cow<'a, str>);
+
+impl<'a> AsRef<str> for RawValue<'a> {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<'a> fmt::Display for RawValue<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Not public API. Should be pub(crate).
+#[doc(hidden)]
+pub const SERDE_STRUCT_NAME: &'static str = "$__serde_private_RawValue";
+
+impl<'a> Serialize for RawValue<'a> {
+    #[inline]
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_newtype_struct(SERDE_STRUCT_NAME, &self.0)
+    }
+}
+
+impl<'a, 'de> Deserialize<'de> for RawValue<'a>
+where
+    'de: 'a,
+{
+    #[inline]
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct RawValueVisitor;
+
+        impl<'de> Visitor<'de> for RawValueVisitor {
+            type Value = RawValue<'de>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                write!(formatter, "a deserializable RawValue")
+            }
+
+            fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
+            where
+                E: ::serde::de::Error,
+            {
+                Ok(RawValue(Cow::Owned(s)))
+            }
+
+            fn visit_byte_buf<E>(self, b: Vec<u8>) -> Result<Self::Value, E>
+            where
+                E: ::serde::de::Error,
+            {
+                String::from_utf8(b)
+                    .map(|s| RawValue(Cow::Owned(s)))
+                    .map_err(|err| ::serde::de::Error::custom(err))
+            }
+
+            fn visit_borrowed_bytes<E>(self, b: &'de [u8]) -> Result<Self::Value, E>
+            where
+                E: ::serde::de::Error,
+            {
+                ::std::str::from_utf8(b)
+                    .map(|s| RawValue(Cow::Borrowed(s)))
+                    .map_err(|err| ::serde::de::Error::custom(err))
+            }
+        }
+
+        deserializer.deserialize_newtype_struct(SERDE_STRUCT_NAME, RawValueVisitor)
+    }
+}

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -19,26 +19,28 @@ use error::Error;
 /// as it relies on the original input buffer.
 
 #[derive(Clone)]
-pub struct RawValue<'a>(Cow<'a, str>);
+pub struct RawValue<'a> {
+    cow: Cow<'a, str>,
+}
 
 impl<'a> Debug for RawValue<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         formatter
             .debug_tuple("RawValue")
-            .field(&format_args!("{}", self.0))
+            .field(&format_args!("{}", self.cow))
             .finish()
     }
 }
 
 impl<'a> AsRef<str> for RawValue<'a> {
     fn as_ref(&self) -> &str {
-        &self.0
+        &self.cow
     }
 }
 
 impl<'a> fmt::Display for RawValue<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.0)
+        f.write_str(&self.cow)
     }
 }
 
@@ -52,7 +54,7 @@ impl<'a> Serialize for RawValue<'a> {
         S: Serializer,
     {
         let mut s = serializer.serialize_struct(SERDE_STRUCT_NAME, 1)?;
-        s.serialize_field(SERDE_STRUCT_FIELD_NAME, &self.0)?;
+        s.serialize_field(SERDE_STRUCT_FIELD_NAME, &self.cow)?;
         s.end()
     }
 }
@@ -145,14 +147,14 @@ impl<'de> Visitor<'de> for RawValueFromString {
     where
         E: de::Error,
     {
-        Ok(RawValue(Cow::Borrowed(s)))
+        Ok(RawValue { cow: Cow::Borrowed(s) })
     }
 
     fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
     where
         E: de::Error,
     {
-        Ok(RawValue(Cow::Owned(s)))
+        Ok(RawValue { cow: Cow::Owned(s) })
     }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::fmt;
+use std::fmt::{self, Debug};
 
 use serde::ser::{Serialize, Serializer, SerializeStruct};
 use serde::de::{self, Deserialize, Deserializer, DeserializeSeed, IntoDeserializer, MapAccess, Unexpected, Visitor};
@@ -18,8 +18,17 @@ use error::Error;
 /// When deserializing, this type can not be used with the `#[serde(flatten)]` attribute,
 /// as it relies on the original input buffer.
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RawValue<'a>(Cow<'a, str>);
+
+impl<'a> Debug for RawValue<'a> {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter
+            .debug_tuple("RawValue")
+            .field(&format_args!("{}", self.0))
+            .finish()
+    }
+}
 
 impl<'a> AsRef<str> for RawValue<'a> {
     fn as_ref(&self) -> &str {

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -18,7 +18,7 @@ use error::Error;
 /// When deserializing, this type can not be used with the `#[serde(flatten)]` attribute,
 /// as it relies on the original input buffer.
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct RawValue<'a>(Cow<'a, str>);
 
 impl<'a> AsRef<str> for RawValue<'a> {

--- a/src/read.rs
+++ b/src/read.rs
@@ -13,7 +13,8 @@ use serde::de::Visitor;
 
 use iter::LineColIterator;
 
-use super::error::{Error, ErrorCode, Result};
+use error::{Error, ErrorCode, Result};
+use raw::{BorrowedRawDeserializer, OwnedRawDeserializer};
 
 /// Trait used by the deserializer for iterating over input. This is manually
 /// "specialized" for iterating over &[u8]. Once feature(specialization) is
@@ -318,7 +319,7 @@ where
     {
         let raw = self.raw_buffer.take().unwrap();
         let raw = String::from_utf8(raw).unwrap();
-        visitor.visit_string(raw)
+        visitor.visit_map(OwnedRawDeserializer { raw_value: Some(raw) })
     }
 }
 
@@ -495,7 +496,7 @@ impl<'a> Read<'a> for SliceRead<'a> {
     {
         let raw = &self.slice[self.raw_buffering_start_index..self.index];
         let raw = str::from_utf8(raw).unwrap();
-        visitor.visit_borrowed_str(raw)
+        visitor.visit_map(BorrowedRawDeserializer { raw_value: Some(raw) })
     }
 }
 
@@ -569,7 +570,7 @@ impl<'a> Read<'a> for StrRead<'a> {
         V: Visitor<'a>,
     {
         let raw = &self.data[self.delegate.raw_buffering_start_index..self.delegate.index];
-        visitor.visit_borrowed_str(raw)
+        visitor.visit_map(BorrowedRawDeserializer { raw_value: Some(raw) })
     }
 }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -166,11 +166,20 @@ where
 {
     /// Create a JSON input source to read from a std::io input stream.
     pub fn new(reader: R) -> Self {
-        IoRead {
-            iter: LineColIterator::new(reader.bytes()),
-            ch: None,
-            #[cfg(feature = "raw_value")]
-            raw_buffer: None,
+        #[cfg(not(feature = "raw_value"))]
+        {
+            IoRead {
+                iter: LineColIterator::new(reader.bytes()),
+                ch: None,
+            }
+        }
+        #[cfg(feature = "raw_value")]
+        {
+            IoRead {
+                iter: LineColIterator::new(reader.bytes()),
+                ch: None,
+                raw_buffer: None,
+            }
         }
     }
 }
@@ -351,11 +360,20 @@ where
 impl<'a> SliceRead<'a> {
     /// Create a JSON input source to read from a slice of bytes.
     pub fn new(slice: &'a [u8]) -> Self {
-        SliceRead {
-            slice: slice,
-            index: 0,
-            #[cfg(feature = "raw_value")]
-            raw_buffering_start_index: 0,
+        #[cfg(not(feature = "raw_value"))]
+        {
+            SliceRead {
+                slice: slice,
+                index: 0,
+            }
+        }
+        #[cfg(feature = "raw_value")]
+        {
+            SliceRead {
+                slice: slice,
+                index: 0,
+                raw_buffering_start_index: 0,
+            }
         }
     }
 
@@ -531,10 +549,18 @@ impl<'a> Read<'a> for SliceRead<'a> {
 impl<'a> StrRead<'a> {
     /// Create a JSON input source to read from a UTF-8 string.
     pub fn new(s: &'a str) -> Self {
-        StrRead {
-            delegate: SliceRead::new(s.as_bytes()),
-            #[cfg(feature = "raw_value")]
-            data: s,
+        #[cfg(not(feature = "raw_value"))]
+        {
+            StrRead {
+                delegate: SliceRead::new(s.as_bytes()),
+            }
+        }
+        #[cfg(feature = "raw_value")]
+        {
+            StrRead {
+                delegate: SliceRead::new(s.as_bytes()),
+                data: s,
+            }
         }
     }
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -14,13 +14,10 @@ use std::num::FpCategory;
 use std::str;
 
 use super::error::{Error, ErrorCode, Result};
-use serde::ser::{self, Impossible};
+use serde::ser::{self, Impossible, Serialize};
 
 use itoa;
 use ryu;
-
-#[cfg(feature = "arbitrary_precision")]
-use serde::Serialize;
 
 /// A structure for serializing Rust values into JSON.
 pub struct Serializer<W, F = CompactFormatter> {
@@ -286,10 +283,14 @@ where
 
     /// Serialize newtypes without an object wrapper.
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<()>
+    fn serialize_newtype_struct<T: ?Sized>(self, name: &'static str, value: &T) -> Result<()>
     where
         T: ser::Serialize,
     {
+        if name == ::raw::SERDE_STRUCT_NAME {
+            return value.serialize(RawValueStrEmitter(self));
+        }
+
         value.serialize(self)
     }
 
@@ -1400,6 +1401,189 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
     }
 }
 
+struct RawValueStrEmitter<'a, W: 'a + io::Write, F: 'a + Formatter>(&'a mut Serializer<W, F>);
+
+impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, W, F> {
+    type Ok = ();
+    type Error = Error;
+
+    type SerializeSeq = Impossible<(), Error>;
+    type SerializeTuple = Impossible<(), Error>;
+    type SerializeTupleStruct = Impossible<(), Error>;
+    type SerializeTupleVariant = Impossible<(), Error>;
+    type SerializeMap = Impossible<(), Error>;
+    type SerializeStruct = Impossible<(), Error>;
+    type SerializeStructVariant = Impossible<(), Error>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_i128(self, _v: i128) -> Result<Self::Ok> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_u128(self, _v: u128) -> Result<Self::Ok> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok> {
+        let RawValueStrEmitter(serializer) = self;
+        serializer
+            .formatter
+            .write_raw_fragment(&mut serializer.writer, value)
+            .map_err(Error::io)
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct(self, _name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+}
+
 /// Represents a character escape code in a type-safe manner.
 pub enum CharEscape {
     /// An escaped quote `"`
@@ -1742,6 +1926,16 @@ pub trait Formatter {
         W: io::Write,
     {
         Ok(())
+    }
+
+    /// Writes a raw  json fragment that doesn't need any escaping to the
+    /// specified writer.
+    #[inline]
+    fn write_raw_fragment<W: ?Sized>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        writer.write_all(fragment.as_bytes())
     }
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -285,7 +285,7 @@ where
     #[inline]
     fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         value.serialize(self)
     }
@@ -299,7 +299,7 @@ where
         value: &T,
     ) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         try!(
             self.formatter
@@ -344,7 +344,7 @@ where
     #[inline]
     fn serialize_some<T: ?Sized>(self, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         value.serialize(self)
     }
@@ -587,7 +587,7 @@ where
     #[inline]
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         match *self {
             Compound::Map {
@@ -644,7 +644,7 @@ where
     #[inline]
     fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -666,7 +666,7 @@ where
     #[inline]
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -688,7 +688,7 @@ where
     #[inline]
     fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -728,7 +728,7 @@ where
     #[inline]
     fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         match *self {
             Compound::Map {
@@ -761,7 +761,7 @@ where
     #[inline]
     fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         match *self {
             Compound::Map { ref mut ser, .. } => {
@@ -814,7 +814,7 @@ where
     #[inline]
     fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         match *self {
             Compound::Map { .. } => {
@@ -865,7 +865,7 @@ where
     #[inline]
     fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         match *self {
             Compound::Map { .. } => ser::SerializeStruct::serialize_field(self, key, value),
@@ -944,7 +944,7 @@ where
     #[inline]
     fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         value.serialize(self)
     }
@@ -1187,7 +1187,7 @@ where
         _value: &T,
     ) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -1198,7 +1198,7 @@ where
 
     fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<()>
     where
-        T: ser::Serialize,
+        T: Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -2207,7 +2207,7 @@ static ESCAPE: [u8; 256] = [
 pub fn to_writer<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
 where
     W: io::Write,
-    T: ser::Serialize,
+    T: Serialize,
 {
     let mut ser = Serializer::new(writer);
     try!(value.serialize(&mut ser));
@@ -2225,7 +2225,7 @@ where
 pub fn to_writer_pretty<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
 where
     W: io::Write,
-    T: ser::Serialize,
+    T: Serialize,
 {
     let mut ser = Serializer::pretty(writer);
     try!(value.serialize(&mut ser));
@@ -2241,7 +2241,7 @@ where
 #[inline]
 pub fn to_vec<T: ?Sized>(value: &T) -> Result<Vec<u8>>
 where
-    T: ser::Serialize,
+    T: Serialize,
 {
     let mut writer = Vec::with_capacity(128);
     try!(to_writer(&mut writer, value));
@@ -2257,7 +2257,7 @@ where
 #[inline]
 pub fn to_vec_pretty<T: ?Sized>(value: &T) -> Result<Vec<u8>>
 where
-    T: ser::Serialize,
+    T: Serialize,
 {
     let mut writer = Vec::with_capacity(128);
     try!(to_writer_pretty(&mut writer, value));
@@ -2273,7 +2273,7 @@ where
 #[inline]
 pub fn to_string<T: ?Sized>(value: &T) -> Result<String>
 where
-    T: ser::Serialize,
+    T: Serialize,
 {
     let vec = try!(to_vec(value));
     let string = unsafe {
@@ -2292,7 +2292,7 @@ where
 #[inline]
 pub fn to_string_pretty<T: ?Sized>(value: &T) -> Result<String>
 where
-    T: ser::Serialize,
+    T: Serialize,
 {
     let vec = try!(to_vec_pretty(value));
     let string = unsafe {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -460,6 +460,7 @@ where
         match name {
             #[cfg(feature = "arbitrary_precision")]
             ::number::SERDE_STRUCT_NAME => Ok(Compound::Number { ser: self }),
+            #[cfg(feature = "raw_value")]
             ::raw::SERDE_STRUCT_NAME => Ok(Compound::RawValue { ser: self }),
             _ => self.serialize_map(Some(len)),
         }
@@ -571,6 +572,7 @@ pub enum Compound<'a, W: 'a, F: 'a> {
     },
     #[cfg(feature = "arbitrary_precision")]
     Number { ser: &'a mut Serializer<W, F> },
+    #[cfg(feature = "raw_value")]
     RawValue { ser: &'a mut Serializer<W, F> },
 }
 
@@ -608,6 +610,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -624,6 +627,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -707,6 +711,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -748,6 +753,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -774,6 +780,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -790,6 +797,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -822,6 +830,7 @@ where
                     Err(invalid_number())
                 }
             }
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { ref mut ser, .. } => {
                 if key == ::raw::SERDE_STRUCT_FIELD_NAME {
                     try!(value.serialize(RawValueStrEmitter(&mut *ser)));
@@ -839,6 +848,7 @@ where
             Compound::Map { .. } => ser::SerializeMap::end(self),
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => Ok(()),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => Ok(()),
         }
     }
@@ -861,6 +871,7 @@ where
             Compound::Map { .. } => ser::SerializeStruct::serialize_field(self, key, value),
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -883,6 +894,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             Compound::RawValue { .. } => unreachable!(),
         }
     }
@@ -897,6 +909,7 @@ fn invalid_number() -> Error {
     Error::syntax(ErrorCode::InvalidNumber, 0, 0)
 }
 
+#[cfg(feature = "raw_value")]
 fn invalid_raw_value() -> Error {
     Error::syntax(ErrorCode::ExpectedSomeValue, 0, 0)
 }
@@ -1420,8 +1433,10 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
     }
 }
 
+#[cfg(feature = "raw_value")]
 struct RawValueStrEmitter<'a, W: 'a + io::Write, F: 'a + Formatter>(&'a mut Serializer<W, F>);
 
+#[cfg(feature = "raw_value")]
 impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, W, F> {
     type Ok = ();
     type Error = Error;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -459,9 +459,9 @@ where
     fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
         match name {
             #[cfg(feature = "arbitrary_precision")]
-            ::number::SERDE_STRUCT_NAME => Ok(Compound::Number { ser: self }),
+            ::number::TOKEN => Ok(Compound::Number { ser: self }),
             #[cfg(feature = "raw_value")]
-            ::raw::SERDE_STRUCT_NAME => Ok(Compound::RawValue { ser: self }),
+            ::raw::TOKEN => Ok(Compound::RawValue { ser: self }),
             _ => self.serialize_map(Some(len)),
         }
     }
@@ -823,7 +823,7 @@ where
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { ref mut ser, .. } => {
-                if key == ::number::SERDE_STRUCT_FIELD_NAME {
+                if key == ::number::TOKEN {
                     try!(value.serialize(NumberStrEmitter(&mut *ser)));
                     Ok(())
                 } else {
@@ -832,7 +832,7 @@ where
             }
             #[cfg(feature = "raw_value")]
             Compound::RawValue { ref mut ser, .. } => {
-                if key == ::raw::SERDE_STRUCT_FIELD_NAME {
+                if key == ::raw::TOKEN {
                     try!(value.serialize(RawValueStrEmitter(&mut *ser)));
                     Ok(())
                 } else {

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -313,7 +313,7 @@ impl<'de> serde::Deserializer<'de> for Value {
     {
         #[cfg(feature = "raw_value")]
         {
-            if name == ::raw::SERDE_STRUCT_NAME {
+            if name == ::raw::TOKEN {
                 return visitor.visit_map(::raw::OwnedRawDeserializer {
                     raw_value: Some(self.to_string()),
                 });
@@ -852,7 +852,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     {
         #[cfg(feature = "raw_value")]
         {
-            if name == ::raw::SERDE_STRUCT_NAME {
+            if name == ::raw::TOKEN {
                 return visitor.visit_map(::raw::OwnedRawDeserializer {
                     raw_value: Some(self.to_string()),
                 });
@@ -1345,9 +1345,9 @@ impl<'de> Visitor<'de> for KeyClassifier {
     {
         match s {
             #[cfg(feature = "arbitrary_precision")]
-            ::number::SERDE_STRUCT_FIELD_NAME => Ok(KeyClass::Number),
+            ::number::TOKEN => Ok(KeyClass::Number),
             #[cfg(feature = "raw_value")]
-            ::raw::SERDE_STRUCT_FIELD_NAME => Ok(KeyClass::RawValue),
+            ::raw::TOKEN => Ok(KeyClass::RawValue),
             _ => Ok(KeyClass::Map(s.to_owned())),
         }
     }
@@ -1358,9 +1358,9 @@ impl<'de> Visitor<'de> for KeyClassifier {
     {
         match s.as_str() {
             #[cfg(feature = "arbitrary_precision")]
-            ::number::SERDE_STRUCT_FIELD_NAME => Ok(KeyClass::Number),
+            ::number::TOKEN => Ok(KeyClass::Number),
             #[cfg(feature = "raw_value")]
-            ::raw::SERDE_STRUCT_FIELD_NAME => Ok(KeyClass::RawValue),
+            ::raw::TOKEN => Ok(KeyClass::RawValue),
             _ => Ok(KeyClass::Map(s)),
         }
     }

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -120,8 +120,8 @@ impl<'de> Deserialize<'de> for Value {
                     }
                     #[cfg(feature = "raw_value")]
                     Some(KeyClass::RawValue) => {
-                        let value = visitor.next_value_seed(::raw::RawValueFromString)?;
-                        ::from_str(value.as_ref()).map_err(de::Error::custom)
+                        let value = visitor.next_value_seed(::raw::BoxedFromString)?;
+                        ::from_str(value.get()).map_err(de::Error::custom)
                     }
                     Some(KeyClass::Map(first_key)) => {
                         let mut values = Map::new();

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -300,12 +300,16 @@ impl<'de> serde::Deserializer<'de> for Value {
     #[inline]
     fn deserialize_newtype_struct<V>(
         self,
-        _name: &'static str,
+        name: &'static str,
         visitor: V,
     ) -> Result<V::Value, Self::Error>
     where
         V: Visitor<'de>,
     {
+        if name == ::raw::SERDE_STRUCT_NAME {
+            return visitor.visit_string(self.to_string());
+        }
+
         visitor.visit_newtype_struct(self)
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -118,6 +118,8 @@ use serde::ser::Serialize;
 use error::Error;
 pub use map::Map;
 pub use number::Number;
+
+#[cfg(feature = "raw_value")]
 pub use raw::RawValue;
 
 pub use self::index::Index;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -118,6 +118,7 @@ use serde::ser::Serialize;
 use error::Error;
 pub use map::Map;
 pub use number::Number;
+pub use raw::RawValue;
 
 pub use self::index::Index;
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -120,7 +120,7 @@ pub use map::Map;
 pub use number::Number;
 
 #[cfg(feature = "raw_value")]
-pub use raw::RawValue;
+pub use raw::{RawSlice, RawValue};
 
 pub use self::index::Index;
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -120,7 +120,7 @@ pub use map::Map;
 pub use number::Number;
 
 #[cfg(feature = "raw_value")]
-pub use raw::{RawSlice, RawValue};
+pub use raw::RawValue;
 
 pub use self::index::Index;
 

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use serde::ser::{self, Impossible};
+use serde::ser::Impossible;
 use serde::{self, Serialize};
 
 use error::{Error, ErrorCode};
@@ -663,7 +663,7 @@ fn invalid_number() -> Error {
 }
 
 #[cfg(feature = "arbitrary_precision")]
-impl ser::Serializer for NumberValueEmitter {
+impl serde::ser::Serializer for NumberValueEmitter {
     type Ok = Value;
     type Error = Error;
 
@@ -842,7 +842,7 @@ fn invalid_raw_value() -> Error {
 }
 
 #[cfg(feature = "raw_value")]
-impl ser::Serializer for RawValueEmitter {
+impl serde::ser::Serializer for RawValueEmitter {
     type Ok = Value;
     type Error = Error;
 

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -229,9 +229,9 @@ impl serde::Serializer for Serializer {
     ) -> Result<Self::SerializeStruct, Error> {
         match name {
             #[cfg(feature = "arbitrary_precision")]
-            ::number::SERDE_STRUCT_NAME => Ok(SerializeMap::Number { out_value: None }),
+            ::number::TOKEN => Ok(SerializeMap::Number { out_value: None }),
             #[cfg(feature = "raw_value")]
-            ::raw::SERDE_STRUCT_NAME => Ok(SerializeMap::RawValue { out_value: None }),
+            ::raw::TOKEN => Ok(SerializeMap::RawValue { out_value: None }),
             _ => self.serialize_map(Some(len)),
         }
     }
@@ -599,7 +599,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
             }
             #[cfg(feature = "arbitrary_precision")]
             SerializeMap::Number { ref mut out_value } => {
-                if key == ::number::SERDE_STRUCT_FIELD_NAME {
+                if key == ::number::TOKEN {
                     *out_value = Some(value.serialize(NumberValueEmitter)?);
                     Ok(())
                 } else {
@@ -608,7 +608,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
             }
             #[cfg(feature = "raw_value")]
             SerializeMap::RawValue { ref mut out_value } => {
-                if key == ::raw::SERDE_STRUCT_FIELD_NAME {
+                if key == ::raw::TOKEN {
                     *out_value = Some(value.serialize(RawValueEmitter)?);
                     Ok(())
                 } else {

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -230,6 +230,7 @@ impl serde::Serializer for Serializer {
         match name {
             #[cfg(feature = "arbitrary_precision")]
             ::number::SERDE_STRUCT_NAME => Ok(SerializeMap::Number { out_value: None }),
+            #[cfg(feature = "raw_value")]
             ::raw::SERDE_STRUCT_NAME => Ok(SerializeMap::RawValue { out_value: None }),
             _ => self.serialize_map(Some(len)),
         }
@@ -265,6 +266,7 @@ pub enum SerializeMap {
     },
     #[cfg(feature = "arbitrary_precision")]
     Number { out_value: Option<Value> },
+    #[cfg(feature = "raw_value")]
     RawValue { out_value: Option<Value> },
 }
 
@@ -360,6 +362,7 @@ impl serde::ser::SerializeMap for SerializeMap {
             }
             #[cfg(feature = "arbitrary_precision")]
             SerializeMap::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             SerializeMap::RawValue { .. } => unreachable!(),
         }
     }
@@ -382,6 +385,7 @@ impl serde::ser::SerializeMap for SerializeMap {
             }
             #[cfg(feature = "arbitrary_precision")]
             SerializeMap::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             SerializeMap::RawValue { .. } => unreachable!(),
         }
     }
@@ -391,6 +395,7 @@ impl serde::ser::SerializeMap for SerializeMap {
             SerializeMap::Map { map, .. } => Ok(Value::Object(map)),
             #[cfg(feature = "arbitrary_precision")]
             SerializeMap::Number { .. } => unreachable!(),
+            #[cfg(feature = "raw_value")]
             SerializeMap::RawValue { .. } => unreachable!(),
         }
     }
@@ -601,6 +606,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
                     Err(invalid_number())
                 }
             }
+            #[cfg(feature = "raw_value")]
             SerializeMap::RawValue { ref mut out_value } => {
                 if key == ::raw::SERDE_STRUCT_FIELD_NAME {
                     *out_value = Some(value.serialize(RawValueEmitter)?);
@@ -619,6 +625,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
             SerializeMap::Number { out_value, .. } => {
                 Ok(out_value.expect("number value was not emitted"))
             }
+            #[cfg(feature = "raw_value")]
             SerializeMap::RawValue { out_value, .. } => {
                 Ok(out_value.expect("raw value was not emitted"))
             }
@@ -826,12 +833,15 @@ impl ser::Serializer for NumberValueEmitter {
     }
 }
 
+#[cfg(feature = "raw_value")]
 struct RawValueEmitter;
 
+#[cfg(feature = "raw_value")]
 fn invalid_raw_value() -> Error {
     Error::syntax(ErrorCode::ExpectedSomeValue, 0, 0)
 }
 
+#[cfg(feature = "raw_value")]
 impl ser::Serializer for RawValueEmitter {
     type Ok = Value;
     type Error = Error;

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -6,16 +6,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use serde::ser::Impossible;
+use serde::ser::{self, Impossible};
 use serde::{self, Serialize};
 
 use error::{Error, ErrorCode};
 use map::Map;
 use number::Number;
 use value::{to_value, Value};
-
-#[cfg(feature = "arbitrary_precision")]
-use serde::ser;
 
 impl Serialize for Value {
     #[inline]
@@ -150,12 +147,16 @@ impl serde::Serializer for Serializer {
     #[inline]
     fn serialize_newtype_struct<T: ?Sized>(
         self,
-        _name: &'static str,
+        name: &'static str,
         value: &T,
     ) -> Result<Value, Error>
     where
         T: Serialize,
     {
+        if name == ::raw::SERDE_STRUCT_NAME {
+            return value.serialize(RawValueEmitter);
+        }
+
         value.serialize(self)
     }
 
@@ -810,5 +811,188 @@ impl ser::Serializer for NumberValueEmitter {
         _len: usize,
     ) -> Result<Self::SerializeStructVariant, Self::Error> {
         Err(invalid_number())
+    }
+}
+
+struct RawValueEmitter;
+
+impl ser::Serializer for RawValueEmitter {
+    type Ok = Value;
+    type Error = Error;
+
+    type SerializeSeq = Impossible<Value, Error>;
+    type SerializeTuple = Impossible<Value, Error>;
+    type SerializeTupleStruct = Impossible<Value, Error>;
+    type SerializeTupleVariant = Impossible<Value, Error>;
+    type SerializeMap = Impossible<Value, Error>;
+    type SerializeStruct = Impossible<Value, Error>;
+    type SerializeStructVariant = Impossible<Value, Error>;
+
+    fn serialize_bool(self, _v: bool) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    serde_if_integer128! {
+        fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
+            Err(ser::Error::custom("expected RawValue"))
+        }
+    }
+
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_str(self, value: &str) -> Result<Self::Ok, Self::Error> {
+        ::from_str(value)
+    }
+
+    fn serialize_bytes(self, _value: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_struct<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_newtype_variant<T: ?Sized>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: Serialize,
+    {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
+    }
+
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -44,7 +44,7 @@ use serde_bytes::{ByteBuf, Bytes};
 
 use serde_json::{
     from_reader, from_slice, from_str, from_value, to_string, to_string_pretty, to_value, to_vec,
-    to_writer, Deserializer, Number, RawValue, Value,
+    to_writer, Deserializer, Number, Value,
 };
 
 macro_rules! treemap {
@@ -2040,8 +2040,11 @@ fn test_integer128() {
     ]);
 }
 
+#[cfg(feature = "raw_value")]
 #[test]
 fn test_raw_value() {
+    use serde_json::RawValue;
+
     #[derive(Serialize, Deserialize)]
     struct Wrapper<'a> {
         a: i8,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2042,20 +2042,20 @@ fn test_integer128() {
 
 #[cfg(feature = "raw_value")]
 #[test]
-fn test_raw_slice() {
-    use serde_json::value::RawSlice;
+fn test_borrowed_raw_value() {
+    use serde_json::value::RawValue;
 
     #[derive(Serialize, Deserialize)]
     struct Wrapper<'a> {
         a: i8,
         #[serde(borrow)]
-        b: &'a RawSlice,
+        b: &'a RawValue,
         c: i8,
     };
 
     let wrapper_from_str: Wrapper =
         serde_json::from_str(r#"{"a": 1, "b": {"foo": 2}, "c": 3}"#).unwrap();
-    assert_eq!(r#"{"foo": 2}"#, wrapper_from_str.b.as_ref());
+    assert_eq!(r#"{"foo": 2}"#, wrapper_from_str.b.get());
 
     let wrapper_to_string = serde_json::to_string(&wrapper_from_str).unwrap();
     assert_eq!(r#"{"a":1,"b":{"foo": 2},"c":3}"#, wrapper_to_string);
@@ -2063,12 +2063,12 @@ fn test_raw_slice() {
     let wrapper_to_value = serde_json::to_value(&wrapper_from_str).unwrap();
     assert_eq!(json!({"a": 1, "b": {"foo": 2}, "c": 3}), wrapper_to_value);
 
-    let array_from_str: Vec<&RawSlice> =
+    let array_from_str: Vec<&RawValue> =
         serde_json::from_str(r#"["a", 42, {"foo": "bar"}, null]"#).unwrap();
-    assert_eq!(r#""a""#, array_from_str[0].as_ref());
-    assert_eq!(r#"42"#, array_from_str[1].as_ref());
-    assert_eq!(r#"{"foo": "bar"}"#, array_from_str[2].as_ref());
-    assert_eq!(r#"null"#, array_from_str[3].as_ref());
+    assert_eq!(r#""a""#, array_from_str[0].get());
+    assert_eq!(r#"42"#, array_from_str[1].get());
+    assert_eq!(r#"{"foo": "bar"}"#, array_from_str[2].get());
+    assert_eq!(r#"null"#, array_from_str[3].get());
 
     let array_to_string = serde_json::to_string(&array_from_str).unwrap();
     assert_eq!(r#"["a",42,{"foo": "bar"},null]"#, array_to_string);
@@ -2076,29 +2076,29 @@ fn test_raw_slice() {
 
 #[cfg(feature = "raw_value")]
 #[test]
-fn test_raw_value() {
+fn test_boxed_raw_value() {
     use serde_json::value::RawValue;
 
     #[derive(Serialize, Deserialize)]
     struct Wrapper {
         a: i8,
-        b: RawValue,
+        b: Box<RawValue>,
         c: i8,
     };
 
     let wrapper_from_str: Wrapper =
         serde_json::from_str(r#"{"a": 1, "b": {"foo": 2}, "c": 3}"#).unwrap();
-    assert_eq!(r#"{"foo": 2}"#, wrapper_from_str.b.as_ref());
+    assert_eq!(r#"{"foo": 2}"#, wrapper_from_str.b.get());
 
     let wrapper_from_reader: Wrapper = serde_json::from_reader(
         br#"{"a": 1, "b": {"foo": 2}, "c": 3}"#.as_ref(),
     ).unwrap();
-    assert_eq!(r#"{"foo": 2}"#, wrapper_from_reader.b.as_ref());
+    assert_eq!(r#"{"foo": 2}"#, wrapper_from_reader.b.get());
 
     let wrapper_from_value: Wrapper =
         serde_json::from_value(json!({"a": 1, "b": {"foo": 2}, "c": 3}))
             .unwrap();
-    assert_eq!(r#"{"foo":2}"#, wrapper_from_value.b.as_ref());
+    assert_eq!(r#"{"foo":2}"#, wrapper_from_value.b.get());
 
     let wrapper_to_string = serde_json::to_string(&wrapper_from_str).unwrap();
     assert_eq!(r#"{"a":1,"b":{"foo": 2},"c":3}"#, wrapper_to_string);
@@ -2106,20 +2106,20 @@ fn test_raw_value() {
     let wrapper_to_value = serde_json::to_value(&wrapper_from_str).unwrap();
     assert_eq!(json!({"a": 1, "b": {"foo": 2}, "c": 3}), wrapper_to_value);
 
-    let array_from_str: Vec<RawValue> =
+    let array_from_str: Vec<Box<RawValue>> =
         serde_json::from_str(r#"["a", 42, {"foo": "bar"}, null]"#).unwrap();
-    assert_eq!(r#""a""#, array_from_str[0].as_ref());
-    assert_eq!(r#"42"#, array_from_str[1].as_ref());
-    assert_eq!(r#"{"foo": "bar"}"#, array_from_str[2].as_ref());
-    assert_eq!(r#"null"#, array_from_str[3].as_ref());
+    assert_eq!(r#""a""#, array_from_str[0].get());
+    assert_eq!(r#"42"#, array_from_str[1].get());
+    assert_eq!(r#"{"foo": "bar"}"#, array_from_str[2].get());
+    assert_eq!(r#"null"#, array_from_str[3].get());
 
-    let array_from_reader: Vec<RawValue> = serde_json::from_reader(
+    let array_from_reader: Vec<Box<RawValue>> = serde_json::from_reader(
         br#"["a", 42, {"foo": "bar"}, null]"#.as_ref(),
     ).unwrap();
-    assert_eq!(r#""a""#, array_from_reader[0].as_ref());
-    assert_eq!(r#"42"#, array_from_reader[1].as_ref());
-    assert_eq!(r#"{"foo": "bar"}"#, array_from_reader[2].as_ref());
-    assert_eq!(r#"null"#, array_from_reader[3].as_ref());
+    assert_eq!(r#""a""#, array_from_reader[0].get());
+    assert_eq!(r#"42"#, array_from_reader[1].get());
+    assert_eq!(r#"{"foo": "bar"}"#, array_from_reader[2].get());
+    assert_eq!(r#"null"#, array_from_reader[3].get());
 
     let array_to_string = serde_json::to_string(&array_from_str).unwrap();
     assert_eq!(r#"["a",42,{"foo": "bar"},null]"#, array_to_string);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -938,9 +938,9 @@ fn test_serialize_char() {
 #[test]
 fn test_malicious_number() {
     #[derive(Serialize)]
-    #[serde(rename = "$__serde_private_Number")]
+    #[serde(rename = "$serde_json::private::Number")]
     struct S {
-        #[serde(rename = "$__serde_private_number")]
+        #[serde(rename = "$serde_json::private::Number")]
         f: &'static str,
     }
 


### PR DESCRIPTION
This PR builds on #480 but eliminates the `Cow` in favor of distinct `&RawValue` and `Box<RawValue>` options.

Documentation of `RawValue`:

---

Reference to a range of bytes encompassing a single valid JSON value in the input data.

A `RawValue` can be used to defer parsing parts of a payload until later, or to avoid parsing it at all in the case that part of the payload just needs to be transferred verbatim into a different output object.

When serializing, a value of this type will retain its original formatting and will not be minified or pretty-printed.

### Example

```rust
#[macro_use]
extern crate serde_derive;
extern crate serde_json;

use serde_json::{Result, value::RawValue};

#[derive(Deserialize)]
struct Input<'a> {
    code: u32,
    #[serde(borrow)]
    payload: &'a RawValue,
}

#[derive(Serialize)]
struct Output<'a> {
    info: (u32, &'a RawValue),
}

// Efficiently rearrange JSON input containing separate "code" and "payload"
// keys into a single "info" key holding an array of code and payload.
//
// This could be done equivalently using serde_json::Value as the type for
// payload, but &RawValue will perform netter because it does not require
// memory allocation. The correct range of bytes is borrowed from the input
// data and pasted verbatim into the output.
fn rearrange(input: &str) -> Result<String> {
    let input: Input = serde_json::from_str(input)?;

    let output = Output {
        info: (input.code, input.payload),
    };

    serde_json::to_string(&output)
}

fn main() -> Result<()> {
    let out = rearrange(r#" {"code": 200, "payload": {}} "#)?;

    assert_eq!(out, r#"{"info":[200,{}]}"#);

    Ok(())
}
```

### Ownership

The typical usage of `RawValue` will be in the borrowed form:

```rust
#[derive(Deserialize)]
struct SomeStruct<'a> {
    #[serde(borrow)]
    raw_value: &'a RawValue,
}
```

The borrowed form is suitable when deserializing through [`serde_json::from_str`] and [`serde_json::from_slice`] which support borrowing from the input data without memory allocation.

When deserializing through [`serde_json::from_reader`] you will need to use the boxed form of `RawValue` instead. This is almost as efficient but involves buffering the raw value from the I/O stream into memory.

[`serde_json::from_str`]: https://docs.serde.rs/serde_json/fn.from_str.html
[`serde_json::from_slice`]: https://docs.serde.rs/serde_json/fn.from_slice.html
[`serde_json::from_reader`]: https://docs.serde.rs/serde_json/fn.from_reader.html

```rust
#[derive(Deserialize)]
struct SomeStruct {
    raw_value: Box<RawValue>,
}
```