### PR TITLE
add serde dep to the sample dependencies section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 
 ```toml
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ```
 


### PR DESCRIPTION
it's required to use the library it seems like. 

Maybe that was obvious to everyone else, but I just spent a good few minutes trying to figure out why the sample code didn't run.