### PR TITLE
Add serde_json::error::Error::msg() method

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,11 @@ pub struct Error {
 pub type Result<T> = result::Result<T, Error>;
 
 impl Error {
+    /// Message of this error
+    pub fn msg(&self) -> String {
+        self.err.code.to_string()
+    }
+
     /// One-based line number at which the error was detected.
     ///
     /// Characters in the first line of the input (before the first newline


### PR DESCRIPTION
Actually it is not possible to have the error message without the line and column number.

I had to parse a file with one object by line, the error line was always 1 but not necessary in the file.

You cant get the line and column with serde_json::error::Error::{line,column} but the error message from the `ErrorCode` is private.

You can now get only ```missing field `type` ```  instead of the whole ```missing field `type` at line 1 column 26```

