### PR TITLE
Implement IntoDeserializer for Value

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -479,6 +479,14 @@ impl<'de> EnumAccess<'de> for EnumDeserializer {
     }
 }
 
+impl<'de> IntoDeserializer<'de, Error> for Value {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
 struct VariantDeserializer {
     value: Option<Value>,
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -26,7 +26,7 @@ use std::{f32, f64};
 use std::{i16, i32, i64, i8};
 use std::{u16, u32, u64, u8};
 
-use serde::de::{self, Deserialize, IgnoredAny};
+use serde::de::{self, Deserialize, IgnoredAny, IntoDeserializer};
 use serde::ser::{self, Serialize, Serializer};
 
 use serde_bytes::{ByteBuf, Bytes};
@@ -2178,4 +2178,23 @@ fn test_borrow_in_map_key() {
 
     let value = json!({ "map": { "1": null } });
     Outer::deserialize(&value).unwrap();
+}
+
+#[test]
+fn test_value_into_deserializer() {
+    #[derive(Deserialize)]
+    struct Outer {
+        inner: Inner,
+    }
+
+    #[derive(Deserialize)]
+    struct Inner {
+        string: String,
+    }
+
+    let mut map = BTreeMap::new();
+    map.insert("inner", json!({ "string": "Hello World" }));
+
+    let outer = Outer::deserialize(map.into_deserializer()).unwrap();
+    assert_eq!(outer.inner.string, "Hello World");
 }


### PR DESCRIPTION
This allows users to deserialize from types like `HashMap<String, Value>`.