### PR TITLE
Add value::to_raw_value

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -102,7 +102,7 @@ pub use crate::map::Map;
 pub use crate::number::Number;
 
 #[cfg(feature = "raw_value")]
-pub use crate::raw::RawValue;
+pub use crate::raw::{to_raw_value, RawValue};
 
 /// Represents any valid JSON value.
 ///


### PR DESCRIPTION
Resolves #654.

I adopted the `# Errors` doc section from `to_value`. I can also try coming up with a semi-realistic example of how one would use this.