### PR TITLE
[RFC] Add an option to allow C99-like comments.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,9 @@ extern crate itoa;
 extern crate ryu;
 
 #[doc(inline)]
-pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
+pub use self::de::{
+    from_reader, from_slice, from_str, from_str_with_options, Deserializer, Options, StreamDeserializer,
+};
 #[doc(inline)]
 pub use self::error::{Error, Result};
 #[doc(inline)]


### PR DESCRIPTION
This would introduce a `serde_json::Options` type that could be
passed to `from_str`, `from_bytes, or `from_reader`. Initially,
the only option would be `allow_comments`, though I would also
like to add support for `allow_trailing_commas` going forward.

I read through https://github.com/serde-rs/json/issues/168 and
saw that this was rejected in the past, but I was curious if we
could revisit this issue. The suggestion on the issue was to use
[Hjson](https://github.com/hjson/hjson-rust), which I think is
"too loose" for most peoples' taste. Also it has [not been updated to
target serde 1.0.x yet](https://github.com/hjson/hjson-rust/issues/6).

Allowing C99-like comments and trailing commas results in an input
language that is still valid ECMAScript (it's just version 5.1 instead
of 3), which cannot be said for things like Hjson. Because it is
familiar to JavaScript developers, I have seen it used as an input
language in a number of domains. For example, all settings files in VS
Code appear to allow this: it even has a special language mode to
recognize this named "JSON with Comments (jsonc)."

It is fairly common for JSON parsers to allow options like this.
For example, here is the full set of options supported by Folly's
(C++ library) JSON parser:

https://github.com/facebook/folly/blob/74ea53886c3333eda4eaf457d538a678ceaa5add/folly/json.h#L56-L72

Google's Gson parser has a `setLenient()` option:

https://github.com/google/gson/blob/9d44cbc19a73b45971c4ecb33c8d34d673afa210/gson/src/main/java/com/google/gson/stream/JsonReader.java#L296-L324

There's also https://json5.org/, which tries to formalize the leniency.

If `serde_json` is not on board with this direction, I guess I should
fork this repo and create `serde_jsonc` or `serde_lenient_json`? I would
prefer not to do that, but if you want to keep `serde_json` so that it
only supports RFC 8259 or whatever it is, then I suppose forking is the
best way forward.

One final note: although https://github.com/serde-rs/json/issues/168
notes that comments were "explicitly excluded from JSON," it doesn't
mean it was the right choice. I've been arguing against it for years
now: http://bolinfest.com/essays/json.html.