### PR TITLE
Adding ability to set recursion limit.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -204,6 +204,19 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         self.disable_recursion_limit = true;
     }
 
+    /// Sets the recursion limit.
+    ///
+    /// serde_json sets an upper limit to how deep into the structure it will
+    /// recurse, to avoid exhausting the stack. A sensible default is set, but it
+    /// can be overridden by this function.
+    ///
+    /// If you wish to have no limit at all, see `disable_recursion_limit`
+    /// which is only available when serde_json is built with the `"unbounded_depth"`
+    /// feature.
+    pub fn set_recursion_limit(&mut self, depth: u8) {
+        self.remaining_depth = depth;
+    }
+
     fn peek(&mut self) -> Result<Option<u8>> {
         self.read.peek()
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1755,6 +1755,18 @@ fn test_stack_overflow() {
 }
 
 #[test]
+fn test_set_recursion_limit() {
+    let brackets: String = iter::repeat('[')
+        .take(140)
+        .chain(iter::repeat(']').take(140))
+        .collect();
+
+    let mut deserializer = Deserializer::from_str(&brackets);
+    deserializer.set_recursion_limit(160);
+    Value::deserialize(&mut deserializer).unwrap();
+}
+
+#[test]
 #[cfg(feature = "unbounded_depth")]
 fn test_disable_recursion_limit() {
     let brackets: String = iter::repeat('[')


### PR DESCRIPTION
Add ability to set the recursion depth limit to values other than 128 and infinity.

There is [some evidence here that a depth of 200 is useful](https://source.chromium.org/gn/gn/+/master:src/base/json/json_reader.cc;l=18?q=kStackMaxDepth).

```
// Chosen to support 99.9% of documents found in the wild late 2016.
// http://crbug.com/673263
```
