### PR TITLE
Support parsing of JSON with arbitrary depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
         - cargo test --features preserve_order
         - cargo test --features arbitrary_precision
         - cargo test --features raw_value
+        - cargo test --features arbitrary_depth
 
     - rust: 1.15.0
       script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1.0.60"
 indexmap = { version = "1.0", optional = true }
 itoa = "0.4.3"
 ryu = "0.2"
+stacker = { version = "0.1", optional = true }
 
 [dev-dependencies]
 compiletest_rs = { version = "0.3", features = ["stable"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,9 @@ arbitrary_precision = []
 
 # Provide a RawValue type that can hold unprocessed JSON during deserialization.
 raw_value = []
+
+# Parse arbitrarily deep JSON structures at the cost of extra stack check on
+# each recursion. Note that this helps only with the parsing itself, and it's
+# left to the user to correctly handle all other recursive operations on the
+# parsed result, including, but not limited to, Display, Debug and Drop impls.
+arbitrary_depth = ["stacker"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1060,9 +1060,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                 }
             }
             b'[' => {
-                self.eat_char();
-
-                let ret = self.recurse(|this| visitor.visit_seq(SeqAccess::new(this)));
+                let ret = self.recurse(|this| {
+                    this.eat_char();
+                    visitor.visit_seq(SeqAccess::new(this))
+                });
 
                 match (ret, self.end_seq()) {
                     (Ok(ret), Ok(())) => Ok(ret),
@@ -1070,9 +1071,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                 }
             }
             b'{' => {
-                self.eat_char();
-
-                let ret = self.recurse(|this| visitor.visit_map(MapAccess::new(this)));
+                let ret = self.recurse(|this| {
+                    this.eat_char();
+                    visitor.visit_map(MapAccess::new(this))
+                });
 
                 match (ret, self.end_map()) {
                     (Ok(ret), Ok(())) => Ok(ret),
@@ -1440,9 +1442,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
         let value = match peek {
             b'[' => {
-                self.eat_char();
-
-                let ret = self.recurse(|this| visitor.visit_seq(SeqAccess::new(this)));
+                let ret = self.recurse(|this| {
+                    this.eat_char();
+                    visitor.visit_seq(SeqAccess::new(this))
+                });
 
                 match (ret, self.end_seq()) {
                     (Ok(ret), Ok(())) => Ok(ret),
@@ -1490,9 +1493,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
         let value = match peek {
             b'{' => {
-                self.eat_char();
-
-                let ret = self.recurse(|this| visitor.visit_map(MapAccess::new(this)));
+                let ret = self.recurse(|this| {
+                    this.eat_char();
+                    visitor.visit_map(MapAccess::new(this))
+                });
 
                 match (ret, self.end_map()) {
                     (Ok(ret), Ok(())) => Ok(ret),
@@ -1526,9 +1530,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
         let value = match peek {
             b'[' => {
-                self.eat_char();
-
-                let ret = self.recurse(|this| visitor.visit_seq(SeqAccess::new(this)));
+                let ret = self.recurse(|this| {
+                    this.eat_char();
+                    visitor.visit_seq(SeqAccess::new(this))
+                });
 
                 match (ret, self.end_seq()) {
                     (Ok(ret), Ok(())) => Ok(ret),
@@ -1536,9 +1541,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                 }
             }
             b'{' => {
-                self.eat_char();
-
-                let ret = self.recurse(|this| visitor.visit_map(MapAccess::new(this)));
+                let ret = self.recurse(|this| {
+                    this.eat_char();
+                    visitor.visit_map(MapAccess::new(this))
+                });
 
                 match (ret, self.end_map()) {
                     (Ok(ret), Ok(())) => Ok(ret),
@@ -1568,9 +1574,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     {
         match try!(self.parse_whitespace()) {
             Some(b'{') => {
-                self.eat_char();
-
-                let value = self.recurse(|this| visitor.visit_enum(VariantAccess::new(this)))?;
+                let value = self.recurse(|this| {
+                    this.eat_char();
+                    visitor.visit_enum(VariantAccess::new(this))
+                })?;
 
                 match try!(self.parse_whitespace()) {
                     Some(b'}') => {

--- a/src/de.rs
+++ b/src/de.rs
@@ -32,7 +32,7 @@ use number::NumberDeserializer;
 pub struct Deserializer<R> {
     read: R,
     scratch: Vec<u8>,
-    #[cfg(not(feature = "stacker"))]
+    #[cfg(not(feature = "arbitrary_depth"))]
     remaining_depth: u8,
 }
 
@@ -52,7 +52,7 @@ where
         Deserializer {
             read: read,
             scratch: Vec::new(),
-            #[cfg(not(feature = "stacker"))]
+            #[cfg(not(feature = "arbitrary_depth"))]
             remaining_depth: 128,
         }
     }
@@ -152,7 +152,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
 
     #[inline(always)]
     fn recurse<T, F: FnOnce(&mut Self) -> Result<T>>(&mut self, f: F) -> Result<T> {
-        #[cfg(not(feature = "stacker"))]
+        #[cfg(not(feature = "arbitrary_depth"))]
         {
             self.remaining_depth -= 1;
             if self.remaining_depth == 0 {
@@ -166,7 +166,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             ret
         }
 
-        #[cfg(feature = "stacker")]
+        #[cfg(feature = "arbitrary_depth")]
         {
             stacker::maybe_grow(32 * 1024, 1024 * 1024, move || f(self))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,7 +346,7 @@ extern crate serde;
 extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
-#[cfg(feature = "stacker")]
+#[cfg(feature = "arbitrary_depth")]
 extern crate stacker;
 
 #[doc(inline)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,8 @@ extern crate serde;
 extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
+#[cfg(feature = "stacker")]
+extern crate stacker;
 
 #[doc(inline)]
 pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1761,7 +1761,7 @@ fn test_json_pointer_mut() {
 }
 
 #[test]
-#[cfg(not(feature = "stacker"))]
+#[cfg(not(feature = "arbitrary_depth"))]
 fn test_stack_overflow() {
     let brackets: String = iter::repeat('[')
         .take(127)
@@ -1774,7 +1774,7 @@ fn test_stack_overflow() {
 }
 
 #[test]
-#[cfg(feature = "stacker")]
+#[cfg(feature = "arbitrary_depth")]
 fn test_stack_overflow() {
     let brackets: String = iter::repeat('[')
         .take(2000)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1769,7 +1769,7 @@ fn test_stack_overflow() {
         .collect();
     let _: Value = from_str(&brackets).unwrap();
 
-    let brackets: String = iter::repeat('[').take(128).collect();
+    let brackets: String = iter::repeat('[').take(129).collect();
     test_parse_err::<Value>(&[(&brackets, "recursion limit exceeded at line 1 column 128")]);
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1761,6 +1761,7 @@ fn test_json_pointer_mut() {
 }
 
 #[test]
+#[cfg(not(feature = "stacker"))]
 fn test_stack_overflow() {
     let brackets: String = iter::repeat('[')
         .take(127)
@@ -1770,6 +1771,17 @@ fn test_stack_overflow() {
 
     let brackets: String = iter::repeat('[').take(128).collect();
     test_parse_err::<Value>(&[(&brackets, "recursion limit exceeded at line 1 column 128")]);
+}
+
+#[test]
+#[cfg(feature = "stacker")]
+fn test_stack_overflow() {
+    let brackets: String = iter::repeat('[')
+        .take(2000)
+        .chain(iter::once('1'))
+        .chain(iter::repeat(']').take(2000))
+        .collect();
+    let _: Value = from_str(&brackets).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This introduces a feature flag that would use [`stacker`](https://github.com/alexcrichton/stacker) to prevent stack overflow while parsing a deeply nested JSON.

Benchmarks show no change with default feature flags (despite extracting a custom helper for recursion), and a relatively small cost for stack probes when nesting into arrays / objects with a feature enabled.

This doesn't attempt to fix all the other operations on the parsed result, and so `PartialEq` / `ParialOrd` / `Display` / `Debug` / `Drop` / ... can still stack overflow after certain depth as they normally would in Rust.

Fixes #334.