### PR TITLE
fix outdated reference to serde macro location

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ largely automatically.
 </a>
 
 ```rust
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Result;
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
The `Serialize` and `Deserialize` macros are no longer part of `serde` and have been moved to `serde_derive`