### PR TITLE
Return EOF on truncated numbers

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -496,7 +496,10 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
 
         if !at_least_one_digit {
-            return Err(self.peek_error(ErrorCode::InvalidNumber));
+            match try!(self.peek()) {
+                Some(_) => return Err(self.peek_error(ErrorCode::InvalidNumber)),
+                None => return Err(self.peek_error(ErrorCode::EofWhileParsingValue)),
+            }
         }
 
         match try!(self.peek_or_null()) {
@@ -680,7 +683,10 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
 
         if !at_least_one_digit {
-            return Err(self.peek_error(ErrorCode::InvalidNumber));
+            match try!(self.peek()) {
+                Some(_) => return Err(self.peek_error(ErrorCode::InvalidNumber)),
+                None => return Err(self.peek_error(ErrorCode::EofWhileParsingValue)),
+            }
         }
 
         match try!(self.peek_or_null()) {

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -92,6 +92,26 @@ fn test_json_stream_truncated_decimal() {
 }
 
 #[test]
+fn test_json_stream_truncated_negative() {
+    let data = "{\"x\":-";
+
+    test_stream!(data, Value, |stream| {
+        assert!(stream.next().unwrap().unwrap_err().is_eof());
+        assert_eq!(stream.byte_offset(), 0);
+    });
+}
+
+#[test]
+fn test_json_stream_truncated_exponent() {
+    let data = "{\"x\":4e";
+
+    test_stream!(data, Value, |stream| {
+        assert!(stream.next().unwrap().unwrap_err().is_eof());
+        assert_eq!(stream.byte_offset(), 0);
+    });
+}
+
+#[test]
 fn test_json_stream_empty() {
     let data = "";
 

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -82,6 +82,16 @@ fn test_json_stream_truncated() {
 }
 
 #[test]
+fn test_json_stream_truncated_decimal() {
+    let data = "{\"x\":4.";
+
+    test_stream!(data, Value, |stream| {
+        assert!(stream.next().unwrap().unwrap_err().is_eof());
+        assert_eq!(stream.byte_offset(), 0);
+    });
+}
+
+#[test]
 fn test_json_stream_empty() {
     let data = "";
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -737,15 +737,15 @@ fn test_parse_number_errors() {
     test_parse_err::<f64>(&[
         ("+", "expected value at line 1 column 1"),
         (".", "expected value at line 1 column 1"),
-        ("-", "invalid number at line 1 column 1"),
+        ("-", "EOF while parsing a value at line 1 column 1"),
         ("00", "invalid number at line 1 column 2"),
         ("0x80", "trailing characters at line 1 column 2"),
         ("\\0", "expected value at line 1 column 1"),
         ("1.", "EOF while parsing a value at line 1 column 2"),
         ("1.a", "invalid number at line 1 column 3"),
         ("1.e1", "invalid number at line 1 column 3"),
-        ("1e", "invalid number at line 1 column 2"),
-        ("1e+", "invalid number at line 1 column 3"),
+        ("1e", "EOF while parsing a value at line 1 column 2"),
+        ("1e+", "EOF while parsing a value at line 1 column 3"),
         ("1a", "trailing characters at line 1 column 2"),
         (
             "100e777777777777777777777777777",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -741,7 +741,7 @@ fn test_parse_number_errors() {
         ("00", "invalid number at line 1 column 2"),
         ("0x80", "trailing characters at line 1 column 2"),
         ("\\0", "expected value at line 1 column 1"),
-        ("1.", "invalid number at line 1 column 2"),
+        ("1.", "EOF while parsing a value at line 1 column 2"),
         ("1.a", "invalid number at line 1 column 3"),
         ("1.e1", "invalid number at line 1 column 3"),
         ("1e", "invalid number at line 1 column 2"),


### PR DESCRIPTION
My attempt at fixing #524. First commit fixes that issue, the second commit also fixes a similar issue with truncated negative numbers ("-") and truncated exponents ("1e" and "1e+").