### PR TITLE
Fix Required Minimum `indexmap` Version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
 serde = "1.0.60"
-indexmap = { version = "1.0", optional = true }
+indexmap = { version = "1.2", optional = true }
 itoa = "0.4.3"
 ryu = "1.0"
 


### PR DESCRIPTION
The `preserve-order` feature uses `indexmap::map::OccupiedEntry::swap_remove` method which was only added in `1.2`, however, the `Cargo.toml` incorrectly requires `^1.0`.