### PR TITLE
Simplify Map::remove

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -116,10 +116,7 @@ impl Map<String, Value> {
         String: Borrow<Q>,
         Q: ?Sized + Ord + Eq + Hash,
     {
-        #[cfg(feature = "preserve_order")]
-        return self.map.swap_remove(key);
-        #[cfg(not(feature = "preserve_order"))]
-        return self.map.remove(key);
+        self.map.remove(key)
     }
 
     /// Removes a key from the map, returning the stored key and value if the


### PR DESCRIPTION
Small remaining useful change from #708. The review didn't say anything about this commit, so I assume it was probably overlooked.