### PR TITLE
Extended support for binary data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1.0.60"
 indexmap = { version = "1.0", optional = true }
 itoa = "0.4.3"
 ryu = "1.0"
+hex = { version = "0.3.2", default-features = false, optional = true }
 
 [dev-dependencies]
 automod = "0.1"
@@ -63,3 +64,6 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+# Enables hex crate and API for hex-encoded binary strings
+binary_hex = ["hex"]

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,0 +1,12 @@
+/// Specifies the way to encode serde "bytes" type into JSON.
+pub enum BinaryMode {
+    /// Encodes serde "bytes" type as an array of numbers.
+    /// This is the original behavior of `serde_json`, and it is not recommended if you have binary
+    /// data: you could encode, but then you may not decode if the data type does not explicitly support
+    /// deserializing from a "sequence of numbers".
+    Array,
+
+    /// Encodes serde "bytes" type as hex-encoded string.
+    #[cfg(feature = "binary_hex")]
+    Hex,
+}

--- a/src/de.rs
+++ b/src/de.rs
@@ -2215,7 +2215,15 @@ where
     R: Read<'de>,
     T: de::Deserialize<'de>,
 {
-    let mut de = Deserializer::new(read);
+    from_trait_with_binary_mode(read, BinaryMode::Array)
+}
+
+fn from_trait_with_binary_mode<'de, R, T>(read: R, binary_mode: BinaryMode) -> Result<T>
+where
+    R: Read<'de>,
+    T: de::Deserialize<'de>,
+{
+    let mut de = Deserializer::new_with_binary_mode(read, binary_mode);
     let value = try!(de::Deserialize::deserialize(&mut de));
 
     // Make sure the whole stream has been consumed.
@@ -2295,6 +2303,15 @@ where
     from_trait(read::IoRead::new(rdr))
 }
 
+/// See `from_reader`.
+pub fn from_reader_with_binary_mode<R, T>(rdr: R, binary_mode: BinaryMode) -> Result<T>
+where
+    R: io::Read,
+    T: de::DeserializeOwned,
+{
+    from_trait_with_binary_mode(read::IoRead::new(rdr), binary_mode)
+}
+
 /// Deserialize an instance of type `T` from bytes of JSON text.
 ///
 /// # Example
@@ -2337,6 +2354,14 @@ where
     from_trait(read::SliceRead::new(v))
 }
 
+/// See `from_slice`.
+pub fn from_slice_with_binary_mode<'a, T>(v: &'a [u8], binary_mode: BinaryMode) -> Result<T>
+where
+    T: de::Deserialize<'a>,
+{
+    from_trait_with_binary_mode(read::SliceRead::new(v), binary_mode)
+}
+
 /// Deserialize an instance of type `T` from a string of JSON text.
 ///
 /// # Example
@@ -2377,4 +2402,12 @@ where
     T: de::Deserialize<'a>,
 {
     from_trait(read::StrRead::new(s))
+}
+
+/// See `from_str`.
+pub fn from_str_with_binary_mode<'a, T>(s: &'a str, binary_mode: BinaryMode) -> Result<T>
+where
+    T: de::Deserialize<'a>,
+{
+    from_trait_with_binary_mode(read::StrRead::new(s), binary_mode)
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -6,9 +6,9 @@ use std::result;
 use std::str::FromStr;
 use std::{i32, u64};
 
-use serde::de::{self, Expected, Unexpected};
 use super::binary::BinaryMode;
 use super::error::{Error, ErrorCode, Result};
+use serde::de::{self, Expected, Unexpected};
 
 use read::{self, Reference};
 
@@ -674,7 +674,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 buf.push(b as char);
                 Ok(b)
             }
-            None => Err(self.error(ErrorCode::EofWhileParsingValue))
+            None => Err(self.error(ErrorCode::EofWhileParsingValue)),
         }
     }
 
@@ -1456,11 +1456,11 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                     BinaryMode::Hex => {
                         use std::ops::Deref;
                         let bytes: &[u8] = str_ref.deref();
-                        let bytes = try!(hex::decode(bytes).map_err(|_| self.peek_error(ErrorCode::InvalidHexEncoding)));
+                        let bytes = try!(hex::decode(bytes)
+                            .map_err(|_| self.peek_error(ErrorCode::InvalidHexEncoding)));
                         visitor.visit_bytes(&bytes)
                     }
                 }
-                
             }
             b'[' => self.deserialize_seq(visitor),
             _ => Err(self.peek_invalid_type(&visitor)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,6 +73,8 @@ impl Error {
             | ErrorCode::TrailingCharacters
             | ErrorCode::UnexpectedEndOfHexEscape
             | ErrorCode::RecursionLimitExceeded => Category::Syntax,
+            #[cfg(feature = "binary_hex")]
+            ErrorCode::InvalidHexEncoding => Category::Syntax,
         }
     }
 
@@ -252,6 +254,10 @@ pub enum ErrorCode {
 
     /// Encountered nesting of JSON maps and arrays more than 128 layers deep.
     RecursionLimitExceeded,
+
+    /// Invalid hex 
+    #[cfg(feature = "binary_hex")]
+    InvalidHexEncoding,
 }
 
 impl Error {
@@ -329,6 +335,8 @@ impl Display for ErrorCode {
             ErrorCode::TrailingCharacters => f.write_str("trailing characters"),
             ErrorCode::UnexpectedEndOfHexEscape => f.write_str("unexpected end of hex escape"),
             ErrorCode::RecursionLimitExceeded => f.write_str("recursion limit exceeded"),
+            #[cfg(feature = "binary_hex")]
+            ErrorCode::InvalidHexEncoding => f.write_str("invalid hex encoding"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -255,7 +255,7 @@ pub enum ErrorCode {
     /// Encountered nesting of JSON maps and arrays more than 128 layers deep.
     RecursionLimitExceeded,
 
-    /// Invalid hex 
+    /// Invalid hex
     #[cfg(feature = "binary_hex")]
     InvalidHexEncoding,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,10 +327,11 @@ extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
 
-#[cfg(feature="binary_hex")]
+#[cfg(feature = "binary_hex")]
 extern crate hex;
 
-
+#[doc(inline)]
+pub use self::binary::BinaryMode;
 #[doc(inline)]
 pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]
@@ -341,8 +342,6 @@ pub use self::ser::{
 };
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
-#[doc(inline)]
-pub use self::binary::BinaryMode;
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
@@ -364,13 +363,13 @@ pub mod map;
 pub mod ser;
 pub mod value;
 
+mod binary;
 mod iter;
 mod number;
 mod read;
-mod binary;
 
 /// FIXME: this is a temporary shortcut to enable binary2hex tests
-#[cfg(feature="binary_hex")]
+#[cfg(feature = "binary_hex")]
 pub use read::StrRead as StrReadForTestsOnlyDoNotUse;
 
 #[cfg(feature = "raw_value")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,10 @@ pub use self::binary::BinaryMode;
 #[doc(inline)]
 pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]
+pub use self::de::{
+    from_reader_with_binary_mode, from_slice_with_binary_mode, from_str_with_binary_mode,
+};
+#[doc(inline)]
 pub use self::error::{Error, Result};
 #[doc(inline)]
 pub use self::ser::{
@@ -367,10 +371,6 @@ mod binary;
 mod iter;
 mod number;
 mod read;
-
-/// FIXME: this is a temporary shortcut to enable binary2hex tests
-#[cfg(feature = "binary_hex")]
-pub use read::StrRead as StrReadForTestsOnlyDoNotUse;
 
 #[cfg(feature = "raw_value")]
 mod raw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,10 @@ extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
 
+#[cfg(feature="binary_hex")]
+extern crate hex;
+
+
 #[doc(inline)]
 pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]
@@ -337,6 +341,8 @@ pub use self::ser::{
 };
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
+#[doc(inline)]
+pub use self::binary::BinaryMode;
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
@@ -361,6 +367,11 @@ pub mod value;
 mod iter;
 mod number;
 mod read;
+mod binary;
+
+/// FIXME: this is a temporary shortcut to enable binary2hex tests
+#[cfg(feature="binary_hex")]
+pub use read::StrRead as StrReadForTestsOnlyDoNotUse;
 
 #[cfg(feature = "raw_value")]
 mod raw;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -5,8 +5,8 @@ use std::io;
 use std::num::FpCategory;
 use std::str;
 
-use super::error::{Error, ErrorCode, Result};
 use super::binary::BinaryMode;
+use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible, Serialize};
 
 use itoa;
@@ -53,14 +53,18 @@ where
         Serializer {
             writer: writer,
             formatter: formatter,
-            binary_mode: BinaryMode::Array
+            binary_mode: BinaryMode::Array,
         }
     }
 
     /// Creates a new JSON visitor whose output will be written to the writer
     /// specified, with explicit choice of formatter (compact or pretty)
     #[inline]
-    pub fn with_formatter_and_binary_mode(writer: W, formatter: F, binary_mode: BinaryMode) -> Self {
+    pub fn with_formatter_and_binary_mode(
+        writer: W,
+        formatter: F,
+        binary_mode: BinaryMode,
+    ) -> Self {
         Serializer {
             writer: writer,
             formatter: formatter,
@@ -249,11 +253,9 @@ where
                     try!(seq.serialize_element(byte));
                 }
                 seq.end()
-            },
+            }
             #[cfg(feature = "binary_hex")]
-            BinaryMode::Hex => {
-                self.serialize_str(&hex::encode(value))
-            },
+            BinaryMode::Hex => self.serialize_str(&hex::encode(value)),
         }
     }
 
@@ -1141,9 +1143,7 @@ where
         match self.ser.binary_mode {
             BinaryMode::Array => Err(key_must_be_a_string()),
             #[cfg(feature = "binary_hex")]
-            BinaryMode::Hex => {
-                self.serialize_str(&hex::encode(_value))
-            },
+            BinaryMode::Hex => self.serialize_str(&hex::encode(_value)),
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -32,8 +32,8 @@ use serde::ser::{self, Serialize, Serializer};
 use serde_bytes::{ByteBuf, Bytes};
 
 use serde_json::{
-    from_reader, from_slice, from_str, from_value, to_string, to_string_pretty, to_value, to_vec,
-    to_writer, Deserializer, Number, Value,
+    from_reader, from_slice, from_str, from_str_with_binary_mode, from_value, to_string,
+    to_string_pretty, to_value, to_vec, to_writer, Deserializer, Number, Value,
 };
 
 macro_rules! treemap {
@@ -1658,7 +1658,6 @@ fn test_byte_buf_de_multiple() {
 #[test]
 fn test_bytes_hex_ser_de() {
     use serde_json::ser::CompactFormatter;
-    use serde_json::StrReadForTestsOnlyDoNotUse as StrRead;
     use serde_json::{BinaryMode, Serializer};
     use std::collections::HashMap;
 
@@ -1676,11 +1675,7 @@ fn test_bytes_hex_ser_de() {
     where
         T: de::Deserialize<'a>,
     {
-        let mut de = Deserializer::new_with_binary_mode(StrRead::new(s), BinaryMode::Hex);
-        let value = de::Deserialize::deserialize(&mut de).expect("Should deserialize");
-        // Make sure the whole stream has been consumed.
-        de.end().expect("Should consume the whole stream");
-        value
+        from_str_with_binary_mode(s, BinaryMode::Hex).expect("Should deserialize")
     }
 
     // Encode/decode empty buffer

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -33,7 +33,7 @@ use serde_bytes::{ByteBuf, Bytes};
 
 use serde_json::{
     from_reader, from_slice, from_str, from_value, to_string, to_string_pretty, to_value, to_vec,
-    to_writer, Deserializer, Number, Value
+    to_writer, Deserializer, Number, Value,
 };
 
 macro_rules! treemap {
@@ -1654,18 +1654,21 @@ fn test_byte_buf_de_multiple() {
     assert_eq!(vec![a, b], s);
 }
 
-#[cfg(feature="binary_hex")]
+#[cfg(feature = "binary_hex")]
 #[test]
 fn test_bytes_hex_ser_de() {
-    use std::collections::HashMap;
-    use serde_json::{BinaryMode, Serializer};
     use serde_json::ser::CompactFormatter;
     use serde_json::StrReadForTestsOnlyDoNotUse as StrRead;
-    
+    use serde_json::{BinaryMode, Serializer};
+    use std::collections::HashMap;
+
     fn to_string_with_hex<T: Serialize>(value: &T) -> String {
         let mut vec = Vec::with_capacity(128);
-        let mut ser = Serializer::with_formatter_and_binary_mode(&mut vec, CompactFormatter, BinaryMode::Hex);
-        value.serialize(&mut ser).expect("Serialization should work");
+        let mut ser =
+            Serializer::with_formatter_and_binary_mode(&mut vec, CompactFormatter, BinaryMode::Hex);
+        value
+            .serialize(&mut ser)
+            .expect("Serialization should work");
         String::from_utf8(vec).expect("Should not emit invalid UTF-8")
     }
 
@@ -1693,18 +1696,21 @@ fn test_bytes_hex_ser_de() {
     assert_eq!(to_string_with_hex(&bytes), "\"010203\"".to_string());
     let bytes2: ByteBuf = from_str_with_hex("\"010203\"");
     assert_eq!(bytes2.into_vec(), buf);
-    
-    // TBD: add ser/de test for binary keys in hashmap 
+
+    // TBD: add ser/de test for binary keys in hashmap
     let mut dict = HashMap::new();
     dict.insert(ByteBuf::from(vec![1, 2, 3]), ByteBuf::from(vec![4, 5, 6]));
-    assert_eq!(to_string_with_hex(&dict), "{\"010203\":\"040506\"}".to_string());
+    assert_eq!(
+        to_string_with_hex(&dict),
+        "{\"010203\":\"040506\"}".to_string()
+    );
 
     dict = from_str_with_hex("{\"010203\":\"040506\"}");
-    let vec: Vec<(_,_)> = dict.into_iter().collect();
-    assert_eq!(vec, vec![(
-        ByteBuf::from(vec![1, 2, 3]),
-        ByteBuf::from(vec![4, 5, 6])
-    )]);
+    let vec: Vec<(_, _)> = dict.into_iter().collect();
+    assert_eq!(
+        vec,
+        vec![(ByteBuf::from(vec![1, 2, 3]), ByteBuf::from(vec![4, 5, 6]))]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This is a draft PR, would love to hear some feedback to decide what is the best way to move forward. Thanks!

## Summary

This adds optional flag to encode binary data types (those that use `(de)serialize_bytes`) in JSON via hex-encoded strings. The flag requires setting a compile-time feature `"binary_hex"`, and then constructing a Serializer and Deserializer with the new constructors that permit additional parameter `BinaryMode`. Currently two modes are provided: `::Array` (default) and `::Hex`.

## Problem

Currently, `serde_json` does not work well with binary data types (e.g. with cryptographic libraries: keys, signatures, proofs, etc). For an example, please see serialization of Scalars and Points in https://github.com/dalek-cryptography/curve25519-dalek and serialization of zero-knowledge proof in https://github.com/dalek-cryptography/bulletproofs/

* Binary data is serialized as an array of numbers, which is suboptimal encoding.
* Deserialization of "bytes" fails because `serde_json` expectedly calls `visit_seq` when decoding array of numbers, while the target data type only implements `visit_bytes` (for symmetry with its serialization code).
* Additionally, serialization of binary keys fails since arrays cannot be valid keys. Encoding those values as strings would fix this problem.

## Compatibility

Existing users will have the same behavior: binary data is encoded as array of numbers.

Users who add the feature flag `"binary_hex"`, but do not update the code, also retain the original behavior.

## Issue: API

Currently the deserialization API consists of pure functions such as `from_str`, `from_slice`. The abstract reader API necessary to construct a deserializer with `::new(reader, binary_mode)` is not public. ~For the purposes of this draft PR I have simply exported `StrReader` to be used in tests, but this is obviously not how it should be done.~ UPD: fixed.

One way to fix this is to pair existing functions with siblings `_with_binary_mode()` that allows specifying the encoding for the binary data. (UPDATE: this is what i've done in this PR)

Alternatively, there could be a one-stop API that permits specifying both the mode, and the input type, but that may be more complex to implement, as we'd need to publish various reader types.

## Issue: other encoding formats

There are two ways to support alternative encoding formats:

1. Add extra options to the `BinaryMode` enum, e.g. `Base64`, and enable them as optional dependencies through additional feature flags like `"binary_base64"`.
2. Add "custom encoder" facility that lets user handle transcoding between bytes and strings, so they can plug in arbitrary hex or base64 library and also be able to customize strictness (e.g. "only lowercase is accepted"). This seems to me like a better idea in general.

## Issue: mixing different formats

This patch should not pose a problem to those who seek to mix different binary-encoding formats: if someone is already encoding binary data into strings, this change should not affect them. Only the data that's explicitly (de)serialized as serde "bytes" type is affected.
