### PR TITLE
Return None instead of lossy f64 conversion

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -207,9 +207,11 @@ impl Number {
     pub fn as_f64(&self) -> Option<f64> {
         #[cfg(not(feature = "arbitrary_precision"))]
         match self.n {
-            N::PosInt(n) => Some(n as f64),
-            N::NegInt(n) => Some(n as f64),
+            // 9007199254740993 is the first non-representable integer
+            N::PosInt(n) if n < 9007199254740993 => Some(n as f64),
+            N::NegInt(n) if n > -9007199254740993 => Some(n as f64),
             N::Float(n) => Some(n),
+            _ => None,
         }
         #[cfg(feature = "arbitrary_precision")]
         self.n.parse().ok()

--- a/src/number.rs
+++ b/src/number.rs
@@ -216,11 +216,11 @@ impl Number {
 
         #[cfg(feature = "arbitrary_precision")]
         // 16 == length of "9007199254740993"
-        match self.n.len() {
-            0..=15 => self.n.parse().ok(),
+        match (self.n.chars().next().unwrap(), self.n.len()) {
+            (_, 0..=15) | ('-', 16) | ('1'..='8', 16) => self.n.parse().ok(),
             // GT | EQ implies an 'e' 'E' or too high
-            16 if self.n.as_str() < "9007199254740993" => self.n.parse().ok(),
-            // Leading zeroes are invalid, so length is significant
+            ('-', 17) if self.n.as_str() < "-9007199254740993" => self.n.parse().ok(),
+            ('9', 16) if self.n.as_str() < "9007199254740993" => self.n.parse().ok(),
             _ => {
                 for c in self.n.chars() {
                     if c == '.' || c == 'e' || c == 'E' {

--- a/src/number.rs
+++ b/src/number.rs
@@ -217,7 +217,7 @@ impl Number {
         #[cfg(feature = "arbitrary_precision")]
         // 16 == length of "9007199254740993"
         match (self.n.chars().next().unwrap(), self.n.len()) {
-            (_, 0..=15) | ('-', 16) | ('1'..='8', 16) => self.n.parse().ok(),
+            (_, 0...15) | ('-', 16) | ('1'...'8', 16) => self.n.parse().ok(),
             // GT | EQ implies an 'e' 'E' or too high
             ('-', 17) if self.n.as_str() < "-9007199254740993" => self.n.parse().ok(),
             ('9', 16) if self.n.as_str() < "9007199254740993" => self.n.parse().ok(),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2206,5 +2206,12 @@ fn test_integers_as_f64() {
         } else {
             unreachable!()
         }
+
+        // This number is a valid f64, if not for leading zeroes.
+        // The string length is used in the arbitrary precision conversion logic.
+        match Number::from_str("00009007199254740992") {
+            Ok(number) => assert_eq!(9007199254740992.0, number.as_f64().unwrap()),
+            Err(_) => {},
+        }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2206,12 +2206,31 @@ fn test_integers_as_f64() {
         } else {
             unreachable!()
         }
+    }
 
-        // This number is a valid f64, if not for leading zeroes.
-        // The string length is used in the arbitrary precision conversion logic.
-        match Number::from_str("00009007199254740992") {
-            Ok(number) => assert_eq!(9007199254740992.0, number.as_f64().unwrap()),
-            Err(_) => {},
-        }
+    // This number is a valid f64, if not for leading zeroes.
+    // The string length is used in the arbitrary precision conversion logic.
+    match Number::from_str("00009007199254740992") {
+        Ok(number) => assert_eq!(9007199254740992.0, number.as_f64().unwrap()),
+        Err(_) => {},
+    }
+    match Number::from_str("-00009007199254740992") {
+        Ok(number) => assert_eq!(-9007199254740992.0, number.as_f64().unwrap()),
+        Err(_) => {},
+    }
+    for &value in [
+        "-9007199254740992",
+        "9007199254740992",
+        "-999999999999999",
+        "999999999999999",
+    ].iter() {
+        let parsed: f64 = value.parse().unwrap();
+        let converted =
+            Number::from_str(value).expect(value)
+                .as_f64().expect(value);
+        assert_eq!(
+            parsed,
+            converted,
+        )
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2179,3 +2179,32 @@ fn test_borrow_in_map_key() {
     let value = json!({ "map": { "1": null } });
     Outer::deserialize(&value).unwrap();
 }
+
+#[test]
+fn test_integers_as_f64() {
+    for &value in [
+        1,
+        -1,
+        0,
+        9007199254740992,
+        9007199254740993,
+        9007199254740994,
+        9999999999999999,
+        -9007199254740992,
+        -9007199254740993,
+        -9007199254740994,
+        -9999999999999999,
+        i64::MAX,
+        i64::MIN,
+    ].iter() {
+        let number = Number::from_str(&format!("{}", value)).unwrap();
+        if let Some(signed) = number.as_i64() {
+            assert_eq!(signed, value);
+            if let Some(float) = number.as_f64() {
+                assert_eq!(signed, float as i64);
+            }
+        } else {
+            unreachable!()
+        }
+    }
+}


### PR DESCRIPTION
Most numbers representable by `u64` and `i64` aren't representable as `f64` starting from `+/- 9007199254740993`. As per documentation, these should return `None`.