### PR TITLE
Implement `Hash` for `serde_json::Value`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -16,6 +16,7 @@ use serde::de;
 use indexmap::{self, IndexMap};
 
 /// Represents a JSON key/value type.
+#[derive(Hash)]
 pub struct Map<K, V> {
     map: MapImpl<K, V>,
 }

--- a/src/number.rs
+++ b/src/number.rs
@@ -16,13 +16,13 @@ use serde::de::{IntoDeserializer, MapAccess};
 pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Number {
     n: N,
 }
 
 #[cfg(not(feature = "arbitrary_precision"))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Hash)]
 enum N {
     PosInt(u64),
     /// Always less than zero.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -107,7 +107,7 @@ pub use crate::raw::{to_raw_value, RawValue};
 /// Represents any valid JSON value.
 ///
 /// See the `serde_json::value` module documentation for usage examples.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub enum Value {
     /// Represents a JSON null value.
     ///


### PR DESCRIPTION
It happens I need this for custom [sentry](https://sentry.io/) event aggregation, where events may contain extra context represented as `serde_json::Value`. Currently I cannot hash these, due to this missing impl.