### PR TITLE
Improve error message when neither std nor alloc is enabled

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -10,7 +10,7 @@ use crate::lib::borrow::Borrow;
 use crate::lib::iter::FromIterator;
 use crate::lib::*;
 use crate::value::Value;
-use serde::{de, ser};
+use serde::de;
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -289,11 +289,12 @@ impl Debug for Map<String, Value> {
     }
 }
 
-impl ser::Serialize for Map<String, Value> {
+#[cfg(any(feature = "std", feature = "alloc"))]
+impl serde::ser::Serialize for Map<String, Value> {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: ser::Serializer,
+        S: serde::ser::Serializer,
     {
         use serde::ser::SerializeMap;
         let mut map = tri!(serializer.serialize_map(Some(self.len())));
@@ -327,6 +328,7 @@ impl<'de> de::Deserialize<'de> for Map<String, Value> {
                 Ok(Map::new())
             }
 
+            #[cfg(any(feature = "std", feature = "alloc"))]
             #[inline]
             fn visit_map<V>(self, mut visitor: V) -> Result<Self::Value, V::Error>
             where

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -48,6 +48,7 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Number::from_f64(value).map_or(Value::Null, Value::Number))
             }
 
+            #[cfg(any(feature = "std", feature = "alloc"))]
             #[inline]
             fn visit_str<E>(self, value: &str) -> Result<Value, E>
             where
@@ -56,6 +57,7 @@ impl<'de> Deserialize<'de> for Value {
                 self.visit_string(String::from(value))
             }
 
+            #[cfg(any(feature = "std", feature = "alloc"))]
             #[inline]
             fn visit_string<E>(self, value: String) -> Result<Value, E> {
                 Ok(Value::String(value))
@@ -93,6 +95,7 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Value::Array(vec))
             }
 
+            #[cfg(any(feature = "std", feature = "alloc"))]
             fn visit_map<V>(self, mut visitor: V) -> Result<Value, V::Error>
             where
                 V: MapAccess<'de>,
@@ -208,6 +211,7 @@ impl<'de> serde::Deserializer<'de> for Value {
             Value::Null => visitor.visit_unit(),
             Value::Bool(v) => visitor.visit_bool(v),
             Value::Number(n) => n.deserialize_any(visitor),
+            #[cfg(any(feature = "std", feature = "alloc"))]
             Value::String(v) => visitor.visit_string(v),
             Value::Array(v) => visit_array(v, visitor),
             Value::Object(v) => visit_object(v, visitor),
@@ -338,6 +342,7 @@ impl<'de> serde::Deserializer<'de> for Value {
         V: Visitor<'de>,
     {
         match self {
+            #[cfg(any(feature = "std", feature = "alloc"))]
             Value::String(v) => visitor.visit_string(v),
             _ => Err(self.invalid_type(&visitor)),
         }
@@ -355,6 +360,7 @@ impl<'de> serde::Deserializer<'de> for Value {
         V: Visitor<'de>,
     {
         match self {
+            #[cfg(any(feature = "std", feature = "alloc"))]
             Value::String(v) => visitor.visit_string(v),
             Value::Array(v) => visit_array(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
@@ -1225,6 +1231,7 @@ macro_rules! deserialize_integer_key {
             match (self.key.parse(), self.key) {
                 (Ok(integer), _) => visitor.$visit(integer),
                 (Err(_), Cow::Borrowed(s)) => visitor.visit_borrowed_str(s),
+                #[cfg(any(feature = "std", feature = "alloc"))]
                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
             }
         }
@@ -1337,6 +1344,7 @@ impl<'de> Visitor<'de> for KeyClassifier {
         }
     }
 
+    #[cfg(any(feature = "std", feature = "alloc"))]
     fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
     where
         E: de::Error,
@@ -1392,6 +1400,7 @@ impl<'de> de::Deserializer<'de> for BorrowedCowStrDeserializer<'de> {
     {
         match self.value {
             Cow::Borrowed(string) => visitor.visit_borrowed_str(string),
+            #[cfg(any(feature = "std", feature = "alloc"))]
             Cow::Owned(string) => visitor.visit_string(string),
         }
     }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -20,6 +20,7 @@ impl Serialize for Value {
             Value::Number(ref n) => n.serialize(serializer),
             Value::String(ref s) => serializer.serialize_str(s),
             Value::Array(ref v) => v.serialize(serializer),
+            #[cfg(any(feature = "std", feature = "alloc"))]
             Value::Object(ref m) => {
                 use serde::ser::SerializeMap;
                 let mut map = tri!(serializer.serialize_map(Some(m.len())));


### PR DESCRIPTION
Some tweaks to make the following produce a more compact error.

```toml
[dependencies]
serde_json = { version = "1.0", default-features = false }
```

#### After:

```console
error: expected item, found `"serde_json requires that either `std` (default) or `alloc` feature is enabled"`
 --> src/features_check/error.rs:1:1
  |
1 | "serde_json requires that either `std` (default) or `alloc` feature is enabled"
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected item
```

#### Before:

```console
error: expected item, found `"serde_json requires that either `std` (default) or `alloc` feature is enabled"`
 --> src/features_check/error.rs:1:1
  |
1 | "serde_json requires that either `std` (default) or `alloc` feature is enabled"
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected item

error[E0407]: method `visit_string` is not a member of trait `Visitor`
  --> src/value/de.rs:60:13
   |
60 | /             fn visit_string<E>(self, value: String) -> Result<Value, E> {
61 | |                 Ok(Value::String(value))
62 | |             }
   | |_____________^ not a member of trait `Visitor`

error[E0407]: method `visit_string` is not a member of trait `Visitor`
    --> src/value/de.rs:1340:5
     |
1340 | /     fn visit_string<E>(self, s: String) -> Result<Self::Value, E>
1341 | |     where
1342 | |         E: de::Error,
1343 | |     {
...    |
1350 | |         }
1351 | |     }
     | |_____^ not a member of trait `Visitor`

error[E0277]: the trait bound `alloc::string::String: serde::ser::Serialize` is not satisfied
   --> src/map.rs:301:22
    |
301 |             tri!(map.serialize_entry(k, v));
    |                      ^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `alloc::string::String`

error[E0277]: the trait bound `alloc::string::String: serde::de::Deserialize<'de>` is not satisfied
   --> src/map.rs:337:61
    |
337 |                 while let Some((key, value)) = tri!(visitor.next_entry()) {
    |                                                             ^^^^^^^^^^ the trait `serde::de::Deserialize<'de>` is not implemented for `alloc::string::String`

error[E0599]: no method named `visit_string` found for struct `value::de::<impl serde::de::Deserialize<'de> for value::Value>::deserialize::ValueVisitor` in the current scope
  --> src/value/de.rs:56:22
   |
22 |         struct ValueVisitor;
   |         -------------------- method `visit_string` not found for this
...
56 |                 self.visit_string(String::from(value))
   |                      ^^^^^^^^^^^^ method not found in `value::de::<impl serde::de::Deserialize<'de> for value::Value>::deserialize::ValueVisitor`

error[E0277]: the trait bound `alloc::string::String: serde::de::Deserialize<'de>` is not satisfied
   --> src/value/de.rs:115:69
    |
115 |                         while let Some((key, value)) = tri!(visitor.next_entry()) {
    |                                                                     ^^^^^^^^^^ the trait `serde::de::Deserialize<'de>` is not implemented for `alloc::string::String`

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
   --> src/value/de.rs:211:41
    |
211 |             Value::String(v) => visitor.visit_string(v),
    |                                         ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
   --> src/value/de.rs:341:41
    |
341 |             Value::String(v) => visitor.visit_string(v),
    |                                         ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
   --> src/value/de.rs:358:41
    |
358 |             Value::String(v) => visitor.visit_string(v),
    |                                         ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1244 |     deserialize_integer_key!(deserialize_i8 => visit_i8);
     |     ----------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1245 |     deserialize_integer_key!(deserialize_i16 => visit_i16);
     |     ------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1246 |     deserialize_integer_key!(deserialize_i32 => visit_i32);
     |     ------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1247 |     deserialize_integer_key!(deserialize_i64 => visit_i64);
     |     ------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1248 |     deserialize_integer_key!(deserialize_u8 => visit_u8);
     |     ----------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1249 |     deserialize_integer_key!(deserialize_u16 => visit_u16);
     |     ------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1250 |     deserialize_integer_key!(deserialize_u32 => visit_u32);
     |     ------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1251 |     deserialize_integer_key!(deserialize_u64 => visit_u64);
     |     ------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1254 |         deserialize_integer_key!(deserialize_i128 => visit_i128);
     |         --------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1228:52
     |
1228 |                 (Err(_), Cow::Owned(s)) => visitor.visit_string(s),
     |                                                    ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`
...
1255 |         deserialize_integer_key!(deserialize_u128 => visit_u128);
     |         --------------------------------------------------------- in this macro invocation
     |
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0599]: no method named `visit_string` found for type parameter `V` in the current scope
    --> src/value/de.rs:1395:43
     |
1395 |             Cow::Owned(string) => visitor.visit_string(string),
     |                                           ^^^^^^^^^^^^ help: there is an associated function with a similar name: `visit_str`

error[E0277]: the trait bound `alloc::string::String: serde::ser::Serialize` is not satisfied
  --> src/value/ser.rs:27:30
   |
27 |                     tri!(map.serialize_entry(k, v));
   |                              ^^^^^^^^^^^^^^^ the trait `serde::ser::Serialize` is not implemented for `alloc::string::String`

error: aborting due to 22 previous errors
```