### PR TITLE
Expose `value::ser::Serializer`

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -90,7 +90,6 @@
 //! [from_slice]: https://docs.serde.rs/serde_json/de/fn.from_slice.html
 //! [from_reader]: https://docs.serde.rs/serde_json/de/fn.from_reader.html
 
-use self::ser::Serializer;
 use crate::error::Error;
 use crate::io;
 use crate::lib::*;
@@ -98,6 +97,7 @@ use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
 pub use self::index::Index;
+pub use self::ser::Serializer;
 pub use crate::map::Map;
 pub use crate::number::Number;
 

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -32,6 +32,7 @@ impl Serialize for Value {
     }
 }
 
+/// Serializer type for `Value`.
 pub struct Serializer;
 
 impl serde::Serializer for Serializer {


### PR DESCRIPTION
This just makes `Serializer` public through a `pub use` in `serde_json::value`.