### PR TITLE
Add support for alternate encodings of bytes types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
         - cargo test --features arbitrary_precision
         - cargo test --features raw_value
         - cargo test --features unbounded_depth
+        - cargo test --features bytes_mode
+        - cargo test --features base64
 
     - rust: stable
     - rust: beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.2", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
-b64-ct = { version = "0.1", default-features = false }
+b64-ct = { version = "0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 automod = "0.1"
@@ -77,3 +77,9 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+# Support alternate encoding modes for bytes. Available on Rust 1.40+
+bytes_mode = []
+
+# Support the Base64-encoding alternate bytes encoding mode
+base64 = ["bytes_mode", "b64-ct"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.2", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
+b64-ct = { version = "0.1", default-features = false }
 
 [dev-dependencies]
 automod = "0.1"

--- a/src/base64.rs
+++ b/src/base64.rs
@@ -1,0 +1,138 @@
+//! Convenience functions for the base64 alternate byte encoding mode.
+
+use crate::de::Deserializer;
+use crate::error::Result;
+use crate::io;
+use crate::read::{self, Read};
+use crate::ser::{CompactFormatter, PrettyFormatter, SerializerBuilder};
+use crate::value;
+use crate::BytesMode;
+use serde::de;
+use serde::ser::Serialize;
+
+fn from_trait<'de, R, T>(read: R) -> Result<T>
+where
+    R: Read<'de>,
+    T: de::Deserialize<'de>,
+{
+    let mut de = Deserializer::with_bytes_mode(read, BytesMode::Base64);
+    let value = tri!(de::Deserialize::deserialize(&mut de));
+
+    // Make sure the whole stream has been consumed.
+    tri!(de.end());
+    Ok(value)
+}
+
+/// Like `from_reader`, except it uses BytesMode::Base64.
+#[cfg(feature = "std")]
+pub fn from_reader<R, T>(rdr: R) -> Result<T>
+where
+    R: crate::io::Read,
+    T: de::DeserializeOwned,
+{
+    from_trait(read::IoRead::new(rdr))
+}
+
+/// Like `from_slice`, except it uses BytesMode::Base64.
+pub fn from_slice<'a, T>(v: &'a [u8]) -> Result<T>
+where
+    T: de::Deserialize<'a>,
+{
+    from_trait(read::SliceRead::new(v))
+}
+
+/// Like `from_str`, except it uses BytesMode::Base64.
+pub fn from_str<'a, T>(s: &'a str) -> Result<T>
+where
+    T: de::Deserialize<'a>,
+{
+    from_trait(read::StrRead::new(s))
+}
+
+/// Like `to_writer`, except it uses BytesMode::Base64.
+#[cfg(feature = "std")]
+#[inline]
+pub fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: ?Sized + Serialize,
+{
+    let mut ser = SerializerBuilder::with_formatter(writer, CompactFormatter)
+        .bytes_mode(BytesMode::Base64)
+        .build();
+    tri!(value.serialize(&mut ser));
+    Ok(())
+}
+
+/// Like `to_writer_pretty`, except it uses BytesMode::Base64.
+#[cfg(feature = "std")]
+#[inline]
+pub fn to_writer_pretty<W, T>(writer: W, value: &T) -> Result<()>
+where
+    W: io::Write,
+    T: ?Sized + Serialize,
+{
+    let mut ser = SerializerBuilder::with_formatter(writer, PrettyFormatter::new())
+        .bytes_mode(BytesMode::Base64)
+        .build();
+    tri!(value.serialize(&mut ser));
+    Ok(())
+}
+
+/// Like `to_vec`, except it uses BytesMode::Base64.
+#[inline]
+pub fn to_vec<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ?Sized + Serialize,
+{
+    let mut writer = Vec::with_capacity(128);
+    tri!(to_writer(&mut writer, value));
+    Ok(writer)
+}
+
+/// Like `to_vec_pretty`, except it uses BytesMode::Base64.
+#[inline]
+pub fn to_vec_pretty<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: ?Sized + Serialize,
+{
+    let mut writer = Vec::with_capacity(128);
+    tri!(to_writer_pretty(&mut writer, value));
+    Ok(writer)
+}
+
+/// Like `to_string`, except it uses BytesMode::Base64.
+#[inline]
+pub fn to_string<T>(value: &T) -> Result<String>
+where
+    T: ?Sized + Serialize,
+{
+    let vec = tri!(to_vec(value));
+    let string = unsafe {
+        // We do not emit invalid UTF-8.
+        String::from_utf8_unchecked(vec)
+    };
+    Ok(string)
+}
+
+/// Like `to_string_pretty`, except it uses BytesMode::Base64.
+#[inline]
+pub fn to_string_pretty<T>(value: &T) -> Result<String>
+where
+    T: ?Sized + Serialize,
+{
+    let vec = tri!(to_vec_pretty(value));
+    let string = unsafe {
+        // We do not emit invalid UTF-8.
+        String::from_utf8_unchecked(vec)
+    };
+    Ok(string)
+}
+
+/// Like `to_value`, except it uses BytesMode::Base64.
+pub fn to_value<T>(value: T) -> Result<value::Value>
+where
+    T: Serialize,
+{
+    value.serialize(value::Serializer::with_bytes_mode(BytesMode::Base64))
+}

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -6,6 +6,7 @@ use crate::lib::num::FpCategory;
 use crate::lib::*;
 use serde::ser::{self, Impossible, Serialize};
 use serde::serde_if_integer128;
+use b64_ct::{ToBase64, STANDARD};
 
 /// A structure for serializing Rust values into JSON.
 pub struct Serializer<W, F = CompactFormatter> {
@@ -221,14 +222,10 @@ where
         Ok(())
     }
 
+    /// Serialize a base64-encoded string.
     #[inline]
     fn serialize_bytes(self, value: &[u8]) -> Result<()> {
-        use serde::ser::SerializeSeq;
-        let mut seq = tri!(self.serialize_seq(Some(value.len())));
-        for byte in value {
-            tri!(seq.serialize_element(byte));
-        }
-        seq.end()
+        self.serialize_str(&value.to_base64(STANDARD))
     }
 
     #[inline]
@@ -872,6 +869,10 @@ where
         self.ser.serialize_str(value)
     }
 
+    fn serialize_bytes(self, value: &[u8]) -> Result<()> {
+        self.ser.serialize_bytes(value)
+    }
+
     #[inline]
     fn serialize_unit_variant(
         self,
@@ -1106,10 +1107,6 @@ where
 
     fn serialize_char(self, value: char) -> Result<()> {
         self.ser.serialize_str(&value.to_string())
-    }
-
-    fn serialize_bytes(self, _value: &[u8]) -> Result<()> {
-        Err(key_must_be_a_string())
     }
 
     fn serialize_unit(self) -> Result<()> {

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -4,6 +4,7 @@ use crate::map::Map;
 use crate::number::Number;
 use crate::value::{to_value, Value};
 use serde::ser::{Impossible, Serialize};
+use b64_ct::{ToBase64, STANDARD};
 
 #[cfg(feature = "arbitrary_precision")]
 use serde::serde_if_integer128;
@@ -148,8 +149,7 @@ impl serde::Serializer for Serializer {
     }
 
     fn serialize_bytes(self, value: &[u8]) -> Result<Value> {
-        let vec = value.iter().map(|&b| Value::Number(b.into())).collect();
-        Ok(Value::Array(vec))
+        Ok(Value::String(value.to_base64(STANDARD)))
     }
 
     #[inline]


### PR DESCRIPTION
JSON does not natively support binary data. `serde_json` currently just supports integer arrays and a deserialization mode for raw strings. However, protocols using JSON specify their own mechanisms to handle binary data in JSON, and it's likely not to be what `serde_json` currently does.

How types in the serde data model are to be encoded should be specified by the (de)serializer, not the type. Suggestions such as https://github.com/serde-rs/json/issues/360#issuecomment-330095360 are therefore not appropriate. By specifying the encoding that way in the type, you can't (de)serialize that type anymore with a (de)serializer that does natively support bytes (such as CBOR).

This PR introduces the concept of alternate encodings for bytes types. When creating a JSON (de)serializer, you can specify the mode you want. The default mode is still integer arrays. This PR adds base64-encoding as an option. All changes can be enabled with features and should be backwards-compatible and zero-cost for existing users. The functionality is thoroughly documented with the `BytesMode` type.

There are a couple of TODO items but I wanted to gather feedback before continuing the work.

TODO:
* [ ] some kind of support for `Value as Deserializer`
* [ ] tests

cc @jseyfried