### PR TITLE
Implement Eq for Map, Number and Value.

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -233,6 +233,8 @@ impl PartialEq for Map<String, Value> {
     }
 }
 
+impl Eq for Map<String, Value> {}
+
 /// Access an element of this map. Panics if the given key is not present in the
 /// map.
 ///

--- a/src/number.rs
+++ b/src/number.rs
@@ -16,7 +16,7 @@ use serde::de::{IntoDeserializer, MapAccess};
 pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Number {
     n: N,
 }
@@ -30,6 +30,10 @@ enum N {
     /// Always finite.
     Float(f64),
 }
+
+// Implementing Eq is fine since any float values are always finite.
+#[cfg(not(feature = "arbitrary_precision"))]
+impl Eq for N {}
 
 #[cfg(feature = "arbitrary_precision")]
 type N = String;

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -107,7 +107,7 @@ pub use crate::raw::RawValue;
 /// Represents any valid JSON value.
 ///
 /// See the `serde_json::value` module documentation for usage examples.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum Value {
     /// Represents a JSON null value.
     ///


### PR DESCRIPTION
These types already have `PartialEq` implementations which define equivalence relations, so we can implement `Eq` as well. Fixes #638.