### PR TITLE
Fix number deserialization with `arbitrary_precision`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+[patch.crates-io]
+serde = { git = "https://github.com/bkchr/serde.git", branch = "bkchr-tagged-content-u128-i128" }

--- a/src/de.rs
+++ b/src/de.rs
@@ -111,7 +111,7 @@ impl ParserNumber {
     where
         V: de::Visitor<'de>,
     {
-        let err = || Err(super::number::invalid_number());
+        let err = || Err(Error::syntax(ErrorCode::InvalidNumber, 0, 0));
 
         serde_if_integer128! {
             let res = if let Some(val) = number.parse::<i128>().ok() {

--- a/src/number.rs
+++ b/src/number.rs
@@ -245,14 +245,6 @@ impl Number {
             None
         }
     }
-
-    #[cfg(feature = "arbitrary_precision")]
-    /// Not public API. Only tests use this.
-    #[doc(hidden)]
-    #[inline]
-    pub fn from_string_unchecked(n: String) -> Self {
-        Number { n: n }
-    }
 }
 
 impl fmt::Display for Number {

--- a/src/number.rs
+++ b/src/number.rs
@@ -444,7 +444,7 @@ impl<'de> de::Deserialize<'de> for NumberFromString {
 }
 
 #[cfg(feature = "arbitrary_precision")]
-fn invalid_number() -> Error {
+pub(crate) fn invalid_number() -> Error {
     Error::syntax(ErrorCode::InvalidNumber, 0, 0)
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -436,7 +436,7 @@ impl<'de> de::Deserialize<'de> for NumberFromString {
 }
 
 #[cfg(feature = "arbitrary_precision")]
-pub(crate) fn invalid_number() -> Error {
+fn invalid_number() -> Error {
     Error::syntax(ErrorCode::InvalidNumber, 0, 0)
 }
 

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -50,6 +50,19 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Value::Number(value.into()))
             }
 
+            #[cfg(feature = "arbitrary_precision")]
+            serde_if_integer128! {
+                #[inline]
+                fn visit_i128<E>(self, value: i128) -> Result<Value, E> {
+                    Ok(Value::Number(value.into()))
+                }
+
+                #[inline]
+                fn visit_u128<E>(self, value: u128) -> Result<Value, E> {
+                    Ok(Value::Number(value.into()))
+                }
+            }
+
             #[inline]
             fn visit_f64<E>(self, value: f64) -> Result<Value, E> {
                 Ok(Number::from_f64(value).map_or(Value::Null, Value::Number))

--- a/tests/regression/issue505.rs
+++ b/tests/regression/issue505.rs
@@ -1,0 +1,22 @@
+use serde_derive::Deserialize;
+
+#[derive(Deserialize)]
+struct Data {
+    _value: i32,
+    _value2: i128,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+enum Wrapper {
+    Data(Data),
+}
+
+#[test]
+fn test() {
+    let json = r#"{"type":"Data","_value":123,"_value2":123244235436463}"#;
+    // Okay
+    let _data1: Data = serde_json::from_str(json).unwrap();
+    // Fails!
+    let _data2: Wrapper = serde_json::from_str(json).unwrap();
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -956,21 +956,6 @@ fn test_parse_number() {
         ("\t1.0", "invalid number at line 1 column 1"),
         ("1.0\t", "invalid number at line 1 column 4"),
     ]);
-
-    #[cfg(feature = "arbitrary_precision")]
-    test_parse_ok(vec![
-        ("1e999", Number::from_string_unchecked("1e999".to_owned())),
-        ("-1e999", Number::from_string_unchecked("-1e999".to_owned())),
-        ("1e-999", Number::from_string_unchecked("1e-999".to_owned())),
-        (
-            "2.3e999",
-            Number::from_string_unchecked("2.3e999".to_owned()),
-        ),
-        (
-            "-2.3e999",
-            Number::from_string_unchecked("-2.3e999".to_owned()),
-        ),
-    ]);
 }
 
 #[test]


### PR DESCRIPTION
When we have a struct that uses `#[serde(flatten)]` and the feature
`arbitrary_precision` is enabled, the deserialization. The problem was
that the arbitrary number was forwarded as a "map" to the visitor and in
a later step this map failed as a number was expected.

Fixes: https://github.com/serde-rs/json/issues/505

Requires: https://github.com/serde-rs/serde/pull/1679