### PR TITLE
Add a no_std/alloc feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - rust: stable
     - rust: beta
     - rust: 1.31.0
+    - rust: 1.36.0
+      script:
+        - cargo build --no-default-features --features alloc
 
     - rust: nightly
       name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "serde-rs/json" }
 [dependencies]
 serde = { version = "1.0.60", default-features = false }
 indexmap = { version = "1.2", optional = true }
-itoa = "0.4.3"
+itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
 
 [dev-dependencies]
@@ -44,7 +44,7 @@ features = ["raw_value"]
 [features]
 default = ["std"]
 
-std = ["serde/std"]
+std = ["serde/std", "itoa/std"]
 
 alloc = ["serde/alloc"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "serde-rs/json" }
 appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
-serde = "1.0.60"
+serde = { version = "1.0.60", default-features = false }
 indexmap = { version = "1.2", optional = true }
 itoa = "0.4.3"
 ryu = "1.0"
@@ -42,7 +42,11 @@ features = ["raw_value"]
 ### FEATURES #################################################################
 
 [features]
-default = []
+default = ["std"]
+
+std = ["serde/std"]
+
+alloc = ["serde/alloc"]
 
 # Use a different representation for the map type of serde_json::Value.
 # This allows data to be read into a Value and written back to a JSON string

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,10 @@ default = ["std"]
 
 std = ["serde/std", "itoa/std"]
 
+# Provide integration for heap-allocated collections without depending on the
+# rest of the Rust standard library.
+# NOTE: Disabling both `std` *and* `alloc` features is not supported yet.
+# Available on Rust 1.36+.
 alloc = ["serde/alloc"]
 
 # Use a different representation for the map type of serde_json::Value.

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,10 +1,14 @@
 //! Deserialize JSON data to a Rust data structure.
 
-use std::io;
-use std::marker::PhantomData;
-use std::result;
-use std::str::FromStr;
-use std::{i32, u64};
+use io;
+use core::marker::PhantomData;
+use core::result;
+use core::str::FromStr;
+use core::{i32, u64};
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use serde::de::{self, Expected, Unexpected};
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,14 +1,9 @@
 //! Deserialize JSON data to a Rust data structure.
 
+use lib::str::FromStr;
+use lib::*;
+
 use io;
-use core::marker::PhantomData;
-use core::result;
-use core::str::FromStr;
-use core::{i32, u64};
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 
 use serde::de::{self, Expected, Unexpected};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,15 @@
 //! When serializing or deserializing JSON goes wrong.
 
+#[cfg(feature = "std")]
 use std::error;
-use std::fmt::{self, Debug, Display};
-use std::io;
-use std::result;
-use std::str::FromStr;
+use core::fmt::{self, Debug, Display};
+use io;
+use core::result;
+use core::str::FromStr;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
 
 use serde::de;
 use serde::ser;
@@ -131,6 +136,7 @@ pub enum Category {
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(fallible_impl_from))]
+#[cfg(feature = "std")]
 impl From<Error> for io::Error {
     /// Convert a `serde_json::Error` into an `io::Error`.
     ///
@@ -333,6 +339,7 @@ impl Display for ErrorCode {
     }
 }
 
+#[cfg(feature = "std")]
 impl error::Error for Error {
     fn source(&self) -> Option<&(error::Error + 'static)> {
         match self.err.code {
@@ -341,6 +348,9 @@ impl error::Error for Error {
         }
     }
 }
+
+#[cfg(not(feature = "std"))]
+impl serde::de::StdError for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,15 +1,9 @@
 //! When serializing or deserializing JSON goes wrong.
 
-#[cfg(feature = "std")]
-use std::error;
-use core::fmt::{self, Debug, Display};
+use lib::str::FromStr;
+use lib::*;
+
 use io;
-use core::result;
-use core::str::FromStr;
-#[cfg(feature = "alloc")]
-use alloc::boxed::Box;
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
 
 use serde::de;
 use serde::ser;

--- a/src/error.rs
+++ b/src/error.rs
@@ -130,7 +130,6 @@ pub enum Category {
 }
 
 #[cfg_attr(feature = "cargo-clippy", allow(fallible_impl_from))]
-#[cfg(feature = "std")]
 impl From<Error> for io::Error {
     /// Convert a `serde_json::Error` into an `io::Error`.
     ///
@@ -333,18 +332,14 @@ impl Display for ErrorCode {
     }
 }
 
-#[cfg(feature = "std")]
-impl error::Error for Error {
-    fn source(&self) -> Option<&(error::Error + 'static)> {
+impl serde::de::StdError for Error {
+    fn source(&self) -> Option<&(serde::de::StdError + 'static)> {
         match self.err.code {
             ErrorCode::Io(ref err) => Some(err),
             _ => None,
         }
     }
 }
-
-#[cfg(not(feature = "std"))]
-impl serde::de::StdError for Error {}
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/features_check/error.rs
+++ b/src/features_check/error.rs
@@ -1,0 +1,1 @@
+"serde_json doesn't work without `alloc` or default `std` feature yet"

--- a/src/features_check/mod.rs
+++ b/src/features_check/mod.rs
@@ -1,0 +1,13 @@
+//! Shows a user-friendly compiler error on incompatible selected features.
+
+#[allow(unused_macros)]
+macro_rules! hide_from_rustfmt {
+    ($mod:item) => {
+        $mod
+    };
+}
+
+#[cfg(all(not(feature = "std"), not(feature = "alloc")))]
+hide_from_rustfmt! {
+    mod error;
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,79 @@
+#[cfg(not(feature = "std"))]
+use core::slice;
+
+#[cfg(feature = "std")]
+pub use std::io::{Result, Write, Read, Error, Bytes, ErrorKind};
+
+#[cfg(not(feature = "std"))]
+pub type Error = &'static str;
+
+#[cfg(not(feature = "std"))]
+pub type Result<T> = core::result::Result<T, Error>;
+
+#[cfg(not(feature = "std"))]
+pub trait Write {
+    fn write(&mut self, buf: &[u8]) -> Result<usize>;
+
+    fn write_all(&mut self, mut buf: &[u8]) -> Result<()> {
+        while !buf.is_empty() {
+            match self.write(buf) {
+                Ok(0) => return Err("failed to write whole buffer"),
+                Ok(n) => buf = &buf[n..],
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<()>;
+}
+
+#[cfg(not(feature = "std"))]
+impl<W: Write> Write for &mut W {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        (*self).write(buf)
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        (*self).flush()
+    }
+}
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+impl Write for &mut serde::export::Vec<u8> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        self.extend(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<()> {Ok(())}
+}
+
+#[cfg(not(feature = "std"))]
+pub trait Read {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+    fn bytes(self) -> Bytes<Self> where Self: Sized {
+        Bytes {
+            inner: self,
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+pub struct Bytes<R> {
+    inner: R,
+}
+
+#[cfg(not(feature = "std"))]
+impl<R: Read> Iterator for Bytes<R> {
+    type Item = Result<u8>;
+
+    fn next(&mut self) -> Option<Result<u8>> {
+        let mut byte = 0;
+        match self.inner.read(slice::from_mut(&mut byte)) {
+            Ok(0) => None,
+            Ok(..) => Some(Ok(byte)),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,15 +1,33 @@
+//! A tiny, `no_std`-friendly facade around `std::io`.
+//! Reexports types from `std` when available; otherwise reimplements and
+//! provides some of the core logic.
+//!
+//! The main reason that `std::io` hasn't found itself reexported as part of
+//! the `core` crate is the `std::io::{Read, Write}` traits' reliance on
+//! `std::io::Error`, which may contain internally a heap-allocated `Box<Error>`
+//! and/or now relying on OS-specific `std::backtrace::Backtrace`.
+//!
+//! Because of this, we simply redefine those traits as if the error type is
+//! simply a `&'static str` and reimplement those traits for `core` primitives
+//! or `alloc` types, e.g. `Vec<T>`.
 #[cfg(not(feature = "std"))]
-use core::slice;
+use lib::*;
 
 #[cfg(feature = "std")]
-pub use std::io::{Result, Write, Read, Error, Bytes, ErrorKind};
+pub use std::io::ErrorKind;
 
+#[cfg(feature = "std")]
+pub use std::io::Error;
 #[cfg(not(feature = "std"))]
 pub type Error = &'static str;
 
+#[cfg(feature = "std")]
+pub use std::io::Result;
 #[cfg(not(feature = "std"))]
 pub type Result<T> = core::result::Result<T, Error>;
 
+#[cfg(feature = "std")]
+pub use std::io::Write;
 #[cfg(not(feature = "std"))]
 pub trait Write {
     fn write(&mut self, buf: &[u8]) -> Result<usize>;
@@ -30,35 +48,57 @@ pub trait Write {
 
 #[cfg(not(feature = "std"))]
 impl<W: Write> Write for &mut W {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         (*self).write(buf)
     }
 
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        (*self).write_all(buf)
+    }
+
+    #[inline]
     fn flush(&mut self) -> Result<()> {
         (*self).flush()
     }
 }
 
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
-impl Write for &mut serde::export::Vec<u8> {
+#[cfg(not(feature = "std"))]
+impl Write for Vec<u8> {
+    #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        self.extend(buf);
+        self.extend_from_slice(buf);
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> Result<()> {Ok(())}
-}
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> Result<()> {
+        self.extend_from_slice(buf);
+        Ok(())
+    }
 
-#[cfg(not(feature = "std"))]
-pub trait Read {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
-    fn bytes(self) -> Bytes<Self> where Self: Sized {
-        Bytes {
-            inner: self,
-        }
+    #[inline]
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
     }
 }
 
+#[cfg(feature = "std")]
+pub use std::io::Read;
+#[cfg(not(feature = "std"))]
+pub trait Read {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize>;
+    fn bytes(self) -> Bytes<Self>
+    where
+        Self: Sized,
+    {
+        Bytes { inner: self }
+    }
+}
+
+#[cfg(feature = "std")]
+pub use std::io::Bytes;
 #[cfg(not(feature = "std"))]
 pub struct Bytes<R> {
     inner: R,

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,0 +1,19 @@
+//! A tiny, `no_std`-friendly facade around `std::io`.
+//! Reexports types from `std` when available; otherwise reimplements and
+//! provides some of the core logic.
+//!
+//! The main reason that `std::io` hasn't found itself reexported as part of
+//! the `core` crate is the `std::io::{Read, Write}` traits' reliance on
+//! `std::io::Error`, which may contain internally a heap-allocated `Box<Error>`
+//! and/or now relying on OS-specific `std::backtrace::Backtrace`.
+
+pub use self::imp::{Bytes, Error, ErrorKind, Read, Result, Write};
+
+mod core;
+
+mod imp {
+    #[cfg(not(feature = "std"))]
+    pub use super::core::*;
+    #[cfg(feature = "std")]
+    pub use std::io::*;
+}

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,4 +1,4 @@
-use std::io;
+use io;
 
 pub struct LineColIterator<I> {
     iter: I,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ extern crate ryu;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-#[cfg(feature = "alloc")]
+#[cfg(not(feature = "std"))]
 extern crate alloc;
 
 /// A facade around all the types we need from the `std`, `core`, and `alloc`
@@ -370,27 +370,27 @@ mod lib {
     pub use self::core::marker::{self, PhantomData};
     pub use self::core::result::{self, Result};
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    #[cfg(not(feature = "std"))]
     pub use alloc::borrow::{Cow, ToOwned};
     #[cfg(feature = "std")]
     pub use std::borrow::{Cow, ToOwned};
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    #[cfg(not(feature = "std"))]
     pub use alloc::string::{String, ToString};
     #[cfg(feature = "std")]
     pub use std::string::{String, ToString};
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    #[cfg(not(feature = "std"))]
     pub use alloc::vec::{self, Vec};
     #[cfg(feature = "std")]
     pub use std::vec::{self, Vec};
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    #[cfg(not(feature = "std"))]
     pub use alloc::boxed::Box;
     #[cfg(feature = "std")]
     pub use std::boxed::Box;
 
-    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    #[cfg(not(feature = "std"))]
     pub use alloc::collections::{btree_map, BTreeMap};
     #[cfg(feature = "std")]
     pub use std::collections::{btree_map, BTreeMap};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,6 +331,7 @@
     must_use_candidate,
 ))]
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 #[macro_use]
 extern crate serde;
@@ -338,6 +339,10 @@ extern crate serde;
 extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
+#[cfg(feature = "std")]
+extern crate core;
+#[cfg(feature = "alloc")]
+extern crate alloc;
 
 #[doc(inline)]
 pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
@@ -355,8 +360,8 @@ pub use self::value::{from_value, to_value, Map, Number, Value};
 macro_rules! try {
     ($e:expr) => {
         match $e {
-            ::std::result::Result::Ok(val) => val,
-            ::std::result::Result::Err(err) => return ::std::result::Result::Err(err),
+            ::core::result::Result::Ok(val) => val,
+            ::core::result::Result::Err(err) => return ::core::result::Result::Err(err),
         }
     };
 }
@@ -370,6 +375,7 @@ pub mod map;
 pub mod ser;
 pub mod value;
 
+mod io;
 mod iter;
 mod number;
 mod read;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,10 +339,67 @@ extern crate serde;
 extern crate indexmap;
 extern crate itoa;
 extern crate ryu;
-#[cfg(feature = "std")]
-extern crate core;
+
+////////////////////////////////////////////////////////////////////////////////
+
 #[cfg(feature = "alloc")]
 extern crate alloc;
+
+/// A facade around all the types we need from the `std`, `core`, and `alloc`
+/// crates. This avoids elaborate import wrangling having to happen in every
+/// module.
+mod lib {
+    mod core {
+        #[cfg(not(feature = "std"))]
+        pub use core::*;
+        #[cfg(feature = "std")]
+        pub use std::*;
+    }
+
+    pub use self::core::{char, str};
+    pub use self::core::{cmp, mem, num, slice};
+
+    pub use self::core::{borrow, iter, ops};
+
+    pub use self::core::cell::{Cell, RefCell};
+    pub use self::core::clone::{self, Clone};
+    pub use self::core::convert::{self, From, Into};
+    pub use self::core::default::{self, Default};
+    pub use self::core::fmt::{self, Debug, Display};
+    pub use self::core::hash::{self, Hash};
+    pub use self::core::marker::{self, PhantomData};
+    pub use self::core::result::{self, Result};
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::borrow::{Cow, ToOwned};
+    #[cfg(feature = "std")]
+    pub use std::borrow::{Cow, ToOwned};
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::string::{String, ToString};
+    #[cfg(feature = "std")]
+    pub use std::string::{String, ToString};
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::vec::{self, Vec};
+    #[cfg(feature = "std")]
+    pub use std::vec::{self, Vec};
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::boxed::Box;
+    #[cfg(feature = "std")]
+    pub use std::boxed::Box;
+
+    #[cfg(all(feature = "alloc", not(feature = "std")))]
+    pub use alloc::collections::{btree_map, BTreeMap};
+    #[cfg(feature = "std")]
+    pub use std::collections::{btree_map, BTreeMap};
+
+    #[cfg(feature = "std")]
+    pub use std::error;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 #[doc(inline)]
 pub use self::de::{from_reader, from_slice, from_str, Deserializer, StreamDeserializer};
@@ -360,8 +417,8 @@ pub use self::value::{from_value, to_value, Map, Number, Value};
 macro_rules! try {
     ($e:expr) => {
         match $e {
-            ::core::result::Result::Ok(val) => val,
-            ::core::result::Result::Err(err) => return ::core::result::Result::Err(err),
+            ::lib::Result::Ok(val) => val,
+            ::lib::Result::Err(err) => return ::lib::Result::Err(err),
         }
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,6 +432,8 @@ pub mod map;
 pub mod ser;
 pub mod value;
 
+mod features_check;
+
 mod io;
 mod iter;
 mod number;

--- a/src/map.rs
+++ b/src/map.rs
@@ -6,20 +6,13 @@
 //! [`BTreeMap`]: https://doc.rust-lang.org/std/collections/struct.BTreeMap.html
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
-use serde::{de, ser};
-use core::borrow::Borrow;
-use core::fmt::{self, Debug};
-use core::hash::Hash;
-use core::iter::FromIterator;
-use core::ops;
-use value::Value;
-#[cfg(feature = "alloc")]
-use alloc::string::String;
+use lib::borrow::Borrow;
+use lib::iter::FromIterator;
+use lib::*;
 
-#[cfg(all(not(feature = "preserve_order"), feature = "std"))]
-use std::collections::{btree_map, BTreeMap};
-#[cfg(all(not(feature = "preserve_order"), feature = "alloc"))]
-use alloc::collections::{btree_map, BTreeMap};
+use value::Value;
+
+use serde::{de, ser};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -155,10 +148,8 @@ impl Map<String, Value> {
     {
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
-        #[cfg(all(not(feature = "preserve_order"), feature = "std"))]
-        use std::collections::btree_map::Entry as EntryImpl;
-        #[cfg(all(not(feature = "preserve_order"), feature = "alloc"))]
-        use alloc::collections::btree_map::Entry as EntryImpl;
+        #[cfg(not(feature = "preserve_order"))]
+        use lib::btree_map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant: vacant }),

--- a/src/map.rs
+++ b/src/map.rs
@@ -7,15 +7,19 @@
 //! [`IndexMap`]: https://docs.rs/indexmap/*/indexmap/map/struct.IndexMap.html
 
 use serde::{de, ser};
-use std::borrow::Borrow;
-use std::fmt::{self, Debug};
-use std::hash::Hash;
-use std::iter::FromIterator;
-use std::ops;
+use core::borrow::Borrow;
+use core::fmt::{self, Debug};
+use core::hash::Hash;
+use core::iter::FromIterator;
+use core::ops;
 use value::Value;
+#[cfg(feature = "alloc")]
+use alloc::string::String;
 
-#[cfg(not(feature = "preserve_order"))]
+#[cfg(all(not(feature = "preserve_order"), feature = "std"))]
 use std::collections::{btree_map, BTreeMap};
+#[cfg(all(not(feature = "preserve_order"), feature = "alloc"))]
+use alloc::collections::{btree_map, BTreeMap};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -151,8 +155,10 @@ impl Map<String, Value> {
     {
         #[cfg(feature = "preserve_order")]
         use indexmap::map::Entry as EntryImpl;
-        #[cfg(not(feature = "preserve_order"))]
+        #[cfg(all(not(feature = "preserve_order"), feature = "std"))]
         use std::collections::btree_map::Entry as EntryImpl;
+        #[cfg(all(not(feature = "preserve_order"), feature = "alloc"))]
+        use alloc::collections::btree_map::Entry as EntryImpl;
 
         match self.map.entry(key.into()) {
             EntryImpl::Vacant(vacant) => Entry::Vacant(VacantEntry { vacant: vacant }),

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,7 +1,7 @@
 use error::Error;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::{self, Debug, Display};
+use core::fmt::{self, Debug, Display};
 
 #[cfg(feature = "arbitrary_precision")]
 use itoa;

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,7 +1,8 @@
+use lib::*;
+
 use error::Error;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use core::fmt::{self, Debug, Display};
 
 #[cfg(feature = "arbitrary_precision")]
 use itoa;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,5 +1,4 @@
-use std::fmt::{self, Debug, Display};
-use std::mem;
+use lib::*;
 
 use serde::de::value::BorrowedStrDeserializer;
 use serde::de::{

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,5 +1,8 @@
-use std::ops::Deref;
-use std::{char, cmp, io, str};
+use core::ops::Deref;
+use io;
+use core::{char, cmp, str};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 #[cfg(feature = "raw_value")]
 use serde::de::Visitor;

--- a/src/read.rs
+++ b/src/read.rs
@@ -1,8 +1,7 @@
-use core::ops::Deref;
+use lib::ops::Deref;
+use lib::*;
+
 use io;
-use core::{char, cmp, str};
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 
 #[cfg(feature = "raw_value")]
 use serde::de::Visitor;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,9 +1,13 @@
 //! Serialize a Rust data structure into JSON data.
 
-use std::fmt;
-use std::io;
-use std::num::FpCategory;
-use std::str;
+use core::fmt;
+use io;
+use core::num::FpCategory;
+use core::str;
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible, Serialize};
@@ -460,7 +464,7 @@ where
     where
         T: fmt::Display,
     {
-        use std::fmt::Write;
+        use core::fmt::Write;
 
         struct Adapter<'ser, W: 'ser, F: 'ser> {
             writer: &'ser mut W,
@@ -1634,6 +1638,7 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(feature = "std")]
     fn write_i8<W: ?Sized>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
     where
         W: io::Write,
@@ -1643,6 +1648,19 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_i8<W: ?Sized>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "std")]
     fn write_i16<W: ?Sized>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
     where
         W: io::Write,
@@ -1652,6 +1670,19 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_i16<W: ?Sized>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "std")]
     fn write_i32<W: ?Sized>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
     where
         W: io::Write,
@@ -1661,6 +1692,19 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_i32<W: ?Sized>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "std")]
     fn write_i64<W: ?Sized>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
     where
         W: io::Write,
@@ -1668,8 +1712,21 @@ pub trait Formatter {
         itoa::write(writer, value).map(drop)
     }
 
+    /// Writes an integer value like `-123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_i64<W: ?Sized>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(feature = "std")]
     fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
     where
         W: io::Write,
@@ -1679,6 +1736,19 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "std")]
     fn write_u16<W: ?Sized>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
     where
         W: io::Write,
@@ -1688,6 +1758,19 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_u16<W: ?Sized>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "std")]
     fn write_u32<W: ?Sized>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
     where
         W: io::Write,
@@ -1697,11 +1780,36 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_u32<W: ?Sized>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(feature = "std")]
     fn write_u64<W: ?Sized>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
     where
         W: io::Write,
     {
         itoa::write(writer, value).map(drop)
+    }
+
+    /// Writes an integer value like `123` to the specified writer.
+    #[inline]
+    #[cfg(not(feature = "std"))]
+    fn write_u64<W: ?Sized>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
+    where
+        W: io::Write,
+    {
+        let mut buffer = itoa::Buffer::new();
+        let s = buffer.format(value);
+        writer.write_all(s.as_bytes())
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1634,17 +1634,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_i8<W: ?Sized>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `-123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_i8<W: ?Sized>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
     where
         W: io::Write,
@@ -1656,17 +1645,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_i16<W: ?Sized>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `-123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_i16<W: ?Sized>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
     where
         W: io::Write,
@@ -1678,17 +1656,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_i32<W: ?Sized>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `-123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_i32<W: ?Sized>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
     where
         W: io::Write,
@@ -1700,17 +1667,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_i64<W: ?Sized>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `-123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_i64<W: ?Sized>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
     where
         W: io::Write,
@@ -1722,17 +1678,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
     where
         W: io::Write,
@@ -1744,17 +1689,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_u16<W: ?Sized>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_u16<W: ?Sized>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
     where
         W: io::Write,
@@ -1766,17 +1700,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_u32<W: ?Sized>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_u32<W: ?Sized>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
     where
         W: io::Write,
@@ -1788,17 +1711,6 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    #[cfg(feature = "std")]
-    fn write_u64<W: ?Sized>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
-    where
-        W: io::Write,
-    {
-        itoa::write(writer, value).map(drop)
-    }
-
-    /// Writes an integer value like `123` to the specified writer.
-    #[inline]
-    #[cfg(not(feature = "std"))]
     fn write_u64<W: ?Sized>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
     where
         W: io::Write,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,13 +1,9 @@
 //! Serialize a Rust data structure into JSON data.
 
-use core::fmt;
+use lib::num::FpCategory;
+use lib::*;
+
 use io;
-use core::num::FpCategory;
-use core::str;
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 
 use super::error::{Error, ErrorCode, Result};
 use serde::ser::{self, Impossible, Serialize};
@@ -464,7 +460,7 @@ where
     where
         T: fmt::Display,
     {
-        use core::fmt::Write;
+        use self::fmt::Write;
 
         struct Adapter<'ser, W: 'ser, F: 'ser> {
             writer: &'ser mut W,

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,8 +1,18 @@
+#[cfg(feature = "std")]
 use std::borrow::Cow;
-use std::fmt;
-use std::slice;
-use std::str;
+#[cfg(feature = "alloc")]
+use alloc::borrow::{Cow, ToOwned};
+use core::fmt;
+use core::slice;
+use core::str;
+#[cfg(feature = "std")]
 use std::vec;
+#[cfg(feature = "alloc")]
+use alloc::vec;
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use serde;
 use serde::de::{

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1,18 +1,5 @@
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-#[cfg(feature = "alloc")]
-use alloc::borrow::{Cow, ToOwned};
-use core::fmt;
-use core::slice;
-use core::str;
-#[cfg(feature = "std")]
-use std::vec;
-#[cfg(feature = "alloc")]
-use alloc::vec;
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use lib::str::FromStr;
+use lib::*;
 
 use serde;
 use serde::de::{
@@ -144,7 +131,7 @@ impl<'de> Deserialize<'de> for Value {
     }
 }
 
-impl str::FromStr for Value {
+impl FromStr for Value {
     type Err = Error;
     fn from_str(s: &str) -> Result<Value, Error> {
         super::super::de::from_str(s)

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,4 +1,11 @@
+#[cfg(feature = "std")]
 use std::borrow::Cow;
+#[cfg(feature = "alloc")]
+use alloc::borrow::Cow;
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 
 use super::Value;
 use map::Map;
@@ -182,7 +189,7 @@ impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
     }
 }
 
-impl<T: Into<Value>> ::std::iter::FromIterator<T> for Value {
+impl<T: Into<Value>> ::core::iter::FromIterator<T> for Value {
     /// Convert an iteratable type to a `Value`
     ///
     /// # Examples

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -1,11 +1,5 @@
-#[cfg(feature = "std")]
-use std::borrow::Cow;
-#[cfg(feature = "alloc")]
-use alloc::borrow::Cow;
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
+use lib::iter::FromIterator;
+use lib::*;
 
 use super::Value;
 use map::Map;
@@ -189,7 +183,7 @@ impl<'a, T: Clone + Into<Value>> From<&'a [T]> for Value {
     }
 }
 
-impl<T: Into<Value>> ::core::iter::FromIterator<T> for Value {
+impl<T: Into<Value>> FromIterator<T> for Value {
     /// Convert an iteratable type to a `Value`
     ///
     /// # Examples

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,5 +1,9 @@
-use std::fmt;
-use std::ops;
+use core::fmt;
+use core::ops;
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned;
 
 use super::Value;
 use map::Map;
@@ -132,6 +136,9 @@ where
 
 // Prevent users from implementing the Index trait.
 mod private {
+    #[cfg(feature = "alloc")]
+    use alloc::string::String;
+
     pub trait Sealed {}
     impl Sealed for usize {}
     impl Sealed for str {}

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -1,9 +1,4 @@
-use core::fmt;
-use core::ops;
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-#[cfg(feature = "alloc")]
-use alloc::borrow::ToOwned;
+use lib::*;
 
 use super::Value;
 use map::Map;
@@ -136,13 +131,10 @@ where
 
 // Prevent users from implementing the Index trait.
 mod private {
-    #[cfg(feature = "alloc")]
-    use alloc::string::String;
-
     pub trait Sealed {}
     impl Sealed for usize {}
     impl Sealed for str {}
-    impl Sealed for String {}
+    impl Sealed for super::String {}
     impl<'a, T: ?Sized> Sealed for &'a T where T: Sealed {}
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -199,10 +199,12 @@ impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
             // maps it to fmt::Error
             io::Error::new(io::ErrorKind::Other, "fmt error")
         }
+
         #[cfg(not(feature = "std"))]
-        fn io_error<E>(_: E) -> &'static str {
+        fn io_error<E>(_: E) -> io::Error {
             "fmt error"
         }
+
         let s = try!(str::from_utf8(buf).map_err(io_error));
         try!(self.inner.write_str(s).map_err(io_error));
         Ok(buf.len())

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -90,14 +90,9 @@
 //! [from_slice]: https://docs.serde.rs/serde_json/de/fn.from_slice.html
 //! [from_reader]: https://docs.serde.rs/serde_json/de/fn.from_reader.html
 
-use core::fmt::{self, Debug};
+use lib::*;
+
 use io;
-use core::mem;
-use core::str;
-#[cfg(feature = "alloc")]
-use alloc::string::String;
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
 
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -193,18 +193,11 @@ struct WriterFormatter<'a, 'b: 'a> {
 
 impl<'a, 'b> io::Write for WriterFormatter<'a, 'b> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        #[cfg(feature = "std")]
         fn io_error<E>(_: E) -> io::Error {
             // Error value does not matter because fmt::Display impl below just
             // maps it to fmt::Error
             io::Error::new(io::ErrorKind::Other, "fmt error")
         }
-
-        #[cfg(not(feature = "std"))]
-        fn io_error<E>(_: E) -> io::Error {
-            "fmt error"
-        }
-
         let s = try!(str::from_utf8(buf).map_err(io_error));
         try!(self.inner.write_str(s).map_err(io_error));
         Ok(buf.len())

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,4 +1,6 @@
 use super::Value;
+#[cfg(feature = "alloc")]
+use alloc::string::String;
 
 fn eq_i64(value: &Value, other: i64) -> bool {
     value.as_i64().map_or(false, |i| i == other)

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,6 +1,6 @@
+use lib::String;
+
 use super::Value;
-#[cfg(feature = "alloc")]
-use alloc::string::String;
 
 fn eq_i64(value: &Value, other: i64) -> bool {
     value.as_i64().map_or(false, |i| i == other)

--- a/src/value/partial_eq.rs
+++ b/src/value/partial_eq.rs
@@ -1,4 +1,4 @@
-use lib::String;
+use lib::*;
 
 use super::Value;
 

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -6,6 +6,13 @@ use map::Map;
 use number::Number;
 use value::{to_value, Value};
 
+#[cfg(feature = "alloc")]
+use alloc::string::{String, ToString};
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
+use alloc::borrow::ToOwned;
+
 impl Serialize for Value {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,3 +1,5 @@
+use lib::*;
+
 use serde::ser::Impossible;
 use serde::{self, Serialize};
 
@@ -5,13 +7,6 @@ use error::{Error, ErrorCode};
 use map::Map;
 use number::Number;
 use value::{to_value, Value};
-
-#[cfg(feature = "alloc")]
-use alloc::string::{String, ToString};
-#[cfg(feature = "alloc")]
-use alloc::vec::Vec;
-#[cfg(feature = "alloc")]
-use alloc::borrow::ToOwned;
 
 impl Serialize for Value {
     #[inline]


### PR DESCRIPTION
This builds up on #588 (thanks @Freax13!).

With this, we support `no_std` with `alloc` crate, starting from Rust 1.36 (this was done so that we can use it in WebAssembly environment but any such environment will work).

To minimize the noise, I tried to use the facade approach already used in Serde to provide some consistency between the two and improved on the `io` facade to work around it missing in `core`.

Thanks in advance for taking your time to review this and let me know if I can improve anything to help this land!

Closes #588. Closes #516.