### PR TITLE
Simplify Map's PartialEq impl

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -229,16 +229,7 @@ impl Clone for Map<String, Value> {
 impl PartialEq for Map<String, Value> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        if cfg!(feature = "preserve_order") {
-            if self.len() != other.len() {
-                return false;
-            }
-
-            self.iter()
-                .all(|(key, value)| other.get(key).map_or(false, |v| *value == *v))
-        } else {
-            self.map.eq(&other.map)
-        }
+        self.map.eq(&other.map)
     }
 }
 


### PR DESCRIPTION
Our custom implementation of PartialEq was added in ffcafc9d35a8fb4765b58866acf5d0d05effa904 because LinkedHashMap's implementation was order dependent. When we later switched to IndexMap in 1c6d0ef3195082f9a7f864ba44241e46c998bb47 the implementation could have been simplified because it matches https://github.com/bluss/indexmap/blob/1.0.0/src/map.rs#L1684-L1697.