### PR TITLE
Optimize compile time of Deserializer trait methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,6 +377,8 @@ mod lib {
     pub use self::core::hash::{self, Hash};
     pub use self::core::iter::FusedIterator;
     pub use self::core::marker::{self, PhantomData};
+    pub use self::core::mem::{ManuallyDrop, MaybeUninit};
+    pub use self::core::ptr;
     pub use self::core::result::{self, Result};
     pub use self::core::{borrow, char, cmp, iter, mem, num, ops, slice, str};
 


### PR DESCRIPTION
We can instantiate the control flow in these methods once per Read type rather than once per Visitor type. This reduces compile time of https://github.com/serde-rs/json-benchmark by 44% as measured by `cargo clean && RUSTFLAGS='-C codegen-units=1' cargo build --release --no-default-features --features parse-struct,lib-serde,all-files -Ztimings`, with 0-13% impact on performance.

#### Before

```console
   Completed serde_json v1.0.55 in 3.8s
   Completed json-benchmark v0.0.1 bin "json-benchmark" in 18.1s
```

```console
                                DOM                  STRUCT
======= serde_json ======= parse|stringify ===== parse|stringify ====
data/canada.json         270 MB/s              620 MB/s
data/citm_catalog.json   390 MB/s              950 MB/s
data/twitter.json        270 MB/s              560 MB/s
```

#### After

```console
   Completed serde_json v1.0.55 in 3.7s
   Completed json-benchmark v0.0.1 bin "json-benchmark" in 10.1s
```

```console
                                DOM                  STRUCT
======= serde_json ======= parse|stringify ===== parse|stringify ====
data/canada.json         250 MB/s              540 MB/s
data/citm_catalog.json   380 MB/s              850 MB/s
data/twitter.json        260 MB/s              560 MB/s
```