### PR TITLE
Updated readme to address array and deep object access.

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,59 @@ fn print_an_address() -> Result<()> {
 }
 ```
 
+## Navigating a hierarchical JSON structure
+
+Some times you'll need to navigate a JSON structure deserialized
+by serde_json. This example should help you conceptualize how to
+accomplish that.
+
+```rust
+use serde_json::{Result, Value};
+
+fn untyped_example() -> Result<()> {
+    // Some JSON input data as a &str. Maybe this comes from the user.
+    let data = r#"
+        {
+            "name": "John Doe",
+            "age": 43,
+            "phones": [
+                "+44 1234567",
+                "+44 2345678"
+            ],
+            "who": {
+                "you": {
+                    "gonna": {
+                        "call": "ghostbusters"
+                    }
+                }
+            }
+        }"#;
+
+    // Parse the string of data into serde_json::Value.
+    let v: Value = serde_json::from_str(data)?;
+
+    // To access an array in a JSON object, make sure to cast
+    // it with the as_array function
+    match v["phones"].as_array() {
+        Some(arr) => {
+            for i in 0..arr.len() {
+                println!("Phone Number: {}", arr[i]);
+            }
+        }
+        None => {
+            println!("Error accessing JSON array");
+        }
+    }
+
+    // If you need to access a deeply set key, you can use
+    // the following syntax to do so. Note the difference
+    // between accessing arrays and regular objects
+    println!("Who you gonna call? {}", v["who"]["you"]["gonna"]["call"]);
+
+    Ok(())
+}
+```
+
 Any type that implements Serde's `Serialize` trait can be serialized this
 way. This includes built-in Rust standard library types like `Vec<T>` and
 `HashMap<K, V>`, as well as any structs or enums annotated with


### PR DESCRIPTION
Even though I had used serde_json to (de)serialize arrays of flat JSON objects previously, I struggled for a little to determine how to navigate the JSON object itself. Once I figured it out, I thought it made sense to update the README with two examples that I personally found helpful so that other people wouldn't have to struggle as much as I did to learn the crate.

Happy to take edits on the commented descriptions. I just put in a good faith effort to describe it as it would make sense to me.