### PR TITLE
Update example to use Result<User, Box<dyn Error>>

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -2432,7 +2432,7 @@ where
 ///     location: String,
 /// }
 ///
-/// fn read_user_from_file<P: AsRef<Path>>(path: P) -> Result<User, Box<Error>> {
+/// fn read_user_from_file<P: AsRef<Path>>(path: P) -> Result<User, Box<dyn Error>> {
 ///     // Open the file in read-only mode with buffer.
 ///     let file = File::open(path)?;
 ///     let reader = BufReader::new(file);


### PR DESCRIPTION
This seem to be what is now expected on stable; as the compiler warnings are saying; and also consistent with what `read_user_from_stream` example is using.