### PR TITLE
Move ?Sized bounds out of generic parameter lists

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -65,10 +65,10 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&Value>
+    pub fn get<Q>(&self, key: &Q) -> Option<&Value>
     where
         String: Borrow<Q>,
-        Q: Ord + Eq + Hash,
+        Q: ?Sized + Ord + Eq + Hash,
     {
         self.map.get(key)
     }
@@ -78,10 +78,10 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
         String: Borrow<Q>,
-        Q: Ord + Eq + Hash,
+        Q: ?Sized + Ord + Eq + Hash,
     {
         self.map.contains_key(key)
     }
@@ -91,10 +91,10 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut Value>
+    pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut Value>
     where
         String: Borrow<Q>,
-        Q: Ord + Eq + Hash,
+        Q: ?Sized + Ord + Eq + Hash,
     {
         self.map.get_mut(key)
     }
@@ -116,10 +116,10 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
-    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<Value>
+    pub fn remove<Q>(&mut self, key: &Q) -> Option<Value>
     where
         String: Borrow<Q>,
-        Q: Ord + Eq + Hash,
+        Q: ?Sized + Ord + Eq + Hash,
     {
         #[cfg(feature = "preserve_order")]
         return self.map.swap_remove(key);
@@ -249,10 +249,10 @@ impl PartialEq for Map<String, Value> {
 /// }
 /// # ;
 /// ```
-impl<'a, Q: ?Sized> ops::Index<&'a Q> for Map<String, Value>
+impl<'a, Q> ops::Index<&'a Q> for Map<String, Value>
 where
     String: Borrow<Q>,
-    Q: Ord + Eq + Hash,
+    Q: ?Sized + Ord + Eq + Hash,
 {
     type Output = Value;
 
@@ -272,10 +272,10 @@ where
 /// #
 /// map["key"] = json!("value");
 /// ```
-impl<'a, Q: ?Sized> ops::IndexMut<&'a Q> for Map<String, Value>
+impl<'a, Q> ops::IndexMut<&'a Q> for Map<String, Value>
 where
     String: Borrow<Q>,
-    Q: Ord + Eq + Hash,
+    Q: ?Sized + Ord + Eq + Hash,
 {
     fn index_mut(&mut self, index: &Q) -> &mut Value {
         self.map.get_mut(index).expect("no entry found for key")

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -257,15 +257,15 @@ where
 
     /// Serialize newtypes without an object wrapper.
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<()>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
 
     #[inline]
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -273,7 +273,7 @@ where
         value: &T,
     ) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         tri!(self
             .formatter
@@ -310,9 +310,9 @@ where
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<()>
+    fn serialize_some<T>(self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -452,9 +452,9 @@ where
         self.serialize_map(Some(len))
     }
 
-    fn collect_str<T: ?Sized>(self, value: &T) -> Result<()>
+    fn collect_str<T>(self, value: &T) -> Result<()>
     where
-        T: Display,
+        T: ?Sized + Display,
     {
         use self::fmt::Write;
 
@@ -537,9 +537,9 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             Compound::Map {
@@ -592,9 +592,9 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -614,9 +614,9 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -636,9 +636,9 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         ser::SerializeSeq::serialize_element(self, value)
     }
@@ -675,9 +675,9 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             Compound::Map {
@@ -706,9 +706,9 @@ where
     }
 
     #[inline]
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             Compound::Map { ref mut ser, .. } => {
@@ -757,9 +757,9 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             Compound::Map { .. } => ser::SerializeMap::serialize_entry(self, key, value),
@@ -805,9 +805,9 @@ where
     type Error = Error;
 
     #[inline]
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             Compound::Map { .. } => ser::SerializeStruct::serialize_field(self, key, value),
@@ -883,9 +883,9 @@ where
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<()>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -1120,7 +1120,7 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -1128,7 +1128,7 @@ where
         _value: &T,
     ) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -1137,9 +1137,9 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<()>
+    fn serialize_some<T>(self, _value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -1188,9 +1188,9 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn collect_str<T: ?Sized>(self, value: &T) -> Result<()>
+    fn collect_str<T>(self, value: &T) -> Result<()>
     where
-        T: Display,
+        T: ?Sized + Display,
     {
         self.ser.collect_str(value)
     }
@@ -1288,9 +1288,9 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<()>
+    fn serialize_some<T>(self, _value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_number())
     }
@@ -1312,14 +1312,14 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<()>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, _value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_number())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -1327,7 +1327,7 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         _value: &T,
     ) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_number())
     }
@@ -1469,9 +1469,9 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<()>
+    fn serialize_some<T>(self, _value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(ser::Error::custom("expected RawValue"))
     }
@@ -1493,14 +1493,14 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<()>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, _value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -1508,7 +1508,7 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         _value: &T,
     ) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(ser::Error::custom("expected RawValue"))
     }
@@ -1603,18 +1603,18 @@ impl CharEscape {
 pub trait Formatter {
     /// Writes a `null` value to the specified writer.
     #[inline]
-    fn write_null<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn write_null<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b"null")
     }
 
     /// Writes a `true` or `false` value to the specified writer.
     #[inline]
-    fn write_bool<W: ?Sized>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
+    fn write_bool<W>(&mut self, writer: &mut W, value: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let s = if value {
             b"true" as &[u8]
@@ -1626,9 +1626,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    fn write_i8<W: ?Sized>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
+    fn write_i8<W>(&mut self, writer: &mut W, value: i8) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1637,9 +1637,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    fn write_i16<W: ?Sized>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
+    fn write_i16<W>(&mut self, writer: &mut W, value: i16) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1648,9 +1648,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    fn write_i32<W: ?Sized>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
+    fn write_i32<W>(&mut self, writer: &mut W, value: i32) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1659,9 +1659,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `-123` to the specified writer.
     #[inline]
-    fn write_i64<W: ?Sized>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
+    fn write_i64<W>(&mut self, writer: &mut W, value: i64) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1670,9 +1670,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    fn write_u8<W: ?Sized>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
+    fn write_u8<W>(&mut self, writer: &mut W, value: u8) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1681,9 +1681,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    fn write_u16<W: ?Sized>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
+    fn write_u16<W>(&mut self, writer: &mut W, value: u16) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1692,9 +1692,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    fn write_u32<W: ?Sized>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
+    fn write_u32<W>(&mut self, writer: &mut W, value: u32) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1703,9 +1703,9 @@ pub trait Formatter {
 
     /// Writes an integer value like `123` to the specified writer.
     #[inline]
-    fn write_u64<W: ?Sized>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
+    fn write_u64<W>(&mut self, writer: &mut W, value: u64) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = itoa::Buffer::new();
         let s = buffer.format(value);
@@ -1714,9 +1714,9 @@ pub trait Formatter {
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
     #[inline]
-    fn write_f32<W: ?Sized>(&mut self, writer: &mut W, value: f32) -> io::Result<()>
+    fn write_f32<W>(&mut self, writer: &mut W, value: f32) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = ryu::Buffer::new();
         let s = buffer.format_finite(value);
@@ -1725,9 +1725,9 @@ pub trait Formatter {
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
     #[inline]
-    fn write_f64<W: ?Sized>(&mut self, writer: &mut W, value: f64) -> io::Result<()>
+    fn write_f64<W>(&mut self, writer: &mut W, value: f64) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         let mut buffer = ryu::Buffer::new();
         let s = buffer.format_finite(value);
@@ -1736,9 +1736,9 @@ pub trait Formatter {
 
     /// Writes a number that has already been rendered to a string.
     #[inline]
-    fn write_number_str<W: ?Sized>(&mut self, writer: &mut W, value: &str) -> io::Result<()>
+    fn write_number_str<W>(&mut self, writer: &mut W, value: &str) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(value.as_bytes())
     }
@@ -1746,9 +1746,9 @@ pub trait Formatter {
     /// Called before each series of `write_string_fragment` and
     /// `write_char_escape`.  Writes a `"` to the specified writer.
     #[inline]
-    fn begin_string<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_string<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b"\"")
     }
@@ -1756,9 +1756,9 @@ pub trait Formatter {
     /// Called after each series of `write_string_fragment` and
     /// `write_char_escape`.  Writes a `"` to the specified writer.
     #[inline]
-    fn end_string<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_string<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b"\"")
     }
@@ -1766,22 +1766,18 @@ pub trait Formatter {
     /// Writes a string fragment that doesn't need any escaping to the
     /// specified writer.
     #[inline]
-    fn write_string_fragment<W: ?Sized>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    fn write_string_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(fragment.as_bytes())
     }
 
     /// Writes a character escape code to the specified writer.
     #[inline]
-    fn write_char_escape<W: ?Sized>(
-        &mut self,
-        writer: &mut W,
-        char_escape: CharEscape,
-    ) -> io::Result<()>
+    fn write_char_escape<W>(&mut self, writer: &mut W, char_escape: CharEscape) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         use self::CharEscape::*;
 
@@ -1814,9 +1810,9 @@ pub trait Formatter {
     /// Called before every array.  Writes a `[` to the specified
     /// writer.
     #[inline]
-    fn begin_array<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_array<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b"[")
     }
@@ -1824,9 +1820,9 @@ pub trait Formatter {
     /// Called after every array.  Writes a `]` to the specified
     /// writer.
     #[inline]
-    fn end_array<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_array<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b"]")
     }
@@ -1834,9 +1830,9 @@ pub trait Formatter {
     /// Called before every array value.  Writes a `,` if needed to
     /// the specified writer.
     #[inline]
-    fn begin_array_value<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         if first {
             Ok(())
@@ -1847,9 +1843,9 @@ pub trait Formatter {
 
     /// Called after every array value.
     #[inline]
-    fn end_array_value<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
+    fn end_array_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         Ok(())
     }
@@ -1857,9 +1853,9 @@ pub trait Formatter {
     /// Called before every object.  Writes a `{` to the specified
     /// writer.
     #[inline]
-    fn begin_object<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_object<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b"{")
     }
@@ -1867,18 +1863,18 @@ pub trait Formatter {
     /// Called after every object.  Writes a `}` to the specified
     /// writer.
     #[inline]
-    fn end_object<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_object<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b"}")
     }
 
     /// Called before every object key.
     #[inline]
-    fn begin_object_key<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         if first {
             Ok(())
@@ -1891,9 +1887,9 @@ pub trait Formatter {
     /// specified writer by either this method or
     /// `begin_object_value`.
     #[inline]
-    fn end_object_key<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
+    fn end_object_key<W>(&mut self, _writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         Ok(())
     }
@@ -1902,18 +1898,18 @@ pub trait Formatter {
     /// the specified writer by either this method or
     /// `end_object_key`.
     #[inline]
-    fn begin_object_value<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_object_value<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b":")
     }
 
     /// Called after every object value.
     #[inline]
-    fn end_object_value<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
+    fn end_object_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         Ok(())
     }
@@ -1921,9 +1917,9 @@ pub trait Formatter {
     /// Writes a raw JSON fragment that doesn't need any escaping to the
     /// specified writer.
     #[inline]
-    fn write_raw_fragment<W: ?Sized>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
+    fn write_raw_fragment<W>(&mut self, writer: &mut W, fragment: &str) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(fragment.as_bytes())
     }
@@ -1967,9 +1963,9 @@ impl<'a> Default for PrettyFormatter<'a> {
 
 impl<'a> Formatter for PrettyFormatter<'a> {
     #[inline]
-    fn begin_array<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_array<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         self.current_indent += 1;
         self.has_value = false;
@@ -1977,9 +1973,9 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     }
 
     #[inline]
-    fn end_array<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_array<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         self.current_indent -= 1;
 
@@ -1992,9 +1988,9 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     }
 
     #[inline]
-    fn begin_array_value<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         if first {
             tri!(writer.write_all(b"\n"));
@@ -2006,18 +2002,18 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     }
 
     #[inline]
-    fn end_array_value<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
+    fn end_array_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         self.has_value = true;
         Ok(())
     }
 
     #[inline]
-    fn begin_object<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_object<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         self.current_indent += 1;
         self.has_value = false;
@@ -2025,9 +2021,9 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     }
 
     #[inline]
-    fn end_object<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn end_object<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         self.current_indent -= 1;
 
@@ -2040,9 +2036,9 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     }
 
     #[inline]
-    fn begin_object_key<W: ?Sized>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
+    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         if first {
             tri!(writer.write_all(b"\n"));
@@ -2053,31 +2049,27 @@ impl<'a> Formatter for PrettyFormatter<'a> {
     }
 
     #[inline]
-    fn begin_object_value<W: ?Sized>(&mut self, writer: &mut W) -> io::Result<()>
+    fn begin_object_value<W>(&mut self, writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         writer.write_all(b": ")
     }
 
     #[inline]
-    fn end_object_value<W: ?Sized>(&mut self, _writer: &mut W) -> io::Result<()>
+    fn end_object_value<W>(&mut self, _writer: &mut W) -> io::Result<()>
     where
-        W: io::Write,
+        W: ?Sized + io::Write,
     {
         self.has_value = true;
         Ok(())
     }
 }
 
-fn format_escaped_str<W: ?Sized, F: ?Sized>(
-    writer: &mut W,
-    formatter: &mut F,
-    value: &str,
-) -> io::Result<()>
+fn format_escaped_str<W, F>(writer: &mut W, formatter: &mut F, value: &str) -> io::Result<()>
 where
-    W: io::Write,
-    F: Formatter,
+    W: ?Sized + io::Write,
+    F: ?Sized + Formatter,
 {
     tri!(formatter.begin_string(writer));
     tri!(format_escaped_str_contents(writer, formatter, value));
@@ -2085,14 +2077,14 @@ where
     Ok(())
 }
 
-fn format_escaped_str_contents<W: ?Sized, F: ?Sized>(
+fn format_escaped_str_contents<W, F>(
     writer: &mut W,
     formatter: &mut F,
     value: &str,
 ) -> io::Result<()>
 where
-    W: io::Write,
-    F: Formatter,
+    W: ?Sized + io::Write,
+    F: ?Sized + Formatter,
 {
     let bytes = value.as_bytes();
 
@@ -2160,10 +2152,10 @@ static ESCAPE: [u8; 256] = [
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
-pub fn to_writer<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
+pub fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
 where
     W: io::Write,
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let mut ser = Serializer::new(writer);
     tri!(value.serialize(&mut ser));
@@ -2178,10 +2170,10 @@ where
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
-pub fn to_writer_pretty<W, T: ?Sized>(writer: W, value: &T) -> Result<()>
+pub fn to_writer_pretty<W, T>(writer: W, value: &T) -> Result<()>
 where
     W: io::Write,
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let mut ser = Serializer::pretty(writer);
     tri!(value.serialize(&mut ser));
@@ -2195,9 +2187,9 @@ where
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
-pub fn to_vec<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
 where
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let mut writer = Vec::with_capacity(128);
     tri!(to_writer(&mut writer, value));
@@ -2211,9 +2203,9 @@ where
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
-pub fn to_vec_pretty<T: ?Sized>(value: &T) -> Result<Vec<u8>>
+pub fn to_vec_pretty<T>(value: &T) -> Result<Vec<u8>>
 where
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let mut writer = Vec::with_capacity(128);
     tri!(to_writer_pretty(&mut writer, value));
@@ -2227,9 +2219,9 @@ where
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
-pub fn to_string<T: ?Sized>(value: &T) -> Result<String>
+pub fn to_string<T>(value: &T) -> Result<String>
 where
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let vec = tri!(to_vec(value));
     let string = unsafe {
@@ -2246,9 +2238,9 @@ where
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
-pub fn to_string_pretty<T: ?Sized>(value: &T) -> Result<String>
+pub fn to_string_pretty<T>(value: &T) -> Result<String>
 where
-    T: Serialize,
+    T: ?Sized + Serialize,
 {
     let vec = tri!(to_vec_pretty(value));
     let string = unsafe {
@@ -2258,9 +2250,9 @@ where
     Ok(string)
 }
 
-fn indent<W: ?Sized>(wr: &mut W, n: usize, s: &[u8]) -> io::Result<()>
+fn indent<W>(wr: &mut W, n: usize, s: &[u8]) -> io::Result<()>
 where
-    W: io::Write,
+    W: ?Sized + io::Write,
 {
     for _ in 0..n {
         tri!(wr.write_all(s));

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -113,9 +113,9 @@ impl Index for String {
     }
 }
 
-impl<'a, T: ?Sized> Index for &'a T
+impl<'a, T> Index for &'a T
 where
-    T: Index,
+    T: ?Sized + Index,
 {
     fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
         (**self).index_into(v)
@@ -134,7 +134,7 @@ mod private {
     impl Sealed for usize {}
     impl Sealed for str {}
     impl Sealed for super::String {}
-    impl<'a, T: ?Sized> Sealed for &'a T where T: Sealed {}
+    impl<'a, T> Sealed for &'a T where T: ?Sized + Sealed {}
 }
 
 /// Used in panic messages.

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -172,14 +172,14 @@ impl serde::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<Value>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -187,7 +187,7 @@ impl serde::Serializer for Serializer {
         value: &T,
     ) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         let mut values = Map::new();
         values.insert(String::from(variant), tri!(to_value(&value)));
@@ -200,9 +200,9 @@ impl serde::Serializer for Serializer {
     }
 
     #[inline]
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Value>
+    fn serialize_some<T>(self, value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -298,9 +298,9 @@ impl serde::ser::SerializeSeq for SerializeVec {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.vec.push(tri!(to_value(&value)));
         Ok(())
@@ -315,9 +315,9 @@ impl serde::ser::SerializeTuple for SerializeVec {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_element<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         serde::ser::SerializeSeq::serialize_element(self, value)
     }
@@ -331,9 +331,9 @@ impl serde::ser::SerializeTupleStruct for SerializeVec {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         serde::ser::SerializeSeq::serialize_element(self, value)
     }
@@ -347,9 +347,9 @@ impl serde::ser::SerializeTupleVariant for SerializeTupleVariant {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.vec.push(tri!(to_value(&value)));
         Ok(())
@@ -368,9 +368,9 @@ impl serde::ser::SerializeMap for SerializeMap {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_key<T: ?Sized>(&mut self, key: &T) -> Result<()>
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             SerializeMap::Map {
@@ -386,9 +386,9 @@ impl serde::ser::SerializeMap for SerializeMap {
         }
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, value: &T) -> Result<()>
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             SerializeMap::Map {
@@ -449,9 +449,9 @@ impl serde::Serializer for MapKeySerializer {
     }
 
     #[inline]
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, value: &T) -> Result<String>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<String>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         value.serialize(self)
     }
@@ -526,7 +526,7 @@ impl serde::Serializer for MapKeySerializer {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -534,7 +534,7 @@ impl serde::Serializer for MapKeySerializer {
         _value: &T,
     ) -> Result<String>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -543,9 +543,9 @@ impl serde::Serializer for MapKeySerializer {
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<String>
+    fn serialize_some<T>(self, _value: &T) -> Result<String>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(key_must_be_a_string())
     }
@@ -599,9 +599,9 @@ impl serde::ser::SerializeStruct for SerializeMap {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         match *self {
             SerializeMap::Map { .. } => serde::ser::SerializeMap::serialize_entry(self, key, value),
@@ -645,9 +645,9 @@ impl serde::ser::SerializeStructVariant for SerializeStructVariant {
     type Ok = Value;
     type Error = Error;
 
-    fn serialize_field<T: ?Sized>(&mut self, key: &'static str, value: &T) -> Result<()>
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<()>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         self.map.insert(String::from(key), tri!(to_value(&value)));
         Ok(())
@@ -744,9 +744,9 @@ impl serde::ser::Serializer for NumberValueEmitter {
         Err(invalid_number())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Value>
+    fn serialize_some<T>(self, _value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_number())
     }
@@ -768,14 +768,14 @@ impl serde::ser::Serializer for NumberValueEmitter {
         Err(invalid_number())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<Value>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, _value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_number())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -783,7 +783,7 @@ impl serde::ser::Serializer for NumberValueEmitter {
         _value: &T,
     ) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_number())
     }
@@ -914,9 +914,9 @@ impl serde::ser::Serializer for RawValueEmitter {
         Err(invalid_raw_value())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Value>
+    fn serialize_some<T>(self, _value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_raw_value())
     }
@@ -938,14 +938,14 @@ impl serde::ser::Serializer for RawValueEmitter {
         Err(invalid_raw_value())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(self, _name: &'static str, _value: &T) -> Result<Value>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, _value: &T) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_raw_value())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -953,7 +953,7 @@ impl serde::ser::Serializer for RawValueEmitter {
         _value: &T,
     ) -> Result<Value>
     where
-        T: Serialize,
+        T: ?Sized + Serialize,
     {
         Err(invalid_raw_value())
     }


### PR DESCRIPTION
```diff
- fn serialize_field<T: ?Sized>(&mut self, value: &T) -> Result<()>
+ fn serialize_field<T>(&mut self, value: &T) -> Result<()>
  where
-     T: Serialize,
+     T: ?Sized + Serialize,
  {
```

These are left over from Rust 1.14 or older, before `?Sized` was supported in where-clauses.