### PR TITLE
Add Map::remove_entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@nightly
       - run: cargo test
+      - run: cargo test --features map_remove_entry --tests -- --skip ui --exact
       - run: cargo test --features preserve_order --tests -- --skip ui --exact
       - run: cargo test --features float_roundtrip --tests -- --skip ui --exact
       - run: cargo test --features arbitrary_precision --tests -- --skip ui --exact
@@ -41,6 +42,8 @@ jobs:
         with:
           toolchain: ${{matrix.rust}}
       - run: cargo check
+      - run: cargo check --features map_remove_entry
+        if: matrix.rust != '1.31.0' && matrix.rust != '1.36.0'
       - run: cargo check --features preserve_order
         if: matrix.rust != '1.31.0'
       - run: cargo check --features float_roundtrip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ alloc = ["serde/alloc"]
 # Make serde_json::Map use a representation which maintains insertion order.
 # This allows data to be read into a Value and written back to a JSON string
 # while preserving the order of map keys in the input.
+# Available on Rust 1.32+.
 preserve_order = ["indexmap"]
 
 # Use sufficient precision when parsing fixed precision floats from JSON to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ default = ["std"]
 
 std = ["serde/std"]
 
+# Provide the method Map::remove_entry. This is behind a feature flag because it
+# only works on Rust 1.45+, unless the preserver_order feature is also
+# activated, in which case the MSRV for that feature applies.
+map_remove_entry = []
+
 # Provide integration for heap-allocated collections without depending on the
 # rest of the Rust standard library.
 # NOTE: Disabling both `std` *and* `alloc` features is not supported yet.

--- a/src/map.rs
+++ b/src/map.rs
@@ -116,10 +116,7 @@ impl Map<String, Value> {
         String: Borrow<Q>,
         Q: ?Sized + Ord + Eq + Hash,
     {
-        #[cfg(feature = "preserve_order")]
-        return self.map.swap_remove(key);
-        #[cfg(not(feature = "preserve_order"))]
-        return self.map.remove(key);
+        self.map.remove(key)
     }
 
     /// Moves all elements from other into Self, leaving other empty.

--- a/src/map.rs
+++ b/src/map.rs
@@ -119,6 +119,21 @@ impl Map<String, Value> {
         self.map.remove(key)
     }
 
+    /// Removes a key from the map, returning the stored key and value if the key
+    /// was previously in the map.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    #[cfg(feature = "map_remove_entry")]
+    #[inline]
+    pub fn remove_entry<Q>(&mut self, key: &Q) -> Option<(String, Value)>
+    where
+        String: Borrow<Q>,
+        Q: ?Sized + Ord + Eq + Hash,
+    {
+        self.map.remove_entry(key)
+    }
+
     /// Moves all elements from other into Self, leaving other empty.
     #[inline]
     pub fn append(&mut self, other: &mut Self) {


### PR DESCRIPTION
… and simplify `Map::remove`, since I noticed it uses `#[cfg]` branching when it doesn't need to.