### PR TITLE
No_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,15 @@ travis-ci = { repository = "serde-rs/json" }
 appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
-serde = "1.0.60"
-indexmap = { version = "1.0", optional = true }
-itoa = "0.4.3"
-ryu = "0.2"
+serde = { version = "1.0.85", default-features = false, features = ["alloc"] }
+#indexmap = { version = "1.0", optional = true }
+itoa = { version = "0.4.3", optional = true, default-features = false }
+ryu = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
-compiletest_rs = { version = "0.3", features = ["stable"] }
-serde_bytes = "0.10"
-serde_derive = "1.0"
+# compiletest_rs = { version = "0.3", features = ["stable"] }
+# serde_bytes = "0.10"
+# serde_derive = "1.0"
 
 [package.metadata.docs.rs]
 features = ["raw_value"]
@@ -41,7 +41,7 @@ default = []
 # Use a different representation for the map type of serde_json::Value.
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.
-preserve_order = ["indexmap"]
+# preserve_order = ["indexmap"]
 
 # Use an arbitrary precision number representation for serde_json::Number. This
 # allows JSON numbers of arbitrary size/precision to be read into a Number and
@@ -50,3 +50,9 @@ arbitrary_precision = []
 
 # Provide a RawValue type that can hold unprocessed JSON during deserialization.
 raw_value = []
+
+# Default feature indicating std support
+# std = ["itoa/default"]
+
+# No-Std feature
+no_std = ["serde/alloc", "itoa", "ryu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
 serde = { version = "1.0.85", default-features = false, features = ["alloc"] }
-#indexmap = { version = "1.0", optional = true }
+indexmap = { version = "1.0", optional = true }
 itoa = { version = "0.4.3", optional = true, default-features = false }
 ryu = { version = "0.2", optional = true, default-features = false }
 
@@ -36,7 +36,7 @@ features = ["raw_value"]
 ### FEATURES #################################################################
 
 [features]
-default = []
+default = ["std"]
 
 # Use a different representation for the map type of serde_json::Value.
 # This allows data to be read into a Value and written back to a JSON string
@@ -52,7 +52,7 @@ arbitrary_precision = []
 raw_value = []
 
 # Default feature indicating std support
-# std = ["itoa/default"]
+std = ["serde/default", "itoa/default", "indexmap", "ryu"]
 
 # No-Std feature
 no_std = ["serde/alloc", "itoa", "ryu"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "serde-rs/json" }
 appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
-serde = { version = "1.0.85", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.85", default-features = false }
 indexmap = { version = "1.0", optional = true }
 itoa = { version = "0.4.3", optional = true, default-features = false }
 ryu = { version = "0.2", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,4 @@ raw_value = []
 std = ["serde/default", "itoa/default", "indexmap", "ryu"]
 
 # No-Std feature
-no_std = ["serde/alloc", "itoa", "ryu"]
+no_std = ["serde/alloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "serde-rs/json" }
 serde = { version = "1.0.85", default-features = false }
 indexmap = { version = "1.0", optional = true }
 itoa = { version = "0.4.3", optional = true, default-features = false }
-ryu = { version = "0.2", optional = true, default-features = false }
+ryu = "0.2"
 
 [dev-dependencies]
 # compiletest_rs = { version = "0.3", features = ["stable"] }
@@ -52,7 +52,7 @@ arbitrary_precision = []
 raw_value = []
 
 # Default feature indicating std support
-std = ["serde/default", "itoa/default", "indexmap", "ryu"]
+std = ["serde/default", "itoa/default", "indexmap"]
 
 # No-Std feature
-no_std = ["serde/alloc"]
+no_std = ["serde/alloc", "itoa"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ default = ["std"]
 # Use a different representation for the map type of serde_json::Value.
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.
-# preserve_order = ["indexmap"]
+preserve_order = ["indexmap"]
 
 # Use an arbitrary precision number representation for serde_json::Number. This
 # allows JSON numbers of arbitrary size/precision to be read into a Number and

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,9 +1,26 @@
 //! Deserialize JSON data to a Rust data structure.
 
+#[cfg(feature ="std")]
 use std::io;
+#[cfg(not(feature = "std"))]
+use core::marker::PhantomData;
+#[cfg(feature = "std")]
 use std::marker::PhantomData;
+#[cfg(feature = "std")]
 use std::result;
+#[cfg(not(feature = "std"))]
+use core::result;
+#[cfg(feature = "std")]
 use std::str::FromStr;
+#[cfg(not(feature = "std"))]
+use alloc::str::FromStr;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use core::{i32, u64};
+#[cfg(feature = "std")]
 use std::{i32, u64};
 
 use serde::de::{self, Expected, Unexpected};
@@ -12,7 +29,9 @@ use super::error::{Error, ErrorCode, Result};
 
 use read::{self, Reference};
 
-pub use read::{IoRead, Read, SliceRead, StrRead};
+pub use read::{Read, SliceRead, StrRead};
+#[cfg(feature = "std")]
+pub use read::IoRead;
 
 use number::Number;
 #[cfg(feature = "arbitrary_precision")]
@@ -48,6 +67,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<R> Deserializer<read::IoRead<R>>
 where
     R: io::Read,
@@ -2161,6 +2181,7 @@ where
 /// is wrong with the data, for example required struct fields are missing from
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
+#[cfg(feature = "std")]
 pub fn from_reader<R, T>(rdr: R) -> Result<T>
 where
     R: io::Read,

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,17 +1,5 @@
 //! Deserialize JSON data to a Rust data structure.
 
-#[cfg(feature ="std")]
-use std::io;
-#[cfg(not(feature = "std"))]
-use core::marker::PhantomData;
-#[cfg(feature = "std")]
-use std::marker::PhantomData;
-#[cfg(feature = "std")]
-use std::result;
-#[cfg(not(feature = "std"))]
-use core::result;
-#[cfg(feature = "std")]
-use std::str::FromStr;
 #[cfg(not(feature = "std"))]
 use alloc::str::FromStr;
 #[cfg(not(feature = "std"))]
@@ -19,7 +7,19 @@ use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
+use core::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use core::result;
+#[cfg(not(feature = "std"))]
 use core::{i32, u64};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::marker::PhantomData;
+#[cfg(feature = "std")]
+use std::result;
+#[cfg(feature = "std")]
+use std::str::FromStr;
 #[cfg(feature = "std")]
 use std::{i32, u64};
 
@@ -29,9 +29,9 @@ use super::error::{Error, ErrorCode, Result};
 
 use read::{self, Reference};
 
-pub use read::{Read, SliceRead, StrRead};
 #[cfg(feature = "std")]
 pub use read::IoRead;
+pub use read::{Read, SliceRead, StrRead};
 
 use number::Number;
 #[cfg(feature = "arbitrary_precision")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,26 @@
 //! When serializing or deserializing JSON goes wrong.
 
-#[cfg(feature = "std")]
-use std::error;
+#[cfg(not(feature = "std"))]
+use alloc::str::FromStr;
 #[cfg(not(feature = "std"))]
 use core::fmt::{self, Debug, Display};
+#[cfg(not(feature = "std"))]
+use core::result;
+#[cfg(feature = "std")]
+use std::error;
 #[cfg(feature = "std")]
 use std::fmt::{self, Debug, Display};
 #[cfg(feature = "std")]
 use std::io;
 #[cfg(feature = "std")]
-use std::str::FromStr;
-#[cfg(not(feature = "std"))]
-use alloc::str::FromStr;
-#[cfg(not(feature = "std"))]
-use core::result;
-#[cfg(feature = "std")]
 use std::result;
+#[cfg(feature = "std")]
+use std::str::FromStr;
 
 #[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
 use alloc::prelude::*;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
 
 use serde::de;
 #[cfg(feature = "std")]
@@ -178,7 +178,6 @@ impl From<Error> for io::Error {
     ///     }
     /// }
     /// ```
-    #[cfg(feature = "std")]
     fn from(j: Error) -> Self {
         if let ErrorCode::Io(err) = j.err.code {
             err

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,7 @@ use alloc::string::String;
 use alloc::prelude::*;
 
 use serde::de;
+#[cfg(feature = "std")]
 use serde::ser;
 
 /// This type represents all possible errors that can occur when serializing or

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,26 @@
 //! When serializing or deserializing JSON goes wrong.
 
+#[cfg(feature = "std")]
 use std::error;
+#[cfg(not(feature = "std"))]
+use core::fmt::{self, Debug, Display};
+#[cfg(feature = "std")]
 use std::fmt::{self, Debug, Display};
+#[cfg(feature = "std")]
 use std::io;
+#[cfg(feature = "std")]
 use std::str::FromStr;
+#[cfg(not(feature = "std"))]
+use alloc::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::result;
+#[cfg(feature = "std")]
 use std::result;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::prelude::*;
 
 use serde::de;
 use serde::ser;
@@ -50,6 +66,7 @@ impl Error {
     pub fn classify(&self) -> Category {
         match self.err.code {
             ErrorCode::Message(_) => Category::Data,
+            #[cfg(feature = "std")]
             ErrorCode::Io(_) => Category::Io,
             ErrorCode::EofWhileParsingList
             | ErrorCode::EofWhileParsingObject
@@ -130,6 +147,7 @@ pub enum Category {
     Eof,
 }
 
+#[cfg(feature = "std")]
 #[cfg_attr(feature = "cargo-clippy", allow(fallible_impl_from))]
 impl From<Error> for io::Error {
     /// Convert a `serde_json::Error` into an `io::Error`.
@@ -159,6 +177,7 @@ impl From<Error> for io::Error {
     ///     }
     /// }
     /// ```
+    #[cfg(feature = "std")]
     fn from(j: Error) -> Self {
         if let ErrorCode::Io(err) = j.err.code {
             err
@@ -185,6 +204,7 @@ pub enum ErrorCode {
     Message(Box<str>),
 
     /// Some IO error occurred while serializing or deserializing.
+    #[cfg(feature = "std")]
     Io(io::Error),
 
     /// EOF while parsing a list.
@@ -271,6 +291,7 @@ impl Error {
     // Not public API. Should be pub(crate).
     //
     // Update `eager_json` crate when this function changes.
+    #[cfg(feature = "std")]
     #[doc(hidden)]
     #[cold]
     pub fn io(error: io::Error) -> Self {
@@ -302,6 +323,7 @@ impl Display for ErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             ErrorCode::Message(ref msg) => f.write_str(msg),
+            #[cfg(feature = "std")]
             ErrorCode::Io(ref err) => Display::fmt(err, f),
             ErrorCode::EofWhileParsingList => f.write_str("EOF while parsing a list"),
             ErrorCode::EofWhileParsingObject => f.write_str("EOF while parsing an object"),
@@ -333,6 +355,7 @@ impl Display for ErrorCode {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {
     fn description(&self) -> &str {
         match self.err.code {
@@ -402,6 +425,7 @@ impl de::Error for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl ser::Error for Error {
     #[cold]
     fn custom<T: Display>(msg: T) -> Error {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,15 +1,4 @@
-#[cfg(feature = "std")]
 use std::io;
-#[cfg(not(feature = "std"))]
-use core::result;
-
-#[cfg(not(feature = "std"))]
-use super::error::Error;
-
-#[cfg(feature = "std")]
-type Result<T> = io::Result<T>;
-#[cfg(not(feature = "std"))]
-type Result<T> = result::Result<T, Error>;
 
 pub struct LineColIterator<I> {
     iter: I,
@@ -32,7 +21,7 @@ pub struct LineColIterator<I> {
 
 impl<I> LineColIterator<I>
 where
-    I: Iterator<Item = Result<u8>>,
+    I: Iterator<Item = io::Result<u8>>,
 {
     pub fn new(iter: I) -> LineColIterator<I> {
         LineColIterator {
@@ -58,11 +47,11 @@ where
 
 impl<I> Iterator for LineColIterator<I>
 where
-    I: Iterator<Item = Result<u8>>,
+    I: Iterator<Item = io::Result<u8>>,
 {
-    type Item = Result<u8>;
+    type Item = io::Result<u8>;
 
-    fn next(&mut self) -> Option<Result<u8>> {
+    fn next(&mut self) -> Option<io::Result<u8>> {
         match self.iter.next() {
             None => None,
             Some(Ok(b'\n')) => {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,15 @@
+#[cfg(feature = "std")]
 use std::io;
+#[cfg(not(feature = "std"))]
+use core::result;
+
+#[cfg(not(feature = "std"))]
+use super::error::Error;
+
+#[cfg(feature = "std")]
+type Result<T> = io::Result<T>;
+#[cfg(not(feature = "std"))]
+type Result<T> = result::Result<T, Error>;
 
 pub struct LineColIterator<I> {
     iter: I,
@@ -21,7 +32,7 @@ pub struct LineColIterator<I> {
 
 impl<I> LineColIterator<I>
 where
-    I: Iterator<Item = io::Result<u8>>,
+    I: Iterator<Item = Result<u8>>,
 {
     pub fn new(iter: I) -> LineColIterator<I> {
         LineColIterator {
@@ -47,11 +58,11 @@ where
 
 impl<I> Iterator for LineColIterator<I>
 where
-    I: Iterator<Item = io::Result<u8>>,
+    I: Iterator<Item = Result<u8>>,
 {
-    type Item = io::Result<u8>;
+    type Item = Result<u8>;
 
-    fn next(&mut self) -> Option<io::Result<u8>> {
+    fn next(&mut self) -> Option<Result<u8>> {
         match self.iter.next() {
             None => None,
             Some(Ok(b'\n')) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,9 +327,7 @@ extern crate serde;
 extern crate alloc;
 #[cfg(feature = "preserve_order")]
 extern crate indexmap;
-#[cfg(feature = "std")]
 extern crate itoa;
-#[cfg(feature = "std")]
 extern crate ryu;
 
 #[cfg(feature = "std")]
@@ -373,7 +371,6 @@ pub mod de;
 pub mod error;
 #[cfg(feature = "std")]
 pub mod map;
-#[cfg(feature = "std")]
 pub mod ser;
 #[cfg(feature = "std")]
 pub mod value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,26 +318,25 @@
     redundant_field_names,
 ))]
 #![deny(missing_docs)]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[macro_use]
 extern crate serde;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 #[cfg(feature = "preserve_order")]
 extern crate indexmap;
 #[cfg(feature = "std")]
 extern crate itoa;
 #[cfg(feature = "std")]
 extern crate ryu;
-#[cfg(not(feature = "std"))]
-extern crate alloc;
 
-#[doc(inline)]
-pub use self::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::de::from_reader;
+#[doc(inline)]
+pub use self::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,47 +319,66 @@
 ))]
 #![deny(missing_docs)]
 
+#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "std"), feature(alloc))]
+
 #[macro_use]
 extern crate serde;
 #[cfg(feature = "preserve_order")]
 extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 
+#[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
+#[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::error::{Error, Result};
+#[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::ser::{
     to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer,
 };
+#[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
+
+#[cfg(not(feature = "std"))]
+use core::result;
+#[cfg(feature = "std")]
+use std::result;
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
 macro_rules! try {
     ($e:expr) => {
         match $e {
-            ::std::result::Result::Ok(val) => val,
-            ::std::result::Result::Err(err) => return ::std::result::Result::Err(err),
+            ::result::Result::Ok(val) => val,
+            ::result::Result::Err(err) => return ::result::Result::Err(err),
         }
     };
 }
 
+#[cfg(feature = "std")]
 #[macro_use]
 mod macros;
 
 pub mod de;
 pub mod error;
+#[cfg(feature = "std")]
 pub mod map;
+#[cfg(feature = "std")]
 pub mod ser;
+#[cfg(feature = "std")]
 pub mod value;
 
 mod iter;
 mod number;
 mod read;
 
+#[cfg(feature = "std")]
 #[cfg(feature = "raw_value")]
 mod raw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,9 +331,11 @@ extern crate ryu;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+#[doc(inline)]
+pub use self::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[cfg(feature = "std")]
 #[doc(inline)]
-pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
+pub use self::de::from_reader;
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,11 +338,11 @@ pub use self::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::error::{Error, Result};
+#[doc(inline)]
+pub use self::ser::{to_string, to_vec, to_writer, Serializer};
 #[cfg(feature = "std")]
 #[doc(inline)]
-pub use self::ser::{
-    to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer,
-};
+pub use self::ser::{to_string_pretty, to_vec_pretty, to_writer_pretty};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,7 @@ pub mod ser;
 #[cfg(feature = "std")]
 pub mod value;
 
+#[cfg(feature = "std")]
 mod iter;
 mod number;
 mod read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,6 @@ pub use self::ser::{to_string, to_vec, to_writer, Serializer};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::ser::{to_string_pretty, to_vec_pretty, to_writer_pretty};
-#[cfg(feature = "std")]
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
 
@@ -369,10 +368,8 @@ mod macros;
 
 pub mod de;
 pub mod error;
-#[cfg(feature = "std")]
 pub mod map;
 pub mod ser;
-#[cfg(feature = "std")]
 pub mod value;
 
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,7 +326,9 @@
 extern crate serde;
 #[cfg(feature = "preserve_order")]
 extern crate indexmap;
+#[cfg(feature = "std")]
 extern crate itoa;
+#[cfg(feature = "std")]
 extern crate ryu;
 #[cfg(not(feature = "std"))]
 extern crate alloc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,7 +362,6 @@ macro_rules! try {
     };
 }
 
-#[cfg(feature = "std")]
 #[macro_use]
 mod macros;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,14 +6,36 @@
 //! [`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
+#[cfg(not(feature = "std"))]
+use core::borrow::Borrow;
+#[cfg(not(feature = "std"))]
+use core::fmt::{self, Debug};
+#[cfg(not(feature = "std"))]
+use core::hash::Hash;
+#[cfg(not(feature = "std"))]
+use core::iter::FromIterator;
+#[cfg(not(feature = "std"))]
+use core::ops;
 use serde::{de, ser};
+#[cfg(feature = "std")]
 use std::borrow::Borrow;
+#[cfg(feature = "std")]
 use std::fmt::{self, Debug};
+#[cfg(feature = "std")]
 use std::hash::Hash;
+#[cfg(feature = "std")]
 use std::iter::FromIterator;
+#[cfg(feature = "std")]
 use std::ops;
 use value::Value;
 
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+
+#[cfg(not(feature = "std"))]
+#[cfg(not(feature = "preserve_order"))]
+use alloc::collections::{btree_map, BTreeMap};
+#[cfg(feature = "std")]
 #[cfg(not(feature = "preserve_order"))]
 use std::collections::{btree_map, BTreeMap};
 
@@ -135,8 +157,12 @@ impl Map<String, Value> {
     where
         S: Into<String>,
     {
+        #[cfg(not(feature = "std"))]
+        #[cfg(not(feature = "preserve_order"))]
+        use alloc::collections::btree_map::Entry as EntryImpl;
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
+        #[cfg(feature = "std")]
         #[cfg(not(feature = "preserve_order"))]
         use std::collections::btree_map::Entry as EntryImpl;
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,7 +1,10 @@
 use error::Error;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(feature = "std")]
 use std::fmt::{self, Debug, Display};
+#[cfg(not(feature = "std"))]
+use core::fmt::{self, Debug, Display};
 
 #[cfg(feature = "arbitrary_precision")]
 use itoa;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,10 +1,10 @@
+#[cfg(not(feature = "std"))]
+use core::fmt::{self, Debug, Display};
 use error::Error;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(feature = "std")]
 use std::fmt::{self, Debug, Display};
-#[cfg(not(feature = "std"))]
-use core::fmt::{self, Debug, Display};
 
 #[cfg(feature = "arbitrary_precision")]
 use itoa;

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "std")]
-use std::ops::Deref;
 #[cfg(not(feature = "std"))]
 use core::ops::Deref;
+#[cfg(not(feature = "std"))]
+use core::{char, cmp, str};
+#[cfg(feature = "std")]
+use std::ops::Deref;
 #[cfg(feature = "std")]
 use std::{char, cmp, io, str};
-#[cfg(not(feature = "std"))]
-use core::{str, char, cmp};
 
 #[cfg(feature = "raw_value")]
 use serde::de::Visitor;

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,5 +1,11 @@
+#[cfg(feature = "std")]
 use std::ops::Deref;
+#[cfg(not(feature = "std"))]
+use core::ops::Deref;
+#[cfg(feature = "std")]
 use std::{char, cmp, io, str};
+#[cfg(not(feature = "std"))]
+use core::{str, char, cmp};
 
 #[cfg(feature = "raw_value")]
 use serde::de::Visitor;
@@ -10,6 +16,9 @@ use error::{Error, ErrorCode, Result};
 
 #[cfg(feature = "raw_value")]
 use raw::{BorrowedRawDeserializer, OwnedRawDeserializer};
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 
 /// Trait used by the deserializer for iterating over input. This is manually
 /// "specialized" for iterating over &[u8]. Once feature(specialization) is
@@ -118,6 +127,7 @@ impl<'b, 'c, T: ?Sized + 'static> Deref for Reference<'b, 'c, T> {
 }
 
 /// JSON input source that reads from a std::io input stream.
+#[cfg(feature = "std")]
 pub struct IoRead<R>
 where
     R: io::Read,
@@ -157,6 +167,7 @@ mod private {
 
 //////////////////////////////////////////////////////////////////////////////
 
+#[cfg(feature = "std")]
 impl<R> IoRead<R>
 where
     R: io::Read,
@@ -181,8 +192,10 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<R> private::Sealed for IoRead<R> where R: io::Read {}
 
+#[cfg(feature = "std")]
 impl<R> IoRead<R>
 where
     R: io::Read,
@@ -221,6 +234,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'de, R> Read<'de> for IoRead<R>
 where
     R: io::Read,

--- a/src/read.rs
+++ b/src/read.rs
@@ -10,6 +10,7 @@ use core::{str, char, cmp};
 #[cfg(feature = "raw_value")]
 use serde::de::Visitor;
 
+#[cfg(feature = "std")]
 use iter::LineColIterator;
 
 use error::{Error, ErrorCode, Result};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,9 +1,19 @@
 //! Serialize a Rust data structure into JSON data.
 
+#[cfg(feature = "std")]
 use std::fmt;
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(feature = "std")]
 use std::io;
+#[cfg(feature = "std")]
 use std::num::FpCategory;
+#[cfg(not(feature = "std"))]
+use core::num::FpCategory;
+#[cfg(feature = "std")]
 use std::str;
+#[cfg(not(feature = "std"))]
+use core::str;
 
 use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible, Serialize};
@@ -12,11 +22,13 @@ use itoa;
 use ryu;
 
 /// A structure for serializing Rust values into JSON.
+#[cfg(feature = "std")]
 pub struct Serializer<W, F = CompactFormatter> {
     writer: W,
     formatter: F,
 }
 
+#[cfg(feature = "std")]
 impl<W> Serializer<W>
 where
     W: io::Write,
@@ -28,6 +40,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W> Serializer<W, PrettyFormatter<'a>>
 where
     W: io::Write,
@@ -39,6 +52,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<W, F> Serializer<W, F>
 where
     W: io::Write,
@@ -61,6 +75,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::Serializer for &'a mut Serializer<W, F>
 where
     W: io::Write,
@@ -510,6 +525,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 #[derive(Eq, PartialEq)]
 /// Not public API. Should be pub(crate).
 #[doc(hidden)]
@@ -519,6 +535,7 @@ pub enum State {
     Rest,
 }
 
+#[cfg(feature = "std")]
 /// Not public API. Should be pub(crate).
 #[doc(hidden)]
 pub enum Compound<'a, W: 'a, F: 'a> {
@@ -532,6 +549,7 @@ pub enum Compound<'a, W: 'a, F: 'a> {
     RawValue { ser: &'a mut Serializer<W, F> },
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::SerializeSeq for Compound<'a, W, F>
 where
     W: io::Write,
@@ -587,6 +605,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::SerializeTuple for Compound<'a, W, F>
 where
     W: io::Write,
@@ -609,6 +628,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::SerializeTupleStruct for Compound<'a, W, F>
 where
     W: io::Write,
@@ -631,6 +651,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::SerializeTupleVariant for Compound<'a, W, F>
 where
     W: io::Write,
@@ -670,6 +691,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::SerializeMap for Compound<'a, W, F>
 where
     W: io::Write,
@@ -752,6 +774,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::SerializeStruct for Compound<'a, W, F>
 where
     W: io::Write,
@@ -803,6 +826,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::SerializeStructVariant for Compound<'a, W, F>
 where
     W: io::Write,
@@ -848,24 +872,29 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 struct MapKeySerializer<'a, W: 'a, F: 'a> {
     ser: &'a mut Serializer<W, F>,
 }
 
+#[cfg(feature = "std")]
 #[cfg(feature = "arbitrary_precision")]
 fn invalid_number() -> Error {
     Error::syntax(ErrorCode::InvalidNumber, 0, 0)
 }
 
+#[cfg(feature = "std")]
 #[cfg(feature = "raw_value")]
 fn invalid_raw_value() -> Error {
     Error::syntax(ErrorCode::ExpectedSomeValue, 0, 0)
 }
 
+#[cfg(feature = "std")]
 fn key_must_be_a_string() -> Error {
     Error::syntax(ErrorCode::KeyMustBeAString, 0, 0)
 }
 
+#[cfg(feature = "std")]
 impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
 where
     W: io::Write,
@@ -1196,9 +1225,11 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(feature = "arbitrary_precision")]
 struct NumberStrEmitter<'a, W: 'a + io::Write, F: 'a + Formatter>(&'a mut Serializer<W, F>);
 
+#[cfg(feature = "std")]
 #[cfg(feature = "arbitrary_precision")]
 impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W, F> {
     type Ok = ();
@@ -1381,9 +1412,11 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(feature = "raw_value")]
 struct RawValueStrEmitter<'a, W: 'a + io::Write, F: 'a + Formatter>(&'a mut Serializer<W, F>);
 
+#[cfg(feature = "std")]
 #[cfg(feature = "raw_value")]
 impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, W, F> {
     type Ok = ();
@@ -1567,6 +1600,7 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
 }
 
 /// Represents a character escape code in a type-safe manner.
+#[cfg(feature = "std")]
 pub enum CharEscape {
     /// An escaped quote `"`
     Quote,
@@ -1589,6 +1623,7 @@ pub enum CharEscape {
     AsciiControl(u8),
 }
 
+#[cfg(feature = "std")]
 impl CharEscape {
     #[inline]
     fn from_escape_table(escape: u8, byte: u8) -> CharEscape {
@@ -1608,6 +1643,7 @@ impl CharEscape {
 
 /// This trait abstracts away serializing the JSON control characters, which allows the user to
 /// optionally pretty print the JSON output.
+#[cfg(feature = "std")]
 pub trait Formatter {
     /// Writes a `null` value to the specified writer.
     #[inline]
@@ -1922,12 +1958,15 @@ pub trait Formatter {
 }
 
 /// This structure compacts a JSON value with no extra whitespace.
+#[cfg(feature = "std")]
 #[derive(Clone, Debug)]
 pub struct CompactFormatter;
 
+#[cfg(feature = "std")]
 impl Formatter for CompactFormatter {}
 
 /// This structure pretty prints a JSON value to make it human readable.
+#[cfg(feature = "std")]
 #[derive(Clone, Debug)]
 pub struct PrettyFormatter<'a> {
     current_indent: usize,
@@ -1935,6 +1974,7 @@ pub struct PrettyFormatter<'a> {
     indent: &'a [u8],
 }
 
+#[cfg(feature = "std")]
 impl<'a> PrettyFormatter<'a> {
     /// Construct a pretty printer formatter that defaults to using two spaces for indentation.
     pub fn new() -> Self {
@@ -1951,12 +1991,14 @@ impl<'a> PrettyFormatter<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> Default for PrettyFormatter<'a> {
     fn default() -> Self {
         PrettyFormatter::new()
     }
 }
 
+#[cfg(feature = "std")]
 impl<'a> Formatter for PrettyFormatter<'a> {
     #[inline]
     fn begin_array<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
@@ -2062,6 +2104,7 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     }
 }
 
+#[cfg(feature = "std")]
 fn format_escaped_str<W: ?Sized, F: ?Sized>(
     writer: &mut W,
     formatter: &mut F,
@@ -2077,6 +2120,7 @@ where
     Ok(())
 }
 
+#[cfg(feature = "std")]
 fn format_escaped_str_contents<W: ?Sized, F: ?Sized>(
     writer: &mut W,
     formatter: &mut F,
@@ -2151,6 +2195,7 @@ static ESCAPE: [u8; 256] = [
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
+#[cfg(feature = "std")]
 #[inline]
 pub fn to_writer<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
 where
@@ -2169,6 +2214,7 @@ where
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
+#[cfg(feature = "std")]
 #[inline]
 pub fn to_writer_pretty<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
 where
@@ -2186,6 +2232,7 @@ where
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
+#[cfg(feature = "std")]
 #[inline]
 pub fn to_vec<T: ?Sized>(value: &T) -> Result<Vec<u8>>
 where
@@ -2202,6 +2249,7 @@ where
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
+#[cfg(feature = "std")]
 #[inline]
 pub fn to_vec_pretty<T: ?Sized>(value: &T) -> Result<Vec<u8>>
 where
@@ -2218,6 +2266,7 @@ where
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
+#[cfg(feature = "std")]
 #[inline]
 pub fn to_string<T: ?Sized>(value: &T) -> Result<String>
 where
@@ -2237,6 +2286,7 @@ where
 ///
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
+#[cfg(feature = "std")]
 #[inline]
 pub fn to_string_pretty<T: ?Sized>(value: &T) -> Result<String>
 where
@@ -2250,6 +2300,7 @@ where
     Ok(string)
 }
 
+#[cfg(feature = "std")]
 fn indent<W: ?Sized>(wr: &mut W, n: usize, s: &[u8]) -> io::Result<()>
 where
     W: io::Write,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,9 +1,20 @@
 //! Serialize a Rust data structure into JSON data.
 
+#[cfg(feature = "std")]
 use std::fmt;
+#[cfg(feature = "std")]
 use std::io;
+#[cfg(feature = "std")]
 use std::num::FpCategory;
+#[cfg(feature = "std")]
 use std::str;
+
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use alloc::fmt::write;
 
 use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible, Serialize};
@@ -1608,6 +1619,7 @@ impl CharEscape {
 
 /// This trait abstracts away serializing the JSON control characters, which allows the user to
 /// optionally pretty print the JSON output.
+#[cfg(feature = "std")]
 pub trait Formatter {
     /// Writes a `null` value to the specified writer.
     #[inline]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2534,6 +2534,24 @@ where
     Ok(())
 }
 
+/// Serialize the given data structure as pretty-printed JSON into the IO
+/// stream.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+// Currently no_std does not support to_writer_pretty. This is a workaround for types that
+// implement alternate `{:#?}`.
+#[cfg(not(feature = "std"))]
+pub fn to_writer_pretty<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
+where
+    W: WriteTrait,
+    T: Serialize,
+{
+    to_writer(writer, value)
+}
+
 /// Serialize the given data structure as a JSON byte vector.
 ///
 /// # Errors

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,20 +1,9 @@
 //! Serialize a Rust data structure into JSON data.
 
-#[cfg(feature = "std")]
 use std::fmt;
-#[cfg(feature = "std")]
 use std::io;
-#[cfg(feature = "std")]
 use std::num::FpCategory;
-#[cfg(feature = "std")]
 use std::str;
-
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
-use alloc::fmt::write;
 
 use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible, Serialize};
@@ -1619,7 +1608,6 @@ impl CharEscape {
 
 /// This trait abstracts away serializing the JSON control characters, which allows the user to
 /// optionally pretty print the JSON output.
-#[cfg(feature = "std")]
 pub trait Formatter {
     /// Writes a `null` value to the specified writer.
     #[inline]

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,7 +1,22 @@
+#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::slice;
+#[cfg(not(feature = "std"))]
+use core::str;
+#[cfg(feature = "std")]
 use std::borrow::Cow;
+#[cfg(feature = "std")]
 use std::fmt;
+#[cfg(feature = "std")]
 use std::slice;
+#[cfg(feature = "std")]
 use std::str;
+#[cfg(feature = "std")]
 use std::vec;
 
 use serde;
@@ -19,6 +34,9 @@ use serde::de;
 
 #[cfg(feature = "arbitrary_precision")]
 use number::NumberFromString;
+
+#[cfg(not(feature = "std"))]
+use alloc::prelude::{String, ToOwned, Vec};
 
 impl<'de> Deserialize<'de> for Value {
     #[inline]

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,8 +1,18 @@
+#[cfg(not(feature = "std"))]
+use core::iter::FromIterator;
+#[cfg(feature = "std")]
 use std::borrow::Cow;
+#[cfg(feature = "std")]
+use std::iter::FromIterator;
 
 use super::Value;
 use map::Map;
 use number::Number;
+
+#[cfg(not(feature = "std"))]
+use alloc::borrow::Cow;
+#[cfg(not(feature = "std"))]
+use alloc::prelude::{String, ToString, Vec};
 
 macro_rules! from_integer {
     ($($ty:ident)*) => {
@@ -182,7 +192,7 @@ impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
     }
 }
 
-impl<T: Into<Value>> ::std::iter::FromIterator<T> for Value {
+impl<T: Into<Value>> FromIterator<T> for Value {
     /// Convert an iteratable type to a `Value`
     ///
     /// # Examples

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,8 +1,17 @@
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::ops;
+#[cfg(feature = "std")]
 use std::fmt;
+#[cfg(feature = "std")]
 use std::ops;
 
 use super::Value;
 use map::Map;
+
+#[cfg(not(feature = "std"))]
+use alloc::prelude::{String, ToOwned};
 
 /// A type that can be used to index into a `serde_json::Value`.
 ///
@@ -132,6 +141,9 @@ where
 
 // Prevent users from implementing the Index trait.
 mod private {
+    #[cfg(not(feature = "std"))]
+    use alloc::prelude::String;
+
     pub trait Sealed {}
     impl Sealed for usize {}
     impl Sealed for str {}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -93,9 +93,19 @@
 //! [from_slice]: https://docs.serde.rs/serde_json/de/fn.from_slice.html
 //! [from_reader]: https://docs.serde.rs/serde_json/de/fn.from_reader.html
 
+#[cfg(not(feature = "std"))]
+use core::fmt::{self, Debug};
+#[cfg(not(feature = "std"))]
+use core::mem;
+#[cfg(not(feature = "std"))]
+use core::str;
+#[cfg(feature = "std")]
 use std::fmt::{self, Debug};
+#[cfg(feature = "std")]
 use std::io;
+#[cfg(feature = "std")]
 use std::mem;
+#[cfg(feature = "std")]
 use std::str;
 
 use serde::de::DeserializeOwned;
@@ -111,6 +121,9 @@ pub use raw::RawValue;
 pub use self::index::Index;
 
 use self::ser::Serializer;
+
+#[cfg(not(feature = "std"))]
+use alloc::prelude::{String, Vec};
 
 /// Represents any valid JSON value.
 ///
@@ -195,6 +208,7 @@ struct WriterFormatter<'a, 'b: 'a> {
     inner: &'a mut fmt::Formatter<'b>,
 }
 
+#[cfg(feature = "std")]
 impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         fn io_error<E>(_: E) -> io::Error {
@@ -208,6 +222,14 @@ impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
     }
 
     fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl<'a, 'b> fmt::Write for WriterFormatter<'a, 'b> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        try!(self.inner.write_str(s));
         Ok(())
     }
 }
@@ -931,28 +953,6 @@ mod ser;
 ///         "location": "Menlo Park, CA",
 ///     });
 ///
-///     let v = serde_json::to_value(u).unwrap();
-///     assert_eq!(v, expected);
-///
-///     Ok(())
-/// }
-/// #
-/// # fn main() {
-/// #     compare_json_values().unwrap();
-/// # }
-/// ```
-///
-/// # Errors
-///
-/// This conversion can fail if `T`'s implementation of `Serialize` decides to
-/// fail, or if `T` contains a map with non-string keys.
-///
-/// ```edition2018
-/// use std::collections::BTreeMap;
-///
-/// fn main() {
-///     // The keys in this map are vectors, not strings.
-///     let mut map = BTreeMap::new();
 ///     map.insert(vec![32, 64], "x86");
 ///
 ///     println!("{}", serde_json::to_value(map).unwrap_err());

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,5 +1,8 @@
 use super::Value;
 
+#[cfg(not(feature = "std"))]
+use alloc::prelude::String;
+
 fn eq_i64(value: &Value, other: i64) -> bool {
     value.as_i64().map_or(false, |i| i == other)
 }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -6,6 +6,9 @@ use map::Map;
 use number::Number;
 use value::{to_value, Value};
 
+#[cfg(not(feature = "std"))]
+use alloc::prelude::{String, ToOwned, ToString, Vec};
+
 impl Serialize for Value {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
_Here be dragons_

This is an attempt at resolving #362.

---

This pr is far from complete. The goal is to start a discussion on what the effort would be to correctly add no_std support to serde_json.

What was done so far:
- Added a std feature that is enabled by default
- Added a no_std feature so that we can enable specific dependencie features as required (e.g. alloc in serde)
- Added no_std support for the deserializer

Build with no_std:
```bash
cargo build --no-default-features --features no_std

# building for a different target
rustup target add thumbv7m-none-eabi
cargo build --no-default-features --features no_std --target thumbv7m-none-eabi
```

This was tested in another project were we use serde_json for json deserialization. We were able successfully compile with no_std support using the changes in this pr.

---
**Problems:**

The import logic can get messy:
- Nested imports makes it cleaner but they were only added in rust version 1.25
- We can probably try to reuse the import logic performed by serde. Although it's weird to depend on how another crate does imports

Requires nightly:
- Both serde `unstable` and `alloc` features require nightly

Cannot have dev-dependencies:
- There seems to be a [problem in cargo](https://github.com/rust-lang/cargo/issues/4866) where the dependencies and dev-dependecies features are unified. With the dev-dependecies I couldn't find a way to disable serde default features
- This also means that we cannot run the tests

Error handling becomes a bit more difficult, specially parts of the code that make heavy use of std::io::Error. 

