### PR TITLE
Add streaming deserializer mode

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -8,6 +8,11 @@ use crate::read::{self, Fused, Reference};
 use serde::de::{self, Expected, Unexpected};
 use serde::{forward_to_deserialize_any, serde_if_integer128};
 
+#[cfg(feature = "std")]
+mod stream;
+#[cfg(feature = "std")]
+pub use stream::Stream;
+
 #[cfg(feature = "arbitrary_precision")]
 use crate::number::NumberDeserializer;
 

--- a/src/de/stream/mod.rs
+++ b/src/de/stream/mod.rs
@@ -1,0 +1,254 @@
+use crate::de::{Deserializer, Read, Result};
+use serde::Deserialize;
+
+mod parse_type;
+use parse_type::{Array, Map, ParseType, Root};
+
+/// Iterator that deserializes a stream into multiple JSON values.
+///
+/// A stream deserializer can be created from any JSON deserializer using the
+/// `Stream::new` method.
+///
+/// The data can consist of any JSON value. Values need to be a self-delineating value e.g.
+/// arrays, objects, or strings, or be followed by whitespace or a self-delineating value.
+///
+/// ```
+/// use serde_json::{Deserializer, Stream, Value};
+/// use std::collections::HashMap;
+///
+/// fn main() {
+///     let data = "{\"k\": 3}1\"cool\"\"stuff\" 3{}  [0, 1, 2]";
+///
+///     let stream = Stream::new(Deserializer::from_str(data));
+///     let mut stream = stream.enter_map().unwrap();
+///     assert_eq!(stream.next_value().unwrap(), ("k".to_string(), 3));
+///     let mut stream = stream.end_map().unwrap();
+///
+///     assert_eq!(stream.next_value::<usize>().unwrap(), 1);
+///     assert_eq!(stream.next_value::<&str>().unwrap(), "cool");
+///     assert_eq!(stream.next_value::<&str>().unwrap(), "stuff");
+///     assert_eq!(stream.next_value::<usize>().unwrap(), 3);
+///     assert_eq!(stream.next_value::<HashMap<String, Value>>().unwrap(), HashMap::new());
+///     assert_eq!(stream.next_value::<Vec<usize>>().unwrap(), vec![0, 1, 2]);
+///
+///     stream.end().unwrap();
+/// }
+/// ```
+pub struct Stream<'de, R: Read<'de>, P> {
+    deserializer: Deserializer<R>,
+    parse_type: P,
+    lifetime: std::marker::PhantomData<&'de ()>,
+}
+
+/// Iterator variant of `Stream`, created by `Stream::iter`
+pub struct StreamIterator<'de, 'a, R: Read<'de>, P, T: Deserialize<'de>> {
+    stream: &'a mut Stream<'de, R, P>,
+    element_type: std::marker::PhantomData<T>,
+}
+
+impl<'de, R: Read<'de>, P> Stream<'de, R, P> {
+    fn inner_new<PP>(src: Stream<'de, R, PP>) -> Self
+    where
+        P: ParseType<PP>,
+    {
+        Stream {
+            deserializer: src.deserializer,
+            parse_type: P::new(src.parse_type),
+            lifetime: std::marker::PhantomData::default(),
+        }
+    }
+
+    fn unwrap<PP>(self) -> Stream<'de, R, PP>
+    where
+        P: ParseType<PP>,
+    {
+        Stream {
+            deserializer: self.deserializer,
+            parse_type: self.parse_type.unwrap(),
+            lifetime: std::marker::PhantomData::default(),
+        }
+    }
+}
+
+/// Root implementation of the `Stream` parser
+impl<'de, R: Read<'de>> Stream<'de, R, Root> {
+    /// Create a JSON stream deserializer from a Deserializer
+    pub fn new(deserializer: Deserializer<R>) -> Self {
+        Stream {
+            deserializer,
+            parse_type: Root::new(()),
+            lifetime: std::marker::PhantomData::default(),
+        }
+    }
+
+    /// Enter an array
+    pub fn enter_array(mut self) -> Result<Stream<'de, R, Array<Root>>> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+        tri!(self.parse_type.enter_array(&mut self.deserializer));
+        Ok(Stream::inner_new(self))
+    }
+
+    /// Enter a map
+    pub fn enter_map(mut self) -> Result<Stream<'de, R, Map<Root>>> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+        tri!(self.parse_type.enter_map(&mut self.deserializer));
+        Ok(Stream::inner_new(self))
+    }
+
+    /// Return the next value, the whole value will be parsed in memory, loosing the streaming feature
+    pub fn next_value<K: Deserialize<'de>>(&mut self) -> Result<K> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+        K::deserialize(&mut self.deserializer)
+    }
+
+    /// Create a single typed iterator
+    pub fn iter<'a, T: Deserialize<'de>>(&'a mut self) -> StreamIterator<'de, 'a, R, Root, T> {
+        StreamIterator {
+            stream: self,
+            element_type: std::marker::PhantomData::default(),
+        }
+    }
+
+    /// Expect iterator to be at the end, should be called to avoid trailing characters
+    pub fn end(mut self) -> Result<()> {
+        self.deserializer.end()
+    }
+}
+
+impl<'de, R: Read<'de>, P> Stream<'de, R, Array<P>> {
+    /// Enter an array
+    pub fn enter_array(mut self) -> Result<Stream<'de, R, Array<Array<P>>>> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+        tri!(self.parse_type.enter_array(&mut self.deserializer));
+        Ok(Stream::inner_new(self))
+    }
+
+    /// Enter an map
+    pub fn enter_map(mut self) -> Result<Stream<'de, R, Map<Array<P>>>> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+        tri!(self.parse_type.enter_map(&mut self.deserializer));
+        Ok(Stream::inner_new(self))
+    }
+
+    /// Return the next value, the whole value will be parsed in memory, loosing the streaming feature
+    pub fn next_value<K: Deserialize<'de>>(&mut self) -> Result<K> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+
+        K::deserialize(&mut self.deserializer)
+    }
+
+    /// Test if we can end the current array
+    pub fn can_end_array(&mut self) -> bool {
+        self.deserializer.parse_whitespace()
+            .unwrap_or_default() == Some(b']')
+    }
+
+    /// Leave the current array
+    pub fn end_array(mut self) -> Result<Stream<'de, R, P>> {
+        self.deserializer.end_seq()?;
+        Ok(self.unwrap())
+    }
+
+    /// Create a single typed iterator
+    pub fn iter<'a, T: Deserialize<'de>>(&'a mut self) -> StreamIterator<'de, 'a, R, Array<P>, T> {
+        StreamIterator {
+            stream: self,
+            element_type: std::marker::PhantomData::default(),
+        }
+    }
+}
+
+impl<'de, R: Read<'de>, P> Stream<'de, R, Map<P>> {
+    /// Enter an array
+    pub fn enter_array(mut self) -> Result<(String, Stream<'de, R, Array<Map<P>>>)> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+
+        let key = tri!(String::deserialize(&mut self.deserializer));
+
+        tri!(self.deserializer.parse_object_colon());
+        tri!(self.parse_type.enter_array(&mut self.deserializer));
+
+        Ok((key, Stream::inner_new(self)))
+    }
+
+    /// Enter an map
+    pub fn enter_map(mut self) -> Result<(String, Stream<'de, R, Map<Map<P>>>)> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+
+        let key = tri!(String::deserialize(&mut self.deserializer));
+
+        tri!(self.deserializer.parse_object_colon());
+        tri!(self.parse_type.enter_map(&mut self.deserializer));
+
+        Ok((key, Stream::inner_new(self)))
+    }
+
+    /// Return the next value, the whole value will be parsed in memory, loosing the streaming feature
+    pub fn next_value<K: Deserialize<'de>>(&mut self) -> Result<(String, K)> {
+        tri!(self.parse_type.parse_separator(&mut self.deserializer));
+
+        let key = tri!(String::deserialize(&mut self.deserializer));
+
+        tri!(self.deserializer.parse_object_colon());
+        let val = tri!(K::deserialize(&mut self.deserializer));
+
+        Ok((key, val))
+    }
+
+    /// Test if we can end the current map
+    pub fn can_end_map(&mut self) -> bool {
+        self.deserializer.parse_whitespace()
+            .unwrap_or_default() == Some(b'}')
+    }
+
+    /// Leave the current map
+    pub fn end_map(mut self) -> Result<Stream<'de, R, P>> {
+        tri!(self.deserializer.end_map());
+        Ok(self.unwrap())
+    }
+
+    /// Create a single typed iterator
+    pub fn iter<'a, T: Deserialize<'de>>(&'a mut self) -> StreamIterator<'de, 'a, R, Map<P>, T> {
+        StreamIterator {
+            stream: self,
+            element_type: std::marker::PhantomData::default(),
+        }
+    }
+}
+
+impl<'de, 'a, R: Read<'de>, T: Deserialize<'de>> Iterator for StreamIterator<'de, 'a, R, Root, T> {
+    type Item = Result<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stream.next_value() {
+            Ok(v) => Some(Ok(v)),
+            Err(err) if err.is_eof() => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+impl<'de, 'a, R: Read<'de>, P, T: Deserialize<'de>> Iterator
+    for StreamIterator<'de, 'a, R, Array<P>, T>
+{
+    type Item = Result<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stream.next_value() {
+            Ok(v) => Some(Ok(v)),
+            Err(_) if self.stream.can_end_array() => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+impl<'de, 'a, R: Read<'de>, P, T: Deserialize<'de>> Iterator
+    for StreamIterator<'de, 'a, R, Map<P>, T>
+{
+    type Item = Result<(String, T)>;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stream.next_value() {
+            Ok(v) => Some(Ok(v)),
+            Err(_) if self.stream.can_end_map() => None,
+            Err(err) => Some(Err(err)),
+        }
+    }
+}

--- a/src/de/stream/parse_type.rs
+++ b/src/de/stream/parse_type.rs
@@ -1,0 +1,140 @@
+//! Represent the structure the `Stream` parser is in
+
+use crate::de::{Deserializer, ErrorCode, Read, Result};
+
+/// Type of the Currently parsed element
+///
+/// This is a recursive trait, where P is the parent type.
+///
+/// Example `Array<Map<Map<Root>>>` would be an array inside two nested map :
+///```json
+/// {
+///     "a": {
+///         "b": [
+///             // We are here
+///         ]
+///     }
+/// }
+///```
+pub trait ParseType<P> {
+    /// Wrap the type `P`, and retrun a new `ParserType`
+    fn new(p: P) -> Self;
+
+    /// Unwrap self, and return the inner value
+    fn unwrap(self) -> P;
+
+    /// Parse the separator for this kind of element
+    ///
+    /// Can be `,` or `]` for `Array`, `,` or `}` for `Map`, or just space for `Root`
+    fn parse_separator<'de, R: Read<'de>>(
+        &mut self,
+        deserializer: &mut Deserializer<R>,
+    ) -> Result<Option<u8>>;
+
+    /// Enter in an array, parse the '['
+    fn enter_array<'de, R: Read<'de>>(&mut self, deserializer: &mut Deserializer<R>) -> Result<()> {
+        match deserializer.parse_whitespace()? {
+            Some(b'[') => Ok(deserializer.eat_char()),
+            Some(_) => Err(deserializer.peek_invalid_type(&"array")),
+            None => Err(deserializer.peek_error(ErrorCode::EofWhileParsingValue)),
+        }
+    }
+
+    /// Enter in the map, parse the `{`
+    fn enter_map<'de, R: Read<'de>>(&mut self, deserializer: &mut Deserializer<R>) -> Result<()> {
+        match deserializer.parse_whitespace()? {
+            Some(b'{') => Ok(deserializer.eat_char()),
+            Some(_) => Err(deserializer.peek_invalid_type(&"map")),
+            None => Err(deserializer.peek_error(ErrorCode::EofWhileParsingValue)),
+        }
+    }
+}
+
+/// Root a the Stream, don't have a parent (use ()). Separator in only empty space, allowing to parse `1 2 3 4`
+pub struct Root;
+impl ParseType<()> for Root {
+    fn new(_: ()) -> Self {
+        Root {}
+    }
+    fn unwrap(self) {}
+    fn parse_separator<'de, R: Read<'de>>(
+        &mut self,
+        deserializer: &mut Deserializer<R>,
+    ) -> Result<Option<u8>> {
+        deserializer.parse_whitespace()
+    }
+}
+
+/// Represent an array structure. Separator is comma `,` and end is `]`. It will parse `1, 2, 3, 4`
+pub struct Array<P> {
+    parent: P,
+    first: bool,
+}
+
+impl<P> ParseType<P> for Array<P> {
+    fn new(parent: P) -> Self {
+        Array {
+            parent,
+            first: true,
+        }
+    }
+    fn unwrap(self) -> P {
+        self.parent
+    }
+
+    fn parse_separator<'de, R: Read<'de>>(
+        &mut self,
+        deserializer: &mut Deserializer<R>,
+    ) -> Result<Option<u8>> {
+        match tri!(deserializer.parse_whitespace()) {
+            Some(b']') => Err(deserializer.peek_error(ErrorCode::ExpectedSomeValue)),
+            Some(b',') if !self.first => {
+                deserializer.eat_char();
+                deserializer.parse_whitespace()
+            }
+            Some(b) if self.first => {
+                self.first = false;
+                Ok(Some(b))
+            }
+            Some(_) => Err(deserializer.peek_error(ErrorCode::ExpectedListCommaOrEnd)),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Represent an object structure. Separator is comma `,` and end is `}`. Expect key-value elements. It will parse `"key": 1, "key2": 2`
+pub struct Map<P> {
+    parent: P,
+    first: bool,
+}
+
+impl<P> ParseType<P> for Map<P> {
+    fn new(parent: P) -> Self {
+        Map {
+            parent,
+            first: true,
+        }
+    }
+    fn unwrap(self) -> P {
+        self.parent
+    }
+
+    fn parse_separator<'de, R: Read<'de>>(
+        &mut self,
+        deserializer: &mut Deserializer<R>,
+    ) -> Result<Option<u8>> {
+        match tri!(deserializer.parse_whitespace()) {
+            Some(b'}') => Err(deserializer.peek_error(ErrorCode::ExpectedSomeValue)),
+            Some(b',') if !self.first => {
+                deserializer.eat_char();
+                deserializer.parse_whitespace()
+            }
+            Some(b) if self.first => {
+                self.first = false;
+                Ok(Some(b))
+            }
+            Some(_) => Err(deserializer.peek_error(ErrorCode::ExpectedObjectCommaOrEnd)),
+            None => Ok(None),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,7 @@ mod lib {
 
 #[cfg(feature = "std")]
 #[doc(inline)]
-pub use crate::de::from_reader;
+pub use crate::de::{from_reader, Stream};
 #[doc(inline)]
 pub use crate::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -1,5 +1,7 @@
 use serde_json::{json, Number, Value};
 
+mod full_stream;
+
 #[test]
 fn number() {
     assert_eq!(format!("{:?}", Number::from(1)), "Number(1)");

--- a/tests/full_stream/mod.rs
+++ b/tests/full_stream/mod.rs
@@ -1,0 +1,70 @@
+use serde_json::Stream;
+
+#[test]
+fn test() {
+    let deserializer = serde_json::Deserializer::from_str(
+        r#"[1, 5, {"a": 1, "b": 2, "c": [1, 2], "d": 3}, 0]
+        {
+            "a"
+            :
+            { "b" : 1 },
+            "d": 5
+        }
+        "#,
+    );
+
+    let stream = Stream::new(deserializer);
+
+    // [1, 5, {a: 1, b: 2, c: [1, 2], d: 3}, 0]
+    let mut stream = stream.enter_array().unwrap();
+    assert_eq!(stream.next_value::<usize>().unwrap(), 1);
+    assert_eq!(stream.next_value::<usize>().unwrap(), 5);
+
+    let mut stream = stream.enter_map().unwrap();
+    assert_eq!(stream.next_value::<usize>().unwrap(), ("a".to_string(), 1));
+    assert_eq!(stream.next_value::<usize>().unwrap(), ("b".to_string(), 2));
+    let (key, mut stream) = stream.enter_array().unwrap();
+    assert_eq!(key, "c".to_string());
+    assert_eq!(stream.next_value::<usize>().unwrap(), 1);
+    assert_eq!(stream.next_value::<usize>().unwrap(), 2);
+
+    let mut stream = stream.end_array().unwrap();
+    assert_eq!(stream.next_value::<usize>().unwrap(), ("d".to_string(), 3));
+    let mut stream = stream.end_map().unwrap();
+
+    assert_eq!(stream.next_value::<usize>().unwrap(), 0);
+    let stream = stream.end_array().unwrap();
+
+    // { a: {b: 1}, d: 5 }
+    let stream = stream.enter_map().unwrap();
+
+    let (key, mut stream) = stream.enter_map().unwrap();
+    assert_eq!(key, "a".to_string());
+    assert_eq!(stream.next_value::<usize>().unwrap(), ("b".to_string(), 1));
+    let mut stream = stream.end_map().unwrap();
+
+    assert_eq!(stream.next_value::<usize>().unwrap(), ("d".to_string(), 5));
+    let stream = stream.end_map().unwrap();
+
+    stream.end().unwrap();
+}
+
+#[test]
+fn simple_iterator() {
+    let deserializer = serde_json::Deserializer::from_str(r#"[1, 2, 5, 6, 0]5"#);
+
+    let stream = Stream::new(deserializer);
+
+    let mut stream = stream.enter_array().unwrap();
+    let mut iter = stream.iter::<usize>();
+    assert_eq!(iter.next().unwrap().unwrap(), 1);
+    assert_eq!(iter.next().unwrap().unwrap(), 2);
+    assert_eq!(iter.next().unwrap().unwrap(), 5);
+    assert_eq!(iter.next().unwrap().unwrap(), 6);
+    assert_eq!(iter.next().unwrap().unwrap(), 0);
+    assert!(iter.next().is_none());
+
+    let mut stream = stream.end_array().unwrap();
+    assert_eq!(stream.next_value::<usize>().unwrap(), 5);
+    stream.end().unwrap();
+}


### PR DESCRIPTION
This allows to efficiently de-serialize array (`[ val, val ]`), map, (`{ key: val, key: val }`), and list (`val val`) of any type.

It follows some idea discussed in https://github.com/serde-rs/json/pull/526#issuecomment-505558106

Full manual example:
```rust
    let deserializer = serde_json::Deserializer::from_str(
        r#"[1, 5, {"a": 1, "b": 2, "c": [1, 2], "d": 3}, 0]
        {
            "a"
            :
            { "b" : 1 },
            "d": 5
        }
        "#,
    );

    let stream = Stream::new(deserializer);

    let mut stream = stream.enter_array().unwrap();
    stream.next_value::<usize>().unwrap(); // 1
    stream.next_value::<usize>().unwrap(); // 5

    let mut stream = stream.enter_map().unwrap();
    stream.next_value::<usize>().unwrap(); // a, 1
    stream.next_value::<usize>().unwrap(); // b, 2
    let (key, mut stream) = stream.enter_array().unwrap(); // key == c
    stream.next_value::<usize>().unwrap(); // 1
    stream.next_value::<usize>().unwrap(); // 2

    let mut stream = stream.end_array().unwrap();
    stream.next_value::<usize>().unwrap(); // d, 3
    let mut stream = stream.end_map().unwrap();

    stream.next_value::<usize>().unwrap(); // 0
    let stream = stream.end_array().unwrap();

    let stream = stream.enter_map().unwrap();

    let (key, mut stream) = stream.enter_map().unwrap(); // key == a
    stream.next_value::<usize>().unwrap(); // b, 1
    let mut stream = stream.end_map().unwrap();

    stream.next_value::<usize>().unwrap(); // d, 5
    let stream = stream.end_map().unwrap();

    stream.end().unwrap();
```

Iterator mode :
```rust
    let deserializer = serde_json::Deserializer::from_str(r#"[1, 2, 5, 6, 0]5"#);

    let stream = Stream::new(deserializer);

    let mut stream = stream.enter_array().unwrap();
    let iter = stream.iter::<usize>();
    for res in iter {
        let el = res.unwrap();
        // ...
    }

    let mut stream = stream.end_array().unwrap();
    stream.next_value::<usize>().unwrap(); // 5
    stream.end().unwrap();
```