### PR TITLE
add no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ serde = { version = "1.0.60", default-features = false, features = ["alloc"] }
 indexmap = { version = "1.0", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
-core_io = { version = "0.1.20190701", optional = true }
 
 [dev-dependencies]
 automod = "0.1"
@@ -66,7 +65,4 @@ raw_value = []
 unbounded_depth = []
 
 # enable std support (enabled by default)
-std = [ "itoa/std" ]
-
-# enable no_std support
-no_std = [ "core_io" ]
+std = [ "itoa/std", "serde/std" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ travis-ci = { repository = "serde-rs/json" }
 appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
-serde = "1.0.60"
+serde = { version = "1.0.60", default-features = false, features = ["alloc"] }
 indexmap = { version = "1.0", optional = true }
-itoa = "0.4.3"
+itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
+core_io = { version = "0.1.20190701", optional = true }
 
 [dev-dependencies]
 automod = "0.1"
@@ -39,7 +40,7 @@ features = ["raw_value"]
 ### FEATURES #################################################################
 
 [features]
-default = []
+default = [ "std" ]
 
 # Use a different representation for the map type of serde_json::Value.
 # This allows data to be read into a Value and written back to a JSON string
@@ -63,3 +64,9 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+# enable std support (enabled by default)
+std = [ "itoa/std" ]
+
+# enable no_std support
+no_std = [ "core_io" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "serde-rs/json" }
 appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
-serde = { version = "1.0.60", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.60", default-features = false }
 indexmap = { version = "1.0", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
@@ -65,4 +65,6 @@ raw_value = []
 unbounded_depth = []
 
 # enable std support (enabled by default)
-std = [ "itoa/std", "serde/std" ]
+std = ["itoa/std", "serde/std"]
+
+alloc = ["serde/alloc"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,29 +1,27 @@
 //! Deserialize JSON data to a Rust data structure.
 
-#[cfg(not(feature = "no_std"))]
-use std::io;
-#[cfg(feature = "no_std")]
-use core_io as io;
-#[cfg(not(feature = "no_std"))]
-use std::marker::PhantomData;
-#[cfg(feature = "no_std")]
-use core::marker::PhantomData;
-#[cfg(not(feature = "no_std"))]
-use std::result;
-#[cfg(feature = "no_std")]
-use core::result;
-#[cfg(not(feature = "no_std"))]
-use std::str::FromStr;
-#[cfg(feature = "no_std")]
-use core::str::FromStr;
-#[cfg(not(feature = "no_std"))]
-use std::{i32, u64};
-#[cfg(feature = "no_std")]
-use core::{i32, u64};
-#[cfg(feature = "no_std")]
-use alloc::vec::Vec;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use core::marker::PhantomData;
+#[cfg(not(feature = "std"))]
+use core::result;
+#[cfg(not(feature = "std"))]
+use core::str::FromStr;
+#[cfg(not(feature = "std"))]
+use core::{i32, u64};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::marker::PhantomData;
+#[cfg(feature = "std")]
+use std::result;
+#[cfg(feature = "std")]
+use std::str::FromStr;
+#[cfg(feature = "std")]
+use std::{i32, u64};
 
 use serde::de::{self, Expected, Unexpected};
 
@@ -31,7 +29,9 @@ use super::error::{Error, ErrorCode, Result};
 
 use read::{self, Reference};
 
-pub use read::{IoRead, Read, SliceRead, StrRead};
+#[cfg(feature = "std")]
+pub use read::IoRead;
+pub use read::{Read, SliceRead, StrRead};
 
 use number::Number;
 #[cfg(feature = "arbitrary_precision")]
@@ -82,6 +82,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<R> Deserializer<read::IoRead<R>>
 where
     R: io::Read,
@@ -665,7 +666,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 buf.push(b as char);
                 Ok(b)
             }
-            None => Err(self.error(ErrorCode::EofWhileParsingValue))
+            None => Err(self.error(ErrorCode::EofWhileParsingValue)),
         }
     }
 
@@ -2267,6 +2268,7 @@ where
 /// is wrong with the data, for example required struct fields are missing from
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
+#[cfg(feature = "std")]
 pub fn from_reader<R, T>(rdr: R) -> Result<T>
 where
     R: io::Read,

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,10 +1,29 @@
 //! Deserialize JSON data to a Rust data structure.
 
+#[cfg(not(feature = "no_std"))]
 use std::io;
+#[cfg(feature = "no_std")]
+use core_io as io;
+#[cfg(not(feature = "no_std"))]
 use std::marker::PhantomData;
+#[cfg(feature = "no_std")]
+use core::marker::PhantomData;
+#[cfg(not(feature = "no_std"))]
 use std::result;
+#[cfg(feature = "no_std")]
+use core::result;
+#[cfg(not(feature = "no_std"))]
 use std::str::FromStr;
+#[cfg(feature = "no_std")]
+use core::str::FromStr;
+#[cfg(not(feature = "no_std"))]
 use std::{i32, u64};
+#[cfg(feature = "no_std")]
+use core::{i32, u64};
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(feature = "no_std")]
+use alloc::string::String;
 
 use serde::de::{self, Expected, Unexpected};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,27 @@
 //! When serializing or deserializing JSON goes wrong.
 
+#[cfg(not(feature = "no_std"))]
 use std::error;
+#[cfg(not(feature = "no_std"))]
 use std::fmt::{self, Debug, Display};
+#[cfg(feature = "no_std")]
+use core::fmt::{self, Debug, Display};
+#[cfg(not(feature = "no_std"))]
 use std::io;
+#[cfg(feature = "no_std")]
+use core_io as io;
+#[cfg(not(feature = "no_std"))]
 use std::result;
+#[cfg(feature = "no_std")]
+use core::result;
+#[cfg(not(feature = "no_std"))]
 use std::str::FromStr;
+#[cfg(feature = "no_std")]
+use core::str::FromStr;
+#[cfg(feature = "no_std")]
+use alloc::boxed::Box;
+#[cfg(feature = "no_std")]
+use alloc::string::{String, ToString};
 
 use serde::de;
 use serde::ser;
@@ -159,6 +176,7 @@ impl From<Error> for io::Error {
     ///     }
     /// }
     /// ```
+    #[cfg(not(feature = "no_std"))]
     fn from(j: Error) -> Self {
         if let ErrorCode::Io(err) = j.err.code {
             err
@@ -167,6 +185,19 @@ impl From<Error> for io::Error {
                 Category::Io => unreachable!(),
                 Category::Syntax | Category::Data => io::Error::new(io::ErrorKind::InvalidData, j),
                 Category::Eof => io::Error::new(io::ErrorKind::UnexpectedEof, j),
+            }
+        }
+    }
+
+    #[cfg(feature = "no_std")]
+    fn from(j: Error) -> Self {
+        if let ErrorCode::Io(err) = j.err.code {
+            err
+        } else {
+            match j.classify() {
+                Category::Io => unreachable!(),
+                Category::Syntax | Category::Data => io::Error::new(io::ErrorKind::InvalidData, "Symtax error"),
+                Category::Eof => io::Error::new(io::ErrorKind::UnexpectedEof, "Eof"),
             }
         }
     }
@@ -333,6 +364,7 @@ impl Display for ErrorCode {
     }
 }
 
+#[cfg(not(feature = "no_std"))]
 impl error::Error for Error {
     fn description(&self) -> &str {
         match self.err.code {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,7 @@
+#[cfg(not(feature = "no_std"))]
 use std::io;
+#[cfg(feature = "no_std")]
+use core_io as io;
 
 pub struct LineColIterator<I> {
     iter: I,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,7 +1,4 @@
-#[cfg(not(feature = "no_std"))]
 use std::io;
-#[cfg(feature = "no_std")]
-use core_io as io;
 
 pub struct LineColIterator<I> {
     iter: I,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,37 +319,34 @@
     redundant_field_names,
 ))]
 #![deny(missing_docs)]
-#![cfg_attr(feature = "no_std", no_std)]
-#[cfg(not(any(feature = "std", feature = "no_std")))]
-compile_error!("std and no_std are both disabled!");
-#[cfg(all(feature = "std", feature = "no_std"))]
-compile_error!("std and no_std cannot both be enabled!");
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
 extern crate serde;
+#[cfg(not(feature = "std"))]
+extern crate alloc;
 #[cfg(feature = "preserve_order")]
 extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
-#[cfg(feature = "no_std")]
-extern crate core_io;
-#[cfg(feature = "no_std")]
-extern crate alloc;
 
 #[doc(inline)]
-pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
+#[cfg(feature = "std")]
+pub use self::de::from_reader;
+#[doc(inline)]
+pub use self::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]
 pub use self::error::{Error, Result};
 #[doc(inline)]
-pub use self::ser::{
-    to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer,
-};
+pub use self::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty, Serializer};
+#[cfg(feature = "std")]
+pub use self::ser::{to_writer, to_writer_pretty};
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 macro_rules! try {
     ($e:expr) => {
         match $e {
@@ -358,7 +355,7 @@ macro_rules! try {
         }
     };
 }
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 macro_rules! try {
     ($e:expr) => {
         match $e {
@@ -377,9 +374,11 @@ pub mod map;
 pub mod ser;
 pub mod value;
 
+#[cfg(feature = "std")]
 mod iter;
 mod number;
 mod read;
+mod write;
 
 #[cfg(feature = "raw_value")]
 mod raw;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,11 @@ pub use self::ser::{to_writer, to_writer_pretty};
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
 
+#[cfg(not(any(feature = "std", feature = "alloc")))]
+compile_error!("std and alloc are both disabled");
+#[cfg(all(feature = "std", feature = "alloc"))]
+compile_error!("std and alloc are both enabled");
+
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
 #[cfg(feature = "std")]

--- a/src/map.rs
+++ b/src/map.rs
@@ -7,15 +7,34 @@
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
 use serde::{de, ser};
+#[cfg(not(feature = "no_std"))]
 use std::borrow::Borrow;
+#[cfg(feature = "no_std")]
+use core::borrow::Borrow;
+#[cfg(not(feature = "no_std"))]
 use std::fmt::{self, Debug};
+#[cfg(feature = "no_std")]
+use core::fmt::{self, Debug};
+#[cfg(not(feature = "no_std"))]
 use std::hash::Hash;
+#[cfg(feature = "no_std")]
+use core::hash::Hash;
+#[cfg(not(feature = "no_std"))]
 use std::iter::FromIterator;
+#[cfg(feature = "no_std")]
+use core::iter::FromIterator;
+#[cfg(not(feature = "no_std"))]
 use std::ops;
+#[cfg(feature = "no_std")]
+use core::ops;
 use value::Value;
+#[cfg(feature = "no_std")]
+use alloc::string::String;
 
-#[cfg(not(feature = "preserve_order"))]
+#[cfg(all(not(feature = "no_std"), not(feature = "preserve_order")))]
 use std::collections::{btree_map, BTreeMap};
+#[cfg(all(feature = "no_std", not(feature = "preserve_order")))]
+use alloc::collections::{btree_map, BTreeMap};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -137,8 +156,10 @@ impl Map<String, Value> {
     {
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
-        #[cfg(not(feature = "preserve_order"))]
+        #[cfg(all(not(feature = "preserve_order"), not(feature = "no_std")))]
         use std::collections::btree_map::Entry as EntryImpl;
+        #[cfg(all(not(feature = "preserve_order"), feature = "no_std"))]
+        use alloc::collections::btree_map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant: vacant }),

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,35 +6,35 @@
 //! [`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
-use serde::{de, ser};
-#[cfg(not(feature = "no_std"))]
-use std::borrow::Borrow;
-#[cfg(feature = "no_std")]
-use core::borrow::Borrow;
-#[cfg(not(feature = "no_std"))]
-use std::fmt::{self, Debug};
-#[cfg(feature = "no_std")]
-use core::fmt::{self, Debug};
-#[cfg(not(feature = "no_std"))]
-use std::hash::Hash;
-#[cfg(feature = "no_std")]
-use core::hash::Hash;
-#[cfg(not(feature = "no_std"))]
-use std::iter::FromIterator;
-#[cfg(feature = "no_std")]
-use core::iter::FromIterator;
-#[cfg(not(feature = "no_std"))]
-use std::ops;
-#[cfg(feature = "no_std")]
-use core::ops;
-use value::Value;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use core::borrow::Borrow;
+#[cfg(not(feature = "std"))]
+use core::fmt::{self, Debug};
+#[cfg(not(feature = "std"))]
+use core::hash::Hash;
+#[cfg(not(feature = "std"))]
+use core::iter::FromIterator;
+#[cfg(not(feature = "std"))]
+use core::ops;
+use serde::{de, ser};
+#[cfg(feature = "std")]
+use std::borrow::Borrow;
+#[cfg(feature = "std")]
+use std::fmt::{self, Debug};
+#[cfg(feature = "std")]
+use std::hash::Hash;
+#[cfg(feature = "std")]
+use std::iter::FromIterator;
+#[cfg(feature = "std")]
+use std::ops;
+use value::Value;
 
-#[cfg(all(not(feature = "no_std"), not(feature = "preserve_order")))]
-use std::collections::{btree_map, BTreeMap};
-#[cfg(all(feature = "no_std", not(feature = "preserve_order")))]
+#[cfg(all(not(feature = "std"), not(feature = "preserve_order")))]
 use alloc::collections::{btree_map, BTreeMap};
+#[cfg(all(feature = "std", not(feature = "preserve_order")))]
+use std::collections::{btree_map, BTreeMap};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -154,12 +154,12 @@ impl Map<String, Value> {
     where
         S: Into<String>,
     {
+        #[cfg(all(not(feature = "preserve_order"), not(feature = "std")))]
+        use alloc::collections::btree_map::Entry as EntryImpl;
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
-        #[cfg(all(not(feature = "preserve_order"), not(feature = "no_std")))]
+        #[cfg(all(not(feature = "preserve_order"), feature = "std"))]
         use std::collections::btree_map::Entry as EntryImpl;
-        #[cfg(all(not(feature = "preserve_order"), feature = "no_std"))]
-        use alloc::collections::btree_map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant: vacant }),

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,7 +1,10 @@
 use error::Error;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(not(feature = "no_std"))]
 use std::fmt::{self, Debug, Display};
+#[cfg(feature = "no_std")]
+use core::fmt::{self, Debug, Display};
 
 #[cfg(feature = "arbitrary_precision")]
 use itoa;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,10 +1,10 @@
+#[cfg(not(feature = "std"))]
+use core::fmt::{self, Debug, Display};
 use error::Error;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-#[cfg(not(feature = "no_std"))]
+#[cfg(feature = "std")]
 use std::fmt::{self, Debug, Display};
-#[cfg(feature = "no_std")]
-use core::fmt::{self, Debug, Display};
 
 #[cfg(feature = "arbitrary_precision")]
 use itoa;

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,21 +1,20 @@
-#[cfg(not(feature = "no_std"))]
-use std::ops::Deref;
-#[cfg(feature = "no_std")]
-use core::ops::Deref;
-#[cfg(not(feature = "no_std"))]
-use std::{char, cmp, str};
-#[cfg(feature = "no_std")]
-use core::{char, cmp, str};
-#[cfg(not(feature = "no_std"))]
-use std::io;
-#[cfg(feature = "no_std")]
-use core_io as io;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use core::ops::Deref;
+#[cfg(not(feature = "std"))]
+use core::{char, cmp, str};
+#[cfg(feature = "std")]
+use std::io;
+#[cfg(feature = "std")]
+use std::ops::Deref;
+#[cfg(feature = "std")]
+use std::{char, cmp, str};
 
 #[cfg(feature = "raw_value")]
 use serde::de::Visitor;
 
+#[cfg(feature = "std")]
 use iter::LineColIterator;
 
 use error::{Error, ErrorCode, Result};
@@ -130,6 +129,7 @@ impl<'b, 'c, T: ?Sized + 'static> Deref for Reference<'b, 'c, T> {
 }
 
 /// JSON input source that reads from a std::io input stream.
+#[cfg(feature = "std")]
 pub struct IoRead<R>
 where
     R: io::Read,
@@ -169,6 +169,7 @@ mod private {
 
 //////////////////////////////////////////////////////////////////////////////
 
+#[cfg(feature = "std")]
 impl<R> IoRead<R>
 where
     R: io::Read,
@@ -193,8 +194,10 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<R> private::Sealed for IoRead<R> where R: io::Read {}
 
+#[cfg(feature = "std")]
 impl<R> IoRead<R>
 where
     R: io::Read,
@@ -233,6 +236,7 @@ where
     }
 }
 
+#[cfg(feature = "std")]
 impl<'de, R> Read<'de> for IoRead<R>
 where
     R: io::Read,

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,5 +1,17 @@
+#[cfg(not(feature = "no_std"))]
 use std::ops::Deref;
-use std::{char, cmp, io, str};
+#[cfg(feature = "no_std")]
+use core::ops::Deref;
+#[cfg(not(feature = "no_std"))]
+use std::{char, cmp, str};
+#[cfg(feature = "no_std")]
+use core::{char, cmp, str};
+#[cfg(not(feature = "no_std"))]
+use std::io;
+#[cfg(feature = "no_std")]
+use core_io as io;
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
 
 #[cfg(feature = "raw_value")]
 use serde::de::Visitor;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,9 +1,29 @@
 //! Serialize a Rust data structure into JSON data.
 
+#[cfg(not(feature = "no_std"))]
+use std::result;
+#[cfg(feature = "no_std")]
+use core::result;
+#[cfg(not(feature = "no_std"))]
 use std::fmt;
+#[cfg(feature = "no_std")]
+use core::fmt;
+#[cfg(not(feature = "no_std"))]
 use std::io;
+#[cfg(feature = "no_std")]
+use core_io as io;
+#[cfg(not(feature = "no_std"))]
 use std::num::FpCategory;
+#[cfg(feature = "no_std")]
+use core::num::FpCategory;
+#[cfg(not(feature = "no_std"))]
 use std::str;
+#[cfg(feature = "no_std")]
+use core::str;
+#[cfg(feature = "no_std")]
+use alloc::string::{String, ToString};
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
 
 use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible, Serialize};
@@ -460,7 +480,10 @@ where
     where
         T: fmt::Display,
     {
+        #[cfg(not(feature = "no_std"))]
         use std::fmt::Write;
+        #[cfg(feature = "no_std")]
+        use core::fmt::Write;
 
         struct Adapter<'ser, W: 'ser, F: 'ser> {
             writer: &'ser mut W,
@@ -1634,6 +1657,7 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_i8<W: ?Sized>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
     where
         W: io::Write,
@@ -1643,6 +1667,18 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_i8<W: ?Sized>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
+    }
+
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_i16<W: ?Sized>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
     where
         W: io::Write,
@@ -1652,6 +1688,18 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_i16<W: ?Sized>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
+    }
+
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_i32<W: ?Sized>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
     where
         W: io::Write,
@@ -1661,6 +1709,18 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_i32<W: ?Sized>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
+    }
+
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_i64<W: ?Sized>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
     where
         W: io::Write,
@@ -1668,8 +1728,20 @@ pub trait Formatter {
         itoa::write(writer, value).map(drop)
     }
 
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_i64<W: ?Sized>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
+    }
+
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
     where
         W: io::Write,
@@ -1679,6 +1751,18 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_u16<W: ?Sized>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
     where
         W: io::Write,
@@ -1688,6 +1772,18 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_u16<W: ?Sized>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_u32<W: ?Sized>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
     where
         W: io::Write,
@@ -1697,11 +1793,34 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_u32<W: ?Sized>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "no_std"))]
     fn write_u64<W: ?Sized>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
     where
         W: io::Write,
     {
         itoa::write(writer, value).map(drop)
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "no_std")]
+    fn write_u64<W: ?Sized>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buf = itoa::Buffer::new();
+        writer.write(buf.format(value).as_bytes()).map(drop)
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
@@ -2180,6 +2299,20 @@ where
     Ok(())
 }
 
+// extra type needed so we can implement Write for FakeVec
+struct VecBox<'v>(&'v mut Vec<u8>);
+
+impl<'v> io::Write for VecBox<'v> {
+    fn write(&mut self, data: &[u8]) -> result::Result<usize, io::Error> {
+        self.0.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self)  -> result::Result<(), io::Error> {
+        Ok(())
+    }
+}
+
 /// Serialize the given data structure as a JSON byte vector.
 ///
 /// # Errors
@@ -2192,7 +2325,8 @@ where
     T: Serialize,
 {
     let mut writer = Vec::with_capacity(128);
-    try!(to_writer(&mut writer, value));
+    let mut fake_vec = VecBox(&mut writer);
+    try!(to_writer(&mut fake_vec, value));
     Ok(writer)
 }
 
@@ -2208,7 +2342,8 @@ where
     T: Serialize,
 {
     let mut writer = Vec::with_capacity(128);
-    try!(to_writer_pretty(&mut writer, value));
+    let mut fake_vec = VecBox(&mut writer);
+    try!(to_writer_pretty(&mut fake_vec, value));
     Ok(writer)
 }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -16,6 +16,8 @@ use std::fmt;
 use std::num::FpCategory;
 #[cfg(feature = "std")]
 use std::str;
+#[cfg(feature = "std")]
+use std::io::Write;
 
 use super::error::{Error, ErrorCode, Result};
 use super::write;
@@ -2050,7 +2052,7 @@ where
 #[cfg(feature = "std")]
 pub fn to_writer<W, T: ?Sized>(mut writer: W, value: &T) -> Result<()>
 where
-    W: std::io::Write,
+    W: Write,
     T: Serialize,
 {
     let writer = write::IoWrite(&mut writer);
@@ -2080,7 +2082,7 @@ where
 #[cfg(feature = "std")]
 pub fn to_writer_pretty<W, T: ?Sized>(mut writer: W, value: &T) -> Result<()>
 where
-    W: std::io::Write,
+    W: Write,
     T: Serialize,
 {
     let writer = write::IoWrite(&mut writer);

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2099,8 +2099,10 @@ where
     T: Serialize,
 {
     let mut writer = Vec::with_capacity(128);
-    let vec_writer = write::VecWriter(&mut writer);
-    to_internal_writer(vec_writer, value)?;
+    {
+        let vec_writer = write::VecWriter(&mut writer);
+        to_internal_writer(vec_writer, value)?;
+    }
     Ok(writer)
 }
 
@@ -2116,8 +2118,10 @@ where
     T: Serialize,
 {
     let mut writer = Vec::with_capacity(128);
-    let vec_writer = write::VecWriter(&mut writer);
-    to_internal_writer_pretty(vec_writer, value)?;
+    {
+        let vec_writer = write::VecWriter(&mut writer);
+        to_internal_writer_pretty(vec_writer, value)?;
+    }
     Ok(writer)
 }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,8 +1,29 @@
+#[cfg(not(feature = "no_std"))]
 use std::borrow::Cow;
+#[cfg(feature = "no_std")]
+use alloc::borrow::Cow;
+#[cfg(not(feature = "no_std"))]
 use std::fmt;
+#[cfg(feature = "no_std")]
+use core::fmt;
+#[cfg(not(feature = "no_std"))]
 use std::slice;
+#[cfg(feature = "no_std")]
+use core::slice;
+#[cfg(not(feature = "no_std"))]
 use std::str;
+#[cfg(feature = "no_std")]
+use core::str;
+#[cfg(not(feature = "no_std"))]
 use std::vec;
+#[cfg(feature = "no_std")]
+use alloc::vec;
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(feature = "no_std")]
+use alloc::string::String;
+#[cfg(feature = "no_std")]
+use alloc::borrow::ToOwned;
 
 use serde;
 use serde::de::{

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,29 +1,29 @@
-#[cfg(not(feature = "no_std"))]
-use std::borrow::Cow;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::borrow::Cow;
-#[cfg(not(feature = "no_std"))]
-use std::fmt;
-#[cfg(feature = "no_std")]
-use core::fmt;
-#[cfg(not(feature = "no_std"))]
-use std::slice;
-#[cfg(feature = "no_std")]
-use core::slice;
-#[cfg(not(feature = "no_std"))]
-use std::str;
-#[cfg(feature = "no_std")]
-use core::str;
-#[cfg(not(feature = "no_std"))]
-use std::vec;
-#[cfg(feature = "no_std")]
-use alloc::vec;
-#[cfg(feature = "no_std")]
-use alloc::vec::Vec;
-#[cfg(feature = "no_std")]
-use alloc::string::String;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::slice;
+#[cfg(not(feature = "std"))]
+use core::str;
+#[cfg(feature = "std")]
+use std::borrow::Cow;
+#[cfg(feature = "std")]
+use std::fmt;
+#[cfg(feature = "std")]
+use std::slice;
+#[cfg(feature = "std")]
+use std::str;
+#[cfg(feature = "std")]
+use std::vec;
 
 use serde;
 use serde::de::{

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,4 +1,16 @@
+#[cfg(not(feature = "no_std"))]
 use std::borrow::Cow;
+#[cfg(feature = "no_std")]
+use alloc::borrow::Cow;
+#[cfg(feature = "no_std")]
+use alloc::string::{String, ToString};
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+
+#[cfg(not(feature = "no_std"))]
+use ::std::iter::FromIterator;
+#[cfg(feature = "no_std")]
+use ::core::iter::FromIterator;
 
 use super::Value;
 use map::Map;
@@ -182,7 +194,7 @@ impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
     }
 }
 
-impl<T: Into<Value>> ::std::iter::FromIterator<T> for Value {
+impl<T: Into<Value>> FromIterator<T> for Value {
     /// Convert an iteratable type to a `Value`
     ///
     /// # Examples

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,16 +1,16 @@
-#[cfg(not(feature = "no_std"))]
-use std::borrow::Cow;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::borrow::Cow;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::string::{String, ToString};
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use std::borrow::Cow;
 
-#[cfg(not(feature = "no_std"))]
-use ::std::iter::FromIterator;
-#[cfg(feature = "no_std")]
-use ::core::iter::FromIterator;
+#[cfg(not(feature = "std"))]
+use core::iter::FromIterator;
+#[cfg(feature = "std")]
+use std::iter::FromIterator;
 
 use super::Value;
 use map::Map;

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,15 +1,15 @@
-#[cfg(not(feature = "no_std"))]
-use std::fmt;
-#[cfg(feature = "no_std")]
-use core::fmt;
-#[cfg(not(feature = "no_std"))]
-use std::ops;
-#[cfg(feature = "no_std")]
-use core::ops;
-#[cfg(feature = "no_std")]
-use alloc::string::String;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
+use alloc::string::String;
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::ops;
+#[cfg(feature = "std")]
+use std::fmt;
+#[cfg(feature = "std")]
+use std::ops;
 
 use super::Value;
 use map::Map;
@@ -142,7 +142,7 @@ where
 
 // Prevent users from implementing the Index trait.
 mod private {
-    #[cfg(feature = "no_std")]
+    #[cfg(not(feature = "std"))]
     use alloc::string::String;
 
     pub trait Sealed {}

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,5 +1,15 @@
+#[cfg(not(feature = "no_std"))]
 use std::fmt;
+#[cfg(feature = "no_std")]
+use core::fmt;
+#[cfg(not(feature = "no_std"))]
 use std::ops;
+#[cfg(feature = "no_std")]
+use core::ops;
+#[cfg(feature = "no_std")]
+use alloc::string::String;
+#[cfg(feature = "no_std")]
+use alloc::borrow::ToOwned;
 
 use super::Value;
 use map::Map;
@@ -132,6 +142,9 @@ where
 
 // Prevent users from implementing the Index trait.
 mod private {
+    #[cfg(feature = "no_std")]
+    use alloc::string::String;
+
     pub trait Sealed {}
     impl Sealed for usize {}
     impl Sealed for str {}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -92,10 +92,26 @@
 //! [from_slice]: https://docs.serde.rs/serde_json/de/fn.from_slice.html
 //! [from_reader]: https://docs.serde.rs/serde_json/de/fn.from_reader.html
 
+#[cfg(not(feature = "no_std"))]
 use std::fmt::{self, Debug};
+#[cfg(feature = "no_std")]
+use core::fmt::{self, Debug};
+#[cfg(not(feature = "no_std"))]
 use std::io;
+#[cfg(feature = "no_std")]
+use core_io as io;
+#[cfg(not(feature = "no_std"))]
 use std::mem;
+#[cfg(feature = "no_std")]
+use core::mem;
+#[cfg(not(feature = "no_std"))]
 use std::str;
+#[cfg(feature = "no_std")]
+use core::str;
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(feature = "no_std")]
+use alloc::string::String;
 
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,5 +1,5 @@
 use super::Value;
-#[cfg(feature = "no_std")]
+#[cfg(not(feature = "std"))]
 use alloc::string::String;
 
 fn eq_i64(value: &Value, other: i64) -> bool {
@@ -61,7 +61,7 @@ impl PartialEq<Value> for String {
 macro_rules! partialeq_numeric {
     ($($eq:ident [$($ty:ty)*])*) => {
         $($(
-            #[cfg(not(feature = "no_std"))]
+            #[cfg(feature = "std")]
             impl PartialEq<$ty> for Value {
                 fn eq(&self, other: &$ty) -> bool {
                     $eq(self, *other as _)

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,4 +1,6 @@
 use super::Value;
+#[cfg(feature = "no_std")]
+use alloc::string::String;
 
 fn eq_i64(value: &Value, other: i64) -> bool {
     value.as_i64().map_or(false, |i| i == other)
@@ -59,6 +61,7 @@ impl PartialEq<Value> for String {
 macro_rules! partialeq_numeric {
     ($($eq:ident [$($ty:ty)*])*) => {
         $($(
+            #[cfg(not(feature = "no_std"))]
             impl PartialEq<$ty> for Value {
                 fn eq(&self, other: &$ty) -> bool {
                     $eq(self, *other as _)

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,16 +1,16 @@
 use serde::ser::Impossible;
 use serde::{self, Serialize};
 
+#[cfg(not(feature = "std"))]
+use alloc::borrow::ToOwned;
+#[cfg(not(feature = "std"))]
+use alloc::string::{String, ToString};
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
 use error::{Error, ErrorCode};
 use map::Map;
 use number::Number;
 use value::{to_value, Value};
-#[cfg(feature = "no_std")]
-use alloc::string::{String, ToString};
-#[cfg(feature = "no_std")]
-use alloc::vec::Vec;
-#[cfg(feature = "no_std")]
-use alloc::borrow::ToOwned;
 
 impl Serialize for Value {
     #[inline]

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -5,6 +5,12 @@ use error::{Error, ErrorCode};
 use map::Map;
 use number::Number;
 use value::{to_value, Value};
+#[cfg(feature = "no_std")]
+use alloc::string::{String, ToString};
+#[cfg(feature = "no_std")]
+use alloc::vec::Vec;
+#[cfg(feature = "no_std")]
+use alloc::borrow::ToOwned;
 
 impl Serialize for Value {
     #[inline]

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,157 @@
+#[cfg(not(feature = "std"))]
+use alloc::string::ToString;
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use core::fmt;
+#[cfg(not(feature = "std"))]
+use core::str;
+use error::{Error, ErrorCode, Result};
+use ser;
+#[cfg(feature = "std")]
+use std::fmt;
+#[cfg(feature = "std")]
+use std::str;
+
+pub trait Write: private::Sealed {
+    fn write(&mut self, buf: &[u8]) -> Result<usize>;
+    fn flush(&mut self) -> Result<()>;
+
+    fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
+        while !buf.is_empty() {
+            match self.write(buf) {
+                Ok(0) => {
+                    return Err(Error::syntax(
+                        ErrorCode::Message(
+                            "failed to write whole buffer".to_string().into_boxed_str(),
+                        ),
+                        0,
+                        0,
+                    ))
+                }
+                Ok(n) => buf = &buf[n..],
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "std")]
+    fn as_io_write(&mut self) -> ImplIoWrite<'_>
+    where
+        Self: Sized,
+    {
+        ImplIoWrite(self)
+    }
+}
+
+#[doc(hidden)]
+#[cfg(feature = "std")]
+pub struct ImplIoWrite<'v>(&'v mut dyn Write);
+
+#[cfg(feature = "std")]
+impl<'v> std::io::Write for ImplIoWrite<'v> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .write(buf)
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "io error"))
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.0
+            .flush()
+            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "io error"))
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+pub struct WriterFormatter<'a, 'b: 'a> {
+    pub inner: &'a mut fmt::Formatter<'b>,
+}
+
+impl<'a, 'b> private::Sealed for WriterFormatter<'a, 'b> {}
+
+impl<'a, 'b> Write for WriterFormatter<'a, 'b> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        fn error<E>(_: E) -> Error {
+            // Error value does not matter because fmt::Display impl below just
+            // maps it to fmt::Error
+            Error::syntax(
+                ErrorCode::Message("fmt error".to_string().into_boxed_str()),
+                0,
+                0,
+            )
+        }
+        let s = try!(str::from_utf8(buf).map_err(error));
+        try!(self.inner.write_str(s).map_err(error));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+// extra type needed so we can implement Write for Vec
+pub struct VecWriter<'v>(pub &'v mut Vec<u8>);
+
+impl<'v> private::Sealed for VecWriter<'v> {}
+
+impl<'v> Write for VecWriter<'v> {
+    fn write(&mut self, data: &[u8]) -> Result<usize> {
+        self.0.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[doc(hidden)]
+pub struct Adapter<'ser, W: 'ser, F: 'ser> {
+    pub writer: &'ser mut W,
+    pub formatter: &'ser mut F,
+    pub error: Option<Error>,
+}
+
+impl<'ser, W, F> fmt::Write for Adapter<'ser, W, F>
+where
+    W: Write,
+    F: ser::Formatter,
+{
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        assert!(self.error.is_none());
+        match ser::format_escaped_str_contents(self.writer, self.formatter, s) {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                self.error = Some(err);
+                Err(fmt::Error)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+pub struct IoWrite<'i>(pub &'i mut std::io::Write);
+
+#[cfg(feature = "std")]
+impl<'i> private::Sealed for IoWrite<'i> {}
+
+#[cfg(feature = "std")]
+impl<'i> Write for IoWrite<'i> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.0.write(buf).map_err(Error::io)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        self.0.flush().map_err(Error::io)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        self.0.write_all(buf).map_err(Error::io)
+    }
+}

--- a/src/write.rs
+++ b/src/write.rs
@@ -12,6 +12,8 @@ use ser;
 use std::fmt;
 #[cfg(feature = "std")]
 use std::str;
+#[cfg(feature = "std")]
+use std::io;
 
 pub trait Write: private::Sealed {
     fn write(&mut self, buf: &[u8]) -> Result<usize>;
@@ -50,17 +52,17 @@ pub trait Write: private::Sealed {
 pub struct ImplIoWrite<'v>(&'v mut Write);
 
 #[cfg(feature = "std")]
-impl<'v> std::io::Write for ImplIoWrite<'v> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+impl<'v> io::Write for ImplIoWrite<'v> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0
             .write(buf)
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "io error"))
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "io error"))
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
+    fn flush(&mut self) -> io::Result<()> {
         self.0
             .flush()
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "io error"))
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "io error"))
     }
 }
 
@@ -136,7 +138,7 @@ where
 }
 
 #[cfg(feature = "std")]
-pub struct IoWrite<'i>(pub &'i mut std::io::Write);
+pub struct IoWrite<'i>(pub &'i mut io::Write);
 
 #[cfg(feature = "std")]
 impl<'i> private::Sealed for IoWrite<'i> {}

--- a/src/write.rs
+++ b/src/write.rs
@@ -39,8 +39,7 @@ pub trait Write: private::Sealed {
     }
 
     #[cfg(feature = "std")]
-    #[allow(clippy::needless_lifetimes)]
-    fn as_io_write<'a>(&'a mut self) -> ImplIoWrite<'a>
+    fn as_io_write(&mut self) -> ImplIoWrite
     where
         Self: Sized,
     {

--- a/src/write.rs
+++ b/src/write.rs
@@ -39,7 +39,8 @@ pub trait Write: private::Sealed {
     }
 
     #[cfg(feature = "std")]
-    fn as_io_write(&mut self) -> ImplIoWrite<'_>
+    #[allow(clippy::needless_lifetimes)]
+    fn as_io_write<'a>(&'a mut self) -> ImplIoWrite<'a>
     where
         Self: Sized,
     {

--- a/src/write.rs
+++ b/src/write.rs
@@ -47,7 +47,7 @@ pub trait Write: private::Sealed {
 
 #[doc(hidden)]
 #[cfg(feature = "std")]
-pub struct ImplIoWrite<'v>(&'v mut dyn Write);
+pub struct ImplIoWrite<'v>(&'v mut Write);
 
 #[cfg(feature = "std")]
 impl<'v> std::io::Write for ImplIoWrite<'v> {


### PR DESCRIPTION
I really needed JSON serde support for a no_std project. I managed to add two new features "std" and "no_std" to support both std and no_std/alloc environments. I know that there is a serde_json_core crate, but this crate doesn't offer full json support such as escapes values.

Usually, one only adds one feature for "std" and has that be enabled by default, but in this specific case, I decided to add a no_std feature because I needed to depend on core_io for no_std support (AFAIK there is no way to conditionally disable a dependency with a feature hence the no_std feature).

Due to the way core_io works, this will only compile one some specific compiler versions (the latest one being nightly-2019-07-01)

I should also note that the tests can only be run in std mode. Some of the dev dependencies depend on serde with std enabled and that causes std to be enabled globally. This only affects the tests though, if this crate is used in another crate as a dependency the dev dependencies don't kick in.