### PR TITLE
Add from_json macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,48 @@ let john = json!({
 });
 ```
 
-This is amazingly convenient but we have the problem we had before with
-`Value` which is that the IDE and Rust compiler cannot help us if we get it
-wrong. Serde JSON provides a better way of serializing strongly-typed data
-structures into JSON text.
+## Constructing JSON values as strongly typed data structures directly
+
+Mapping JSON data to Rust data structures occurs frequently enough that
+Serde provides a macro, `serde_json::from_json`, that first constructs a
+`serde_json::Value` and then adapts it to the annotation type.
+
+<!-- Fix me! -->
+<a href="https://play.rust-lang.org/?edition=2018&gist=15cfab66d38ff8a15a9cf1d8d897ac68" target="_blank">
+<img align="right" width="50" src="https://raw.githubusercontent.com/serde-rs/serde-rs.github.io/master/img/run.png">
+</a>
+
+```rust
+use serde::{Deserialize, Serialize};
+use serde_json::Result;
+
+#[derive(Serialize, Deserialize)]
+struct Person {
+    name: String,
+    age: u8,
+    phones: Vec<String>,
+}
+
+fn typed_example() -> Result<()> {
+    let p: Person = serde_json::from_json!({
+        "name": "John Doe",
+        "age": 43,
+        "phones": [
+            "+44 1234567",
+            "+44 2345678"
+        ]
+    })?;
+
+    println!("Please call {} at the number {}", p.name, p.phones[0]);
+
+    Ok(())
+}
+```
+
+This is amazingly convenient for deserialization but for serialization we
+have the problem we had before with `Value` which is that the IDE and Rust
+compiler cannot help us if we get it wrong. Serde JSON provides a better
+way of serializing strongly-typed data structures into JSON text.
 
 ## Creating JSON by serializing data structures
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,32 @@
+/// Construct a JSON literal as an instance of type `T`.
+///
+/// ```
+/// use serde::Deserialize;
+/// use serde_json::from_json;
+///
+/// #[derive(Deserialize, Debug)]
+/// struct User {
+///     fingerprint: String,
+///     location: String,
+/// }
+///
+/// let u: User = from_json!({
+///     "fingerprint": "0xF9BA143B95FF6D82",
+///     "location": "Menlo Park, CA"
+/// }).unwrap();
+/// println!("{:#?}", u);
+/// ```
+///
+/// # Errors
+///
+/// See the `serde_json::value` module documentation.
+#[macro_export(local_inner_macros)]
+macro_rules! from_json {
+    ($($json:tt)+) => {
+        $crate::from_value($crate::json!($($json)+))
+    };
+}
+
 /// Construct a `serde_json::Value` from a JSON literal.
 ///
 /// ```


### PR DESCRIPTION
The `serde_json::json` macro is amazingly convenient for constructing
`serde_json::Value` objects. However, these values must then be adapted
to user types via the `serde_json::from_value` function. Although the
macro and function are the only primitives needed for a user to perform
this operation on thier own, the pattern is common enough that a
`serde_json::from_json` wrapping macro is worthwhile.

The name "from_json" was chosen as a succinct combination of the two
underlying operations, `serde_json::from_value(serde_json::json!(...))`.

A typical use case before and after this patch:

```
struct Dog {
    name: String,
    age: u8,
}

// Before this patch.
let dog = serde_json::json!({
    "name": "Toto",
    "age": 2
});
let dog: Dog = serde_json::from_value(dog)?;

// After this patch.
let dog: Dog = serde_json::from_json!({
    "name": "Toto",
    "age": 2
})?;

println!("{} is {} year(s) old.", dog.name, dog.age);
```