### PR TITLE
Require serde >= 1.0.100 due to no_std-related Error re-export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "serde-rs/json" }
 appveyor = { repository = "serde-rs/json" }
 
 [dependencies]
-serde = { version = "1.0.60", default-features = false }
+serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.2", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"


### PR DESCRIPTION
Relevant Serde PR: https://github.com/serde-rs/serde/pull/1620

To support both no-/std builds without using somewhat noisy
conditional compilation directives, we implement the re-exported
`serde::de::StdError` trait in https://github.com/serde-rs/json/pull/606.

However, this was only introduced in >= 1.0.100, so we need to bump
the version requirement of serde.

On the off chance of someone pulling in incompatible 1.0.4{5,6} versions
of serde_json, I believe it'd be good to yank those and cut a new
release with this patch.

Sorry for the omission in the original PR.

Fixes #612.

@dtolnay By the way, is there a chance a new version of `alt_serde_*` could be published? It'd help work around the Cargo feature bug, where accidentally pulling in `std` through build/dev dep for `no_std`/`alloc` package breaks the build in `no_std` consumer crates.