### PR TITLE
Implement collect_str for map keys

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -454,7 +454,7 @@ where
 
     fn collect_str<T: ?Sized>(self, value: &T) -> Result<()>
     where
-        T: fmt::Display,
+        T: Display,
     {
         use self::fmt::Write;
 
@@ -1186,6 +1186,13 @@ where
         _len: usize,
     ) -> Result<Self::SerializeStructVariant> {
         Err(key_must_be_a_string())
+    }
+
+    fn collect_str<T: ?Sized>(self, value: &T) -> Result<()>
+    where
+        T: Display,
+    {
+        self.ser.collect_str(value)
     }
 }
 


### PR DESCRIPTION
Previously this would go through the default implementation which does memory allocation.
https://github.com/serde-rs/serde/blob/v1.0.105/serde/src/ser/mod.rs#L1358-L1366