### PR TITLE
Support verifying no-std support through serde_json_test

### DIFF
--- a/tests/crate/test.rs
+++ b/tests/crate/test.rs
@@ -1,1 +1,3 @@
+#![no_std]
+
 pub use serde_json::*;


### PR DESCRIPTION
Tested with:

```
cargo check \
    --manifest-path tests/crate/Cargo.toml \
    --target aarch64-unknown-none \
    --no-default-features \
    --features alloc
```

which fails before this commit and succeeds after.

Before this commit:

```console
    Checking serde_json_test v0.0.0
error[E0463]: can't find crate for `std`
  |
  = note: the `aarch64-unknown-none` target may not be installed

error: aborting due to previous error
```