### PR TITLE
Add hashbrown as option for serde_json::Value::Map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,12 @@ serde = "1.0.60"
 indexmap = { version = "1.0", optional = true }
 itoa = "0.4.3"
 ryu = "0.2"
-hashbrown = "*"
+
+# Use a different representation for the map type of serde_json::Value.
+# This improves performance but will not imoplement a DoubleEndedItterator.
+# This feature is incompatible with preserve_order.
+
+hashbrown = { version = "0.1", optional = true }
 
 [dev-dependencies]
 automod = "0.1"
@@ -44,6 +49,7 @@ default = []
 # Use a different representation for the map type of serde_json::Value.
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.
+# This feature is incompatible with hashbrown.
 preserve_order = ["indexmap"]
 
 # Use an arbitrary precision number representation for serde_json::Number. This

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1.0.60"
 indexmap = { version = "1.0", optional = true }
 itoa = "0.4.3"
 ryu = "0.2"
+hashbrown = "*"
 
 [dev-dependencies]
 automod = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,8 @@
 
 #[macro_use]
 extern crate serde;
+#[cfg(feature = "hashbrown")]
+extern crate hashbrown;
 #[cfg(feature = "preserve_order")]
 extern crate indexmap;
 extern crate itoa;


### PR DESCRIPTION
Using hashbrown for serde_json::Value gives a up to 10% improvement
in serialization/deserialization performance. On the flip side it
looses the option of a double ended itterator. This adds it as a
feature flag allowing people to choose it if it should suite their
needs.