### PR TITLE
Added more raw functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -344,6 +344,8 @@ pub use self::ser::{
 };
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
+#[cfg(feature = "raw_value")]
+pub use self::value::{from_raw, to_raw};
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -345,7 +345,7 @@ pub use self::ser::{
 #[doc(inline)]
 pub use self::value::{from_value, to_value, Map, Number, Value};
 #[cfg(feature = "raw_value")]
-pub use self::value::{from_raw, to_raw};
+pub use self::value::to_raw;
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.

--- a/src/number.rs
+++ b/src/number.rs
@@ -18,7 +18,7 @@ use error::ErrorCode;
 #[cfg(feature = "arbitrary_precision")]
 /// Not public API. Should be pub(crate).
 #[doc(hidden)]
-pub const TOKEN: &'static str = "$serde_json::private::Number";
+pub const TOKEN: &str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
 #[derive(Clone, PartialEq)]
@@ -746,6 +746,8 @@ impl Number {
     // Not public API. Should be pub(crate).
     #[doc(hidden)]
     #[cold]
+    // This function does not compile with clippy, despite the below allow.
+    #[allow(clippy::unused_self)]
     pub fn unexpected(&self) -> Unexpected {
         Unexpected::Other("number")
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -746,8 +746,6 @@ impl Number {
     // Not public API. Should be pub(crate).
     #[doc(hidden)]
     #[cold]
-    // This function does not compile with clippy, despite the below allow.
-    #[allow(clippy::unused_self)]
     pub fn unexpected(&self) -> Unexpected {
         Unexpected::Other("number")
     }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -253,6 +253,22 @@ impl RawValue {
     pub fn get(&self) -> &str {
         &self.json
     }
+
+    /// Converts a `Box<RawValue>` into its JSON text as a boxed str without
+    /// copying or allocating.
+    pub fn into_boxed_str(self: Box<Self>) -> Box<str> {
+        unsafe { mem::transmute::<Box<Self>, Box<str>>(self) }
+    }
+    /// Converts a `Box<RawValue>` into its JSON bytes without copying or
+    /// allocating.
+    pub fn into_boxed_bytes(self: Box<Self>) -> Box<[u8]> {
+        self.into_boxed_str().into_boxed_bytes()
+    }
+    /// Converts a `Box<RawValue>` into its JSON text without copying or
+    /// allocating.
+    pub fn into_string(self: Box<Self>) -> String {
+        self.into_boxed_str().into_string()
+    }
 }
 
 pub const TOKEN: &str = "$serde_json::private::RawValue";

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -793,7 +793,6 @@ where
 
     #[inline]
     fn end(self) -> Result<()> {
-        #[allow(clippy::match_same_arms)]
         match self {
             Compound::Map { .. } => ser::SerializeMap::end(self),
             #[cfg(feature = "arbitrary_precision")]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -793,6 +793,7 @@ where
 
     #[inline]
     fn end(self) -> Result<()> {
+        #[allow(clippy::match_same_arms)]
         match self {
             Compound::Map { .. } => ser::SerializeMap::end(self),
             #[cfg(feature = "arbitrary_precision")]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -103,7 +103,7 @@ pub use map::Map;
 pub use number::Number;
 
 #[cfg(feature = "raw_value")]
-pub use raw::{RawValue, to_raw, from_raw};
+pub use raw::{RawValue, to_raw};
 
 pub use self::index::Index;
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -103,7 +103,7 @@ pub use map::Map;
 pub use number::Number;
 
 #[cfg(feature = "raw_value")]
-pub use raw::RawValue;
+pub use raw::{RawValue, to_raw, from_raw};
 
 pub use self::index::Index;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2078,7 +2078,7 @@ fn test_integer128() {
 fn test_borrowed_raw_value() {
     use serde_json::value::RawValue;
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, PartialEq, Eq)]
     struct Wrapper<'a> {
         a: i8,
         #[serde(borrow)]
@@ -2095,6 +2095,12 @@ fn test_borrowed_raw_value() {
 
     let wrapper_to_value = serde_json::to_value(&wrapper_from_str).unwrap();
     assert_eq!(json!({"a": 1, "b": {"foo": 2}, "c": 3}), wrapper_to_value);
+
+    let wrapper_to_raw = serde_json::to_raw(&wrapper_from_str).unwrap();
+    assert_eq!(r#"{"a":1,"b":{"foo": 2},"c":3}"#, wrapper_to_raw.get());
+
+    let wrapper_from_raw: Wrapper = serde_json::from_raw(&wrapper_to_raw).unwrap();
+    assert_eq!(wrapper_from_str, wrapper_from_raw);
 
     let array_from_str: Vec<&RawValue> =
         serde_json::from_str(r#"["a", 42, {"foo": "bar"}, null]"#).unwrap();
@@ -2136,6 +2142,12 @@ fn test_boxed_raw_value() {
 
     let wrapper_to_value = serde_json::to_value(&wrapper_from_str).unwrap();
     assert_eq!(json!({"a": 1, "b": {"foo": 2}, "c": 3}), wrapper_to_value);
+
+    let wrapper_to_raw = serde_json::to_raw(&wrapper_from_str).unwrap();
+    assert_eq!(r#"{"a":1,"b":{"foo": 2},"c":3}"#, wrapper_to_raw.get());
+
+    let wrapper_from_raw: Wrapper = serde_json::from_raw(&wrapper_to_raw).unwrap();
+    assert_eq!(wrapper_from_str, wrapper_from_raw);
 
     let array_from_str: Vec<Box<RawValue>> =
         serde_json::from_str(r#"["a", 42, {"foo": "bar"}, null]"#).unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2078,7 +2078,7 @@ fn test_integer128() {
 fn test_borrowed_raw_value() {
     use serde_json::value::RawValue;
 
-    #[derive(Serialize, Deserialize, PartialEq, Eq)]
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
     struct Wrapper<'a> {
         a: i8,
         #[serde(borrow)]
@@ -2099,9 +2099,6 @@ fn test_borrowed_raw_value() {
     let wrapper_to_raw = serde_json::to_raw(&wrapper_from_str).unwrap();
     assert_eq!(r#"{"a":1,"b":{"foo": 2},"c":3}"#, wrapper_to_raw.get());
 
-    let wrapper_from_raw: Wrapper = serde_json::from_raw(&wrapper_to_raw).unwrap();
-    assert_eq!(wrapper_from_str, wrapper_from_raw);
-
     let array_from_str: Vec<&RawValue> =
         serde_json::from_str(r#"["a", 42, {"foo": "bar"}, null]"#).unwrap();
     assert_eq!(r#""a""#, array_from_str[0].get());
@@ -2118,7 +2115,7 @@ fn test_borrowed_raw_value() {
 fn test_boxed_raw_value() {
     use serde_json::value::RawValue;
 
-    #[derive(Serialize, Deserialize)]
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
     struct Wrapper {
         a: i8,
         b: Box<RawValue>,
@@ -2145,9 +2142,6 @@ fn test_boxed_raw_value() {
 
     let wrapper_to_raw = serde_json::to_raw(&wrapper_from_str).unwrap();
     assert_eq!(r#"{"a":1,"b":{"foo": 2},"c":3}"#, wrapper_to_raw.get());
-
-    let wrapper_from_raw: Wrapper = serde_json::from_raw(&wrapper_to_raw).unwrap();
-    assert_eq!(wrapper_from_str, wrapper_from_raw);
 
     let array_from_str: Vec<Box<RawValue>> =
         serde_json::from_str(r#"["a", 42, {"foo": "bar"}, null]"#).unwrap();


### PR DESCRIPTION
This PR just adds some more useful functions for using RawValues: unsafe functions for converting to RawValues directly from a str, and `to_raw` which converts a Serializable object into a RawValue.

Things to think about:
* I put `to_raw` in both the crate root and the `value` module like `from_value` and `to_value`, but since `RawValue` is in the `value` module, perhaps it should be in the `value` module.
* I didn't implement `from_raw`, as all it is is `get` + `from_str`, and I had some trouble with its lifetimes in the tests.

I also had to make some changes to other parts of the code to get clippy to compile it.