### PR TITLE
Removing obsolete test instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,21 +37,10 @@ tests for you.
 
 The test suite requires a nightly compiler.
 
-##### In the [`tests/deps`] directory
-
-```sh
-# This is a prerequisite for running the full test suite
-cargo clean && cargo update && cargo build
-```
-
-##### In the top level serde-json directory
-
 ```sh
 # Run the full test suite, including doc test and compile-tests
 cargo test
 ```
-
-[`tests/deps`]: https://github.com/serde-rs/json/tree/master/tests/deps
 
 ## Conduct
 


### PR DESCRIPTION
The `test/deps` directory no longer exists, so I suspect these instructions are simply not necessary since the switch to `trybuild` in commit 8d7f731c2d70b1d2f03e42c1dc34d2ae778676e8.