### PR TITLE
replace serialize key,value functions by serialize_entry

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -307,8 +307,7 @@ impl ser::Serialize for Map<String, Value> {
         use serde::ser::SerializeMap;
         let mut map = tri!(serializer.serialize_map(Some(self.len())));
         for (k, v) in self {
-            tri!(map.serialize_key(k));
-            tri!(map.serialize_value(v));
+            map.serialize_entry(k, v)?;
         }
         map.end()
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -731,6 +731,17 @@ where
     }
 
     #[inline]
+    fn serialize_entry<K: ?Sized, V: ?Sized>(&mut self, key: &K, value: &V) -> Result<()>
+    where
+        K: Serialize,
+        V: Serialize,
+    {
+        self.serialize_key(key)?;
+        self.serialize_value(value)?;
+        Ok(())
+    }
+
+    #[inline]
     fn end(self) -> Result<()> {
         match self {
             Compound::Map { ser, state } => {
@@ -762,10 +773,7 @@ where
         T: Serialize,
     {
         match *self {
-            Compound::Map { .. } => {
-                tri!(ser::SerializeMap::serialize_key(self, key));
-                ser::SerializeMap::serialize_value(self, value)
-            }
+            Compound::Map { .. } => ser::SerializeMap::serialize_entry(self, key, value),
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { ref mut ser, .. } => {
                 if key == crate::number::TOKEN {

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -24,8 +24,7 @@ impl Serialize for Value {
                 use serde::ser::SerializeMap;
                 let mut map = tri!(serializer.serialize_map(Some(m.len())));
                 for (k, v) in m {
-                    tri!(map.serialize_key(k));
-                    tri!(map.serialize_value(v));
+                    map.serialize_entry(k, v)?;
                 }
                 map.end()
             }
@@ -601,10 +600,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
         T: Serialize,
     {
         match *self {
-            SerializeMap::Map { .. } => {
-                tri!(serde::ser::SerializeMap::serialize_key(self, key));
-                serde::ser::SerializeMap::serialize_value(self, value)
-            }
+            SerializeMap::Map { .. } => serde::ser::SerializeMap::serialize_entry(self, key, value),
             #[cfg(feature = "arbitrary_precision")]
             SerializeMap::Number { ref mut out_value } => {
                 if key == crate::number::TOKEN {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1467,8 +1467,7 @@ fn test_serialize_map_with_no_len() {
             use serde::ser::SerializeMap;
             let mut map = serializer.serialize_map(None)?;
             for (k, v) in &self.0 {
-                map.serialize_key(k)?;
-                map.serialize_value(v)?;
+                map.serialize_entry(k, v)?;
             }
             map.end()
         }


### PR DESCRIPTION
The purpuse is to serialize serde_json::Map<> with other serializer like serde-xml-rs::to_writer(&mut writer, &json_value) that is not possible today. The problem is serde_json use only **map.serialize_key(k)** and **map.serialize_key(v)**. Some serializer can use only **map.serialize_entry(k, v)**. If we follow these advices :
https://docs.serde.rs/src/serde/ser/mod.rs.html#1778-1784
/// Serialize a map key.
///
/// If possible, `Serialize` implementations are encouraged to use
/// `serialize_entry` instead as it may be implemented more efficiently in
/// some formats compared to a pair of calls to `serialize_key` and
/// `serialize_value`.
and the implementation of serialize_entry : https://docs.serde.rs/src/serde/ser/mod.rs.html#1798-1826

We should use during the Map serialize use serialize_entry function instead of serialize_key/serialize_key and use them into serialize_entry. 