### PR TITLE
Add `impl From<()> for Value`

### DIFF
--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -211,3 +211,19 @@ impl<T: Into<Value>> ::std::iter::FromIterator<T> for Value {
         Value::Array(iter.into_iter().map(Into::into).collect())
     }
 }
+
+impl From<()> for Value {
+    /// Convert `()` to `Value`
+    ///
+    /// # Examples
+    ///
+    /// ```edition2018
+    /// use serde_json::Value;
+    ///
+    /// let u = ();
+    /// let x: Value = u.into();
+    /// ```
+    fn from((): ()) -> Self {
+        Value::Null
+    }
+}


### PR DESCRIPTION
Hey there,

this tiny PR adds the conversion from `()` to `Value::Null`.

I feel this is justified as serde_json already perceives `()` as the JSON value `null`:
```
println!("{:?}", serde_json::from_str::<()>("null"));
// prints `Ok(())`
    
println!("{:?}", serde_json::to_string(&()));
// prints `Ok("null")`
```
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=0eac935756f3537acdf45486dcabb4db

Cheers,
Felix

PS: Please have a look at the marvelous signature of `<Value as From<()>>::from` :laughing: 