### PR TITLE
Add i128 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,9 @@ matrix:
         - cargo test --features arbitrary_precision
         - cargo test --features raw_value
 
-    - rust: 1.15.0
-      script:
-        # preserve_order is not supported on 1.15.0
-        - cargo build
-        - cargo build --features arbitrary_precision
-
     - rust: stable
     - rust: beta
-    - rust: 1.18.0
+    - rust: 1.26.0
 
     - rust: nightly
       env: CLIPPY

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["json", "serde", "serialization"]
 categories = ["encoding"]
 readme = "README.md"
 include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+build = "build.rs"
 
 [badges]
 travis-ci = { repository = "serde-rs/json" }
@@ -18,7 +19,7 @@ appveyor = { repository = "serde-rs/json" }
 [dependencies]
 serde = "1.0.60"
 indexmap = { version = "1.0", optional = true }
-itoa = "0.4.3"
+itoa = {version= "0.4.3", features = ["std", "i128"]}
 ryu = "0.2"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Serde JSON &emsp; [![Build Status]][travis] [![Latest Version]][crates.io] [![Rustc Version 1.15+]][rustc]
+# Serde JSON &emsp; [![Build Status]][travis] [![Latest Version]][crates.io] [![Rustc Version 1.26+]][rustc]
 
 [Build Status]: https://api.travis-ci.org/serde-rs/json.svg?branch=master
 [travis]: https://travis-ci.org/serde-rs/json
 [Latest Version]: https://img.shields.io/crates/v/serde_json.svg
 [crates.io]: https://crates.io/crates/serde\_json
 [Rustc Version 1.26+]: https://img.shields.io/badge/rustc-1.26+-lightgray.svg
-[rustc]: https://blog.rust-lang.org/2017/02/02/Rust-1.15.html
+[rustc]: https://blog.rust-lang.org/2018/05/10/Rust-1.26.html
 
 **Serde is a framework for *ser*ializing and *de*serializing Rust data structures efficiently and generically.**
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [travis]: https://travis-ci.org/serde-rs/json
 [Latest Version]: https://img.shields.io/crates/v/serde_json.svg
 [crates.io]: https://crates.io/crates/serde\_json
-[Rustc Version 1.15+]: https://img.shields.io/badge/rustc-1.15+-lightgray.svg
+[Rustc Version 1.26+]: https://img.shields.io/badge/rustc-1.26+-lightgray.svg
 [rustc]: https://blog.rust-lang.org/2017/02/02/Rust-1.15.html
 
 **Serde is a framework for *ser*ializing and *de*serializing Rust data structures efficiently and generically.**

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,50 @@
+use std::env;
+use std::process::Command;
+use std::str::{self, FromStr};
+
+fn main() {
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    if minor < 26 {
+        panic!("serde_json requires rustc 1.26+");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    // Logic borrowed from https://github.com/serde-rs/serde/blob/master/serde/build.rs
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return None,
+    };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return None,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return None,
+    };
+
+    // Temporary workaround to support the old 1.26-dev compiler on docs.rs.
+    if version.contains("0eb87c9bf") {
+        return Some(25);
+    }
+
+    let mut pieces = version.split('.');
+
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+
+    let next = match pieces.next() {
+        Some(next) => next,
+        None => return None,
+    };
+
+    u32::from_str(next).ok()
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -92,6 +92,8 @@ pub enum ParserNumber {
     F64(f64),
     U64(u64),
     I64(i64),
+    U128(u128),
+    I128(i128),
     #[cfg(feature = "arbitrary_precision")]
     String(String),
 }
@@ -105,6 +107,8 @@ impl ParserNumber {
             ParserNumber::F64(x) => visitor.visit_f64(x),
             ParserNumber::U64(x) => visitor.visit_u64(x),
             ParserNumber::I64(x) => visitor.visit_i64(x),
+            ParserNumber::U128(x) => visitor.visit_u128(x),
+            ParserNumber::I128(x) => visitor.visit_i128(x),
             #[cfg(feature = "arbitrary_precision")]
             ParserNumber::String(x) => visitor.visit_map(NumberDeserializer { number: x.into() }),
         }
@@ -115,6 +119,12 @@ impl ParserNumber {
             ParserNumber::F64(x) => de::Error::invalid_type(Unexpected::Float(x), exp),
             ParserNumber::U64(x) => de::Error::invalid_type(Unexpected::Unsigned(x), exp),
             ParserNumber::I64(x) => de::Error::invalid_type(Unexpected::Signed(x), exp),
+            ParserNumber::U128(x) => {
+                de::Error::invalid_type(Unexpected::Other(format!("integer `{}`", x).as_str()), exp)
+            }
+            ParserNumber::I128(x) => {
+                de::Error::invalid_type(Unexpected::Other(format!("integer `{}`", x).as_str()), exp)
+            }
             #[cfg(feature = "arbitrary_precision")]
             ParserNumber::String(_) => de::Error::invalid_type(Unexpected::Other("number"), exp),
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -284,30 +284,28 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
-    serde_if_integer128! {
-        fn scan_integer128(&mut self, buf: &mut String) -> Result<()> {
-            match try!(self.next_char_or_null()) {
-                b'0' => {
-                    buf.push('0');
-                    // There can be only one leading '0'.
-                    match try!(self.peek_or_null()) {
-                        b'0'...b'9' => {
-                            Err(self.peek_error(ErrorCode::InvalidNumber))
-                        }
-                        _ => Ok(()),
+    fn scan_integer128(&mut self, buf: &mut String) -> Result<()> {
+        match try!(self.next_char_or_null()) {
+            b'0' => {
+                buf.push('0');
+                // There can be only one leading '0'.
+                match try!(self.peek_or_null()) {
+                    b'0'...b'9' => {
+                        Err(self.peek_error(ErrorCode::InvalidNumber))
                     }
+                    _ => Ok(()),
                 }
-                c @ b'1'...b'9' => {
+            }
+            c @ b'1'...b'9' => {
+                buf.push(c as char);
+                while let c @ b'0'...b'9' = try!(self.peek_or_null()) {
+                    self.eat_char();
                     buf.push(c as char);
-                    while let c @ b'0'...b'9' = try!(self.peek_or_null()) {
-                        self.eat_char();
-                        buf.push(c as char);
-                    }
-                    Ok(())
                 }
-                _ => {
-                    Err(self.error(ErrorCode::InvalidNumber))
-                }
+                Ok(())
+            }
+            _ => {
+                Err(self.error(ErrorCode::InvalidNumber))
             }
         }
     }
@@ -1133,67 +1131,65 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     deserialize_prim_number!(deserialize_f32);
     deserialize_prim_number!(deserialize_f64);
 
-    serde_if_integer128! {
-        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: de::Visitor<'de>,
-        {
-            let mut buf = String::new();
+    fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        let mut buf = String::new();
 
-            match try!(self.parse_whitespace()) {
-                Some(b'-') => {
-                    self.eat_char();
-                    buf.push('-');
-                }
-                Some(_) => {}
-                None => {
-                    return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-                }
-            };
+        match try!(self.parse_whitespace()) {
+            Some(b'-') => {
+                self.eat_char();
+                buf.push('-');
+            }
+            Some(_) => {}
+            None => {
+                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
+            }
+        };
 
-            try!(self.scan_integer128(&mut buf));
+        try!(self.scan_integer128(&mut buf));
 
-            let value = match buf.parse() {
-                Ok(int) => visitor.visit_i128(int),
-                Err(_) => {
-                    return Err(self.error(ErrorCode::NumberOutOfRange));
-                }
-            };
+        let value = match buf.parse() {
+            Ok(int) => visitor.visit_i128(int),
+            Err(_) => {
+                return Err(self.error(ErrorCode::NumberOutOfRange));
+            }
+        };
 
-            match value {
-                Ok(value) => Ok(value),
-                Err(err) => Err(self.fix_position(err)),
+        match value {
+            Ok(value) => Ok(value),
+            Err(err) => Err(self.fix_position(err)),
+        }
+    }
+
+    fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: de::Visitor<'de>,
+    {
+        match try!(self.parse_whitespace()) {
+            Some(b'-') => {
+                return Err(self.peek_error(ErrorCode::NumberOutOfRange));
+            }
+            Some(_) => {}
+            None => {
+                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
             }
         }
 
-        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: de::Visitor<'de>,
-        {
-            match try!(self.parse_whitespace()) {
-                Some(b'-') => {
-                    return Err(self.peek_error(ErrorCode::NumberOutOfRange));
-                }
-                Some(_) => {}
-                None => {
-                    return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-                }
+        let mut buf = String::new();
+        try!(self.scan_integer128(&mut buf));
+
+        let value = match buf.parse() {
+            Ok(int) => visitor.visit_u128(int),
+            Err(_) => {
+                return Err(self.error(ErrorCode::NumberOutOfRange));
             }
+        };
 
-            let mut buf = String::new();
-            try!(self.scan_integer128(&mut buf));
-
-            let value = match buf.parse() {
-                Ok(int) => visitor.visit_u128(int),
-                Err(_) => {
-                    return Err(self.error(ErrorCode::NumberOutOfRange));
-                }
-            };
-
-            match value {
-                Ok(value) => Ok(value),
-                Err(err) => Err(self.fix_position(err)),
-            }
+        match value {
+            Ok(value) => Ok(value),
+            Err(err) => Err(self.fix_position(err)),
         }
     }
 
@@ -1906,11 +1902,8 @@ where
     deserialize_integer_key!(deserialize_u16 => visit_u16);
     deserialize_integer_key!(deserialize_u32 => visit_u32);
     deserialize_integer_key!(deserialize_u64 => visit_u64);
-
-    serde_if_integer128! {
-        deserialize_integer_key!(deserialize_i128 => visit_i128);
-        deserialize_integer_key!(deserialize_u128 => visit_u128);
-    }
+    deserialize_integer_key!(deserialize_i128 => visit_i128);
+    deserialize_integer_key!(deserialize_u128 => visit_u128);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>

--- a/src/number.rs
+++ b/src/number.rs
@@ -875,8 +875,8 @@ macro_rules! impl_from_signed {
     };
 }
 
-impl_from_unsigned!(u8, u16, u32, u64, usize);
-impl_from_signed!(i8, i16, i32, i64, isize);
+impl_from_unsigned!(u8, u16, u32, u64, u128, usize);
+impl_from_signed!(i8, i16, i32, i64, i128, isize);
 
 impl Number {
     #[cfg(not(feature = "arbitrary_precision"))]

--- a/src/number.rs
+++ b/src/number.rs
@@ -678,11 +678,8 @@ impl<'de> Deserializer<'de> for Number {
     deserialize_number!(deserialize_u64 => visit_u64);
     deserialize_number!(deserialize_f32 => visit_f32);
     deserialize_number!(deserialize_f64 => visit_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128 => visit_i128);
-        deserialize_number!(deserialize_u128 => visit_u128);
-    }
+    deserialize_number!(deserialize_i128 => visit_i128);
+    deserialize_number!(deserialize_u128 => visit_u128);
 
     forward_to_deserialize_any! {
         bool char str string bytes byte_buf option unit unit_struct
@@ -706,11 +703,8 @@ impl<'de, 'a> Deserializer<'de> for &'a Number {
     deserialize_number!(deserialize_u64 => visit_u64);
     deserialize_number!(deserialize_f32 => visit_f32);
     deserialize_number!(deserialize_f64 => visit_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128 => visit_i128);
-        deserialize_number!(deserialize_u128 => visit_u128);
-    }
+    deserialize_number!(deserialize_i128 => visit_i128);
+    deserialize_number!(deserialize_u128 => visit_u128);
 
     forward_to_deserialize_any! {
         bool char str string bytes byte_buf option unit unit_struct

--- a/src/number.rs
+++ b/src/number.rs
@@ -37,9 +37,9 @@ pub struct Number {
 #[cfg(not(feature = "arbitrary_precision"))]
 #[derive(Copy, Clone, PartialEq)]
 enum N {
-    PosInt(u64),
+    PosInt(u128),
     /// Always less than zero.
-    NegInt(i64),
+    NegInt(i128),
     /// Always finite.
     Float(f64),
 }
@@ -59,7 +59,7 @@ impl Number {
     /// # extern crate serde_json;
     /// #
     /// # fn main() {
-    /// let big = i64::max_value() as u64 + 10;
+    /// let big = i64::max_value() as u128 + 10;
     /// let v = json!({ "a": 64, "b": big, "c": 256.0 });
     ///
     /// assert!(v["a"].is_i64());
@@ -75,12 +75,47 @@ impl Number {
     pub fn is_i64(&self) -> bool {
         #[cfg(not(feature = "arbitrary_precision"))]
         match self.n {
-            N::PosInt(v) => v <= i64::max_value() as u64,
+            N::PosInt(v) => v <= i64::max_value() as u128,
             N::NegInt(_) => true,
             N::Float(_) => false,
         }
         #[cfg(feature = "arbitrary_precision")]
         self.as_i64().is_some()
+    }
+
+    /// Returns true if the `Number` is an integer between `i128::MIN` and
+    /// `i128::MAX`.
+    ///
+    /// For any Number on which `is_i128` returns true, `as_i128` is guaranteed to
+    /// return the integer value.
+    ///
+    /// ```rust
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    /// #
+    /// # fn main() {
+    /// let big = i128::max_value() as u128 + 10;
+    /// let v = json!({ "a": 128, "b": big, "c": 256.0 });
+    ///
+    /// assert!(v["a"].is_i128());
+    ///
+    /// // Greater than i128::MAX.
+    /// assert!(!v["b"].is_i128());
+    ///
+    /// // Numbers with a decimal point are not considered integers.
+    /// assert!(!v["c"].is_i128());
+    /// # }
+    /// ```
+    #[inline]
+    pub fn is_i128(&self) -> bool {
+        #[cfg(not(feature = "arbitrary_precision"))]
+        match self.n {
+            N::PosInt(v) => v <= i128::max_value() as u128,
+            N::NegInt(_) => true,
+            N::Float(_) => false,
+        }
+        #[cfg(feature = "arbitrary_precision")]
+        self.as_i128().is_some()
     }
 
     /// Returns true if the `Number` is an integer between zero and `u64::MAX`.
@@ -113,6 +148,38 @@ impl Number {
         }
         #[cfg(feature = "arbitrary_precision")]
         self.as_u64().is_some()
+    }
+
+    /// Returns true if the `Number` is an integer between zero and `u128::MAX`.
+    ///
+    /// For any Number on which `is_u128` returns true, `as_u128` is guaranteed to
+    /// return the integer value.
+    ///
+    /// ```rust
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    /// #
+    /// # fn main() {
+    /// let v = json!({ "a": 128, "b": -128, "c": 256.0 });
+    ///
+    /// assert!(v["a"].is_u128());
+    ///
+    /// // Negative integer.
+    /// assert!(!v["b"].is_u128());
+    ///
+    /// // Numbers with a decimal point are not considered integers.
+    /// assert!(!v["c"].is_u128());
+    /// # }
+    /// ```
+    #[inline]
+    pub fn is_u128(&self) -> bool {
+        #[cfg(not(feature = "arbitrary_precision"))]
+        match self.n {
+            N::PosInt(_) => true,
+            N::NegInt(_) | N::Float(_) => false,
+        }
+        #[cfg(feature = "arbitrary_precision")]
+        self.as_u128().is_some()
     }
 
     /// Returns true if the `Number` can be represented by f64.
@@ -155,7 +222,7 @@ impl Number {
         }
     }
 
-    /// If the `Number` is an integer, represent it as i64 if possible. Returns
+    /// If the `Number` is an integer, represent it as i128 if possible. Returns
     /// None otherwise.
     ///
     /// ```rust
@@ -175,8 +242,40 @@ impl Number {
     pub fn as_i64(&self) -> Option<i64> {
         #[cfg(not(feature = "arbitrary_precision"))]
         match self.n {
-            N::PosInt(n) => if n <= i64::max_value() as u64 {
+            N::PosInt(n) => if n <= i64::max_value() as u128 {
                 Some(n as i64)
+            } else {
+                None
+            },
+            N::NegInt(n) => Some(n as i64),
+            N::Float(_) => None,
+        }
+        #[cfg(feature = "arbitrary_precision")]
+        self.n.parse().ok()
+    }
+
+    /// If the `Number` is an integer, represent it as i128 if possible. Returns
+    /// None otherwise.
+    ///
+    /// ```rust
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    /// #
+    /// # fn main() {
+    /// let big = i128::max_value() as u128 + 10;
+    /// let v = json!({ "a": 128, "b": big, "c": 256.0 });
+    ///
+    /// assert_eq!(v["a"].as_i128(), Some(128));
+    /// assert_eq!(v["b"].as_i128(), None);
+    /// assert_eq!(v["c"].as_i128(), None);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn as_i128(&self) -> Option<i128> {
+        #[cfg(not(feature = "arbitrary_precision"))]
+            match self.n {
+            N::PosInt(n) => if n <= i128::max_value() as u128 {
+                Some(n as i128)
             } else {
                 None
             },
@@ -184,10 +283,10 @@ impl Number {
             N::Float(_) => None,
         }
         #[cfg(feature = "arbitrary_precision")]
-        self.n.parse().ok()
+            self.n.parse().ok()
     }
 
-    /// If the `Number` is an integer, represent it as u64 if possible. Returns
+    /// If the `Number` is an integer, represent it as u128 if possible. Returns
     /// None otherwise.
     ///
     /// ```rust
@@ -204,6 +303,32 @@ impl Number {
     /// ```
     #[inline]
     pub fn as_u64(&self) -> Option<u64> {
+        #[cfg(not(feature = "arbitrary_precision"))]
+        match self.n {
+            N::PosInt(n) => Some(n as u64),
+            N::NegInt(_) | N::Float(_) => None,
+        }
+        #[cfg(feature = "arbitrary_precision")]
+        self.n.parse().ok()
+    }
+
+    /// If the `Number` is an integer, represent it as u128 if possible. Returns
+    /// None otherwise.
+    ///
+    /// ```rust
+    /// # #[macro_use]
+    /// # extern crate serde_json;
+    /// #
+    /// # fn main() {
+    /// let v = json!({ "a": 128, "b": -128, "c": 256.0 });
+    ///
+    /// assert_eq!(v["a"].as_u128(), Some(128));
+    /// assert_eq!(v["b"].as_u128(), None);
+    /// assert_eq!(v["c"].as_u128(), None);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn as_u128(&self) -> Option<u128> {
         #[cfg(not(feature = "arbitrary_precision"))]
         match self.n {
             N::PosInt(n) => Some(n),
@@ -326,9 +451,10 @@ impl Serialize for Number {
     where
         S: Serializer,
     {
+        #[cfg(not(feature = "arbitrary_precision"))]
         match self.n {
-            N::PosInt(u) => serializer.serialize_u64(u),
-            N::NegInt(i) => serializer.serialize_i64(i),
+            N::PosInt(u) => serializer.serialize_u128(u),
+            N::NegInt(i) => serializer.serialize_i128(i),
             N::Float(f) => serializer.serialize_f64(f),
         }
     }
@@ -481,8 +607,8 @@ macro_rules! deserialize_any {
             V: Visitor<'de>,
         {
             match self.n {
-                N::PosInt(u) => visitor.visit_u64(u),
-                N::NegInt(i) => visitor.visit_i64(i),
+                N::PosInt(u) => visitor.visit_u128(u),
+                N::NegInt(i) => visitor.visit_i128(i),
                 N::Float(f) => visitor.visit_f64(f),
             }
         }
@@ -659,7 +785,7 @@ impl From<ParserNumber> for Number {
             ParserNumber::U64(u) => {
                 #[cfg(not(feature = "arbitrary_precision"))]
                 {
-                    N::PosInt(u)
+                    N::PosInt(u as u128)
                 }
                 #[cfg(feature = "arbitrary_precision")]
                 {
@@ -667,6 +793,26 @@ impl From<ParserNumber> for Number {
                 }
             }
             ParserNumber::I64(i) => {
+                #[cfg(not(feature = "arbitrary_precision"))]
+                {
+                    N::NegInt(i as i128)
+                }
+                #[cfg(feature = "arbitrary_precision")]
+                {
+                    i.to_string()
+                }
+            }
+            ParserNumber::U128(u) => {
+                #[cfg(not(feature = "arbitrary_precision"))]
+                {
+                    N::PosInt(u)
+                }
+                #[cfg(feature = "arbitrary_precision")]
+                {
+                    u.to_string()
+                }
+            }
+            ParserNumber::I128(i) => {
                 #[cfg(not(feature = "arbitrary_precision"))]
                 {
                     N::NegInt(i)
@@ -693,7 +839,7 @@ macro_rules! impl_from_unsigned {
                 fn from(u: $ty) -> Self {
                     let n = {
                         #[cfg(not(feature = "arbitrary_precision"))]
-                        { N::PosInt(u as u64) }
+                        { N::PosInt(u as u128) }
                         #[cfg(feature = "arbitrary_precision")]
                         {
                             itoa::Buffer::new().format(u).to_owned()
@@ -718,9 +864,9 @@ macro_rules! impl_from_signed {
                         #[cfg(not(feature = "arbitrary_precision"))]
                         {
                             if i < 0 {
-                                N::NegInt(i as i64)
+                                N::NegInt(i as i128)
                             } else {
-                                N::PosInt(i as u64)
+                                N::PosInt(i as u128)
                             }
                         }
                         #[cfg(feature = "arbitrary_precision")]
@@ -745,8 +891,8 @@ impl Number {
     #[cold]
     pub fn unexpected(&self) -> Unexpected {
         match self.n {
-            N::PosInt(u) => Unexpected::Unsigned(u),
-            N::NegInt(i) => Unexpected::Signed(i),
+            N::PosInt(_) => Unexpected::Other("number"), // Unsigned(u),
+            N::NegInt(_) => Unexpected::Other("number"), // Signed(i),
             N::Float(f) => Unexpected::Float(f),
         }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -885,8 +885,7 @@ impl Number {
     #[cold]
     pub fn unexpected(&self) -> Unexpected {
         match self.n {
-            N::PosInt(_) => Unexpected::Other("number"), // Unsigned(u),
-            N::NegInt(_) => Unexpected::Other("number"), // Signed(i),
+            N::PosInt(_) | N::NegInt(_) => Unexpected::Other("number"),
             N::Float(f) => Unexpected::Float(f),
         }
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -135,12 +135,11 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<()> {
-            self.formatter
-                .write_number_str(&mut self.writer, &value.to_string())
-                .map_err(Error::io)
-        }
+    #[inline]
+    fn serialize_i128(self, value: i128) -> Result<()> {
+        self.formatter
+            .write_number_str(&mut self.writer, &value.to_string())
+            .map_err(Error::io)
     }
 
     #[inline]
@@ -183,12 +182,11 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<()> {
-            self.formatter
-                .write_number_str(&mut self.writer, &value.to_string())
-                .map_err(Error::io)
-        }
+    #[inline]
+    fn serialize_u128(self, value: u128) -> Result<()> {
+        self.formatter
+            .write_number_str(&mut self.writer, &value.to_string())
+            .map_err(Error::io)
     }
 
     #[inline]
@@ -1049,13 +1047,11 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<()> {
-            self.ser
-                .formatter
-                .write_number_str(&mut self.ser.writer, &value.to_string())
-                .map_err(Error::io)
-        }
+    fn serialize_i128(self, value: i128) -> Result<()> {
+        self.ser
+            .formatter
+            .write_number_str(&mut self.ser.writer, &value.to_string())
+            .map_err(Error::io)
     }
 
     fn serialize_u8(self, value: u8) -> Result<()> {
@@ -1146,13 +1142,11 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<()> {
-            self.ser
-                .formatter
-                .write_number_str(&mut self.ser.writer, &value.to_string())
-                .map_err(Error::io)
-        }
+    fn serialize_u128(self, value: u128) -> Result<()> {
+        self.ser
+            .formatter
+            .write_number_str(&mut self.ser.writer, &value.to_string())
+            .map_err(Error::io)
     }
 
     fn serialize_f32(self, _value: f32) -> Result<()> {
@@ -1284,10 +1278,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, _v: i128) -> Result<Self::Ok> {
-            Err(invalid_number())
-        }
+    fn serialize_i128(self, _v: i128) -> Result<Self::Ok> {
+        Err(invalid_number())
     }
 
     fn serialize_u8(self, _v: u8) -> Result<Self::Ok> {
@@ -1306,10 +1298,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, _v: u128) -> Result<Self::Ok> {
-            Err(invalid_number())
-        }
+    fn serialize_u128(self, _v: u128) -> Result<Self::Ok> {
+        Err(invalid_number())
     }
 
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok> {
@@ -1469,10 +1459,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, _v: i128) -> Result<Self::Ok> {
-            Err(ser::Error::custom("expected RawValue"))
-        }
+    fn serialize_i128(self, _v: i128) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 
     fn serialize_u8(self, _v: u8) -> Result<Self::Ok> {
@@ -1491,10 +1479,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, _v: u128) -> Result<Self::Ok> {
-            Err(ser::Error::custom("expected RawValue"))
-        }
+    fn serialize_u128(self, _v: u128) -> Result<Self::Ok> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 
     fn serialize_f32(self, _v: f32) -> Result<Self::Ok> {
@@ -1720,15 +1706,13 @@ pub trait Formatter {
         itoa::write(writer, value).map(drop)
     }
 
-    serde_if_integer128! {
-        /// Writes an integer value like `-123` to the specified writer.
-        #[inline]
-        fn write_i128<W: ?Sized>(&mut self, writer: &mut W, value: i128) -> io::Result<()>
-        where
-            W: io::Write,
-        {
-            itoa::write(writer, value).map(drop)
-        }
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    fn write_i128<W: ?Sized>(&mut self, writer: &mut W, value: i128) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        itoa::write(writer, value).map(drop)
     }
 
     /// Writes an integer value like `123` to the specified writer.
@@ -1767,15 +1751,13 @@ pub trait Formatter {
         itoa::write(writer, value).map(drop)
     }
 
-    serde_if_integer128! {
-        /// Writes an integer value like `123` to the specified writer.
-        #[inline]
-        fn write_u128<W: ?Sized>(&mut self, writer: &mut W, value: u128) -> io::Result<()>
-        where
-            W: io::Write,
-        {
-            itoa::write(writer, value).map(drop)
-        }
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    fn write_u128<W: ?Sized>(&mut self, writer: &mut W, value: u128) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        itoa::write(writer, value).map(drop)
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1720,6 +1720,17 @@ pub trait Formatter {
         itoa::write(writer, value).map(drop)
     }
 
+    serde_if_integer128! {
+        /// Writes an integer value like `-123` to the specified writer.
+        #[inline]
+        fn write_i128<W: ?Sized>(&mut self, writer: &mut W, value: i128) -> io::Result<()>
+        where
+            W: io::Write,
+        {
+            itoa::write(writer, value).map(drop)
+        }
+    }
+
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
     fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
@@ -1754,6 +1765,17 @@ pub trait Formatter {
         W: io::Write,
     {
         itoa::write(writer, value).map(drop)
+    }
+
+    serde_if_integer128! {
+        /// Writes an integer value like `123` to the specified writer.
+        #[inline]
+        fn write_u128<W: ?Sized>(&mut self, writer: &mut W, value: u128) -> io::Result<()>
+        where
+            W: io::Write,
+        {
+            itoa::write(writer, value).map(drop)
+        }
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -239,11 +239,8 @@ impl<'de> serde::Deserializer<'de> for Value {
     deserialize_prim_number!(deserialize_u64);
     deserialize_prim_number!(deserialize_f32);
     deserialize_prim_number!(deserialize_f64);
-
-    serde_if_integer128! {
-        deserialize_prim_number!(deserialize_i128);
-        deserialize_prim_number!(deserialize_u128);
-    }
+    deserialize_prim_number!(deserialize_i128);
+    deserialize_prim_number!(deserialize_u128);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -780,11 +777,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     deserialize_value_ref_number!(deserialize_u64);
     deserialize_value_ref_number!(deserialize_f32);
     deserialize_value_ref_number!(deserialize_f64);
-
-    serde_if_integer128! {
-        deserialize_prim_number!(deserialize_i128);
-        deserialize_prim_number!(deserialize_u128);
-    }
+    deserialize_prim_number!(deserialize_i128);
+    deserialize_prim_number!(deserialize_u128);
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
     where
@@ -1264,11 +1258,8 @@ impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
     deserialize_integer_key!(deserialize_u16 => visit_u16);
     deserialize_integer_key!(deserialize_u32 => visit_u32);
     deserialize_integer_key!(deserialize_u64 => visit_u64);
-
-    serde_if_integer128! {
-        deserialize_integer_key!(deserialize_i128 => visit_i128);
-        deserialize_integer_key!(deserialize_u128 => visit_u128);
-    }
+    deserialize_integer_key!(deserialize_i128 => visit_i128);
+    deserialize_integer_key!(deserialize_u128 => visit_u128);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>


### PR DESCRIPTION
This fixes #487.

This PR adds support to 128-bits integers.
To avoid the introduction of a lot of boilerplate and code duplication I've modified the `number::N` to hold 128-bits integer.

I've not verified the whole library yet to ensure that all the integers flows are covered.
I opened this to have an initial feedback about the process.