### PR TITLE
Reduce how much code is generated

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -18,6 +18,18 @@ pub use crate::read::{Read, SliceRead, StrRead};
 #[cfg(feature = "std")]
 pub use crate::read::IoRead;
 
+macro_rules! try_with {
+    ($e:expr, $wrap:expr) => {
+        match $e {
+            crate::lib::Result::Ok(val) => val,
+            crate::lib::Result::Err(err) => return $wrap(err),
+        }
+    };
+    ($e:expr, $wrap:expr,) => {
+        try_with!($e, $wrap)
+    };
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 /// A structure that deserializes JSON into Rust values.
@@ -164,6 +176,16 @@ macro_rules! check_recursion {
     };
 }
 
+enum AnyResult {
+    Null,
+    Bool(bool),
+    Number(bool),
+    String,
+    Array,
+    Map,
+    Error(Error),
+}
+
 impl<'de, R: Read<'de>> Deserializer<R> {
     /// The `Deserializer::end` method should be called after a value has been fully deserialized.
     /// This allows the `Deserializer` to validate that the input stream is at the end or that it
@@ -279,6 +301,57 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     fn peek_error(&self, reason: ErrorCode) -> Error {
         let position = self.read.peek_position();
         Error::syntax(reason, position.line, position.column)
+    }
+
+    fn parse_any_prefix(&mut self) -> AnyResult {
+        match try_with!(self.parse_whitespace_in_value(), AnyResult::Error) {
+            b'n' => {
+                self.eat_char();
+                try_with!(self.parse_ident(b"ull"), AnyResult::Error);
+                AnyResult::Null
+            }
+            b't' => {
+                self.eat_char();
+                try_with!(self.parse_ident(b"rue"), AnyResult::Error);
+                AnyResult::Bool(true)
+            }
+            b'f' => {
+                self.eat_char();
+                try_with!(self.parse_ident(b"alse"), AnyResult::Error);
+                AnyResult::Bool(false)
+            }
+            b'-' => {
+                self.eat_char();
+                AnyResult::Number(false)
+            }
+            b'0'..=b'9' => AnyResult::Number(true),
+            b'"' => {
+                self.eat_char();
+                self.scratch.clear();
+                AnyResult::String
+            }
+            b'[' => {
+                self.eat_char();
+                if_checking_recursion_limit! {
+                    self.remaining_depth -= 1;
+                    if self.remaining_depth == 0 {
+                        return AnyResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
+                    }
+                }
+                AnyResult::Array
+            }
+            b'{' => {
+                self.eat_char();
+                if_checking_recursion_limit! {
+                    self.remaining_depth -= 1;
+                    if self.remaining_depth == 0 {
+                        return AnyResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
+                    }
+                }
+                AnyResult::Map
+            }
+            _ => AnyResult::Error(self.peek_error(ErrorCode::ExpectedSomeValue)),
+        }
     }
 
     fn parse_struct_prefix(&mut self, exp: &dyn Expected) -> StructResult {
@@ -1338,62 +1411,31 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = tri!(self.parse_whitespace_in_value());
+        let value = match self.parse_any_prefix() {
+            AnyResult::Null => visitor.visit_unit(),
+            AnyResult::Bool(b) => visitor.visit_bool(b),
+            AnyResult::Number(positive) => tri!(self.parse_any_number(positive)).visit(visitor),
+            AnyResult::String => match tri!(self.read.parse_str(&mut self.scratch)) {
+                Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
+                Reference::Copied(s) => visitor.visit_str(s),
+            },
+            AnyResult::Array => {
+                let ret = visitor.visit_seq(SeqAccess::new(self));
 
-        let value = match peek {
-            b'n' => {
-                self.eat_char();
-                tri!(self.parse_ident(b"ull"));
-                visitor.visit_unit()
-            }
-            b't' => {
-                self.eat_char();
-                tri!(self.parse_ident(b"rue"));
-                visitor.visit_bool(true)
-            }
-            b'f' => {
-                self.eat_char();
-                tri!(self.parse_ident(b"alse"));
-                visitor.visit_bool(false)
-            }
-            b'-' => {
-                self.eat_char();
-                tri!(self.parse_any_number(false)).visit(visitor)
-            }
-            b'0'..=b'9' => tri!(self.parse_any_number(true)).visit(visitor),
-            b'"' => {
-                self.eat_char();
-                self.scratch.clear();
-                match tri!(self.read.parse_str(&mut self.scratch)) {
-                    Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
-                    Reference::Copied(s) => visitor.visit_str(s),
-                }
-            }
-            b'[' => {
-                self.eat_char();
-                check_recursion! {
-                    self;
-                    let ret = visitor.visit_seq(SeqAccess::new(self));
-                }
-
-                match (ret, self.end_seq()) {
+                match (ret, self.end_recursion_and_seq()) {
                     (Ok(ret), Ok(())) => Ok(ret),
                     (Err(err), _) | (_, Err(err)) => Err(err),
                 }
             }
-            b'{' => {
-                self.eat_char();
-                check_recursion! {
-                    self;
-                    let ret = visitor.visit_map(MapAccess::new(self));
-                }
+            AnyResult::Map => {
+                let ret = visitor.visit_map(MapAccess::new(self));
 
-                match (ret, self.end_map()) {
+                match (ret, self.end_recursion_and_map()) {
                     (Ok(ret), Ok(())) => Ok(ret),
                     (Err(err), _) | (_, Err(err)) => Err(err),
                 }
             }
-            _ => Err(self.peek_error(ErrorCode::ExpectedSomeValue)),
+            AnyResult::Error(err) => Err(err),
         };
 
         match value {
@@ -1831,18 +1873,6 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         tri!(self.ignore_value());
         visitor.visit_unit()
     }
-}
-
-macro_rules! try_with {
-    ($e:expr, $wrap:expr) => {
-        match $e {
-            crate::lib::Result::Ok(val) => val,
-            crate::lib::Result::Err(err) => return $wrap(err),
-        }
-    };
-    ($e:expr, $wrap:expr,) => {
-        try_with!($e, $wrap)
-    };
 }
 
 struct SeqAccess<'a, R: 'a> {

--- a/src/de.rs
+++ b/src/de.rs
@@ -143,6 +143,12 @@ enum StructResult<'a, R> {
     Error(Error),
 }
 
+enum EnumResult<'a, R> {
+    Variant(VariantAccess<'a, R>),
+    Unit(UnitVariantAccess<'a, R>),
+    Error(Error),
+}
+
 #[cfg(not(feature = "unbounded_depth"))]
 macro_rules! if_checking_recursion_limit {
     ($($body:tt)*) => {
@@ -411,6 +417,35 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 StructResult::Error(self.fix_position(err))
             }
             Err(err) => StructResult::Error(err),
+        }
+    }
+
+    #[inline]
+    fn parse_enum_prefix(&mut self) -> EnumResult<'_, R> {
+        match try_with!(self.parse_whitespace_in_value(), EnumResult::Error) {
+            b'{' => {
+                self.eat_char();
+                if_checking_recursion_limit! {
+                    self.remaining_depth -= 1;
+                    if self.remaining_depth == 0 {
+                        return EnumResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
+                    }
+                }
+                EnumResult::Variant(VariantAccess::new(self))
+            }
+            b'"' => EnumResult::Unit(UnitVariantAccess::new(self)),
+            _ => EnumResult::Error(self.peek_error(ErrorCode::ExpectedSomeValue)),
+        }
+    }
+
+    #[inline]
+    fn parse_enum_suffix(&mut self) -> Result<()> {
+        match tri!(self.parse_whitespace_in_object()) {
+            b'}' => {
+                self.eat_char();
+                Ok(())
+            }
+            _ => Err(self.error(ErrorCode::ExpectedSomeValue)),
         }
     }
 
@@ -1858,24 +1893,14 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        match tri!(self.parse_whitespace_in_value()) {
-            b'{' => {
-                self.eat_char();
-                check_recursion! {
-                    self;
-                    let value = tri!(visitor.visit_enum(VariantAccess::new(self)));
-                }
-
-                match tri!(self.parse_whitespace_in_object()) {
-                    b'}' => {
-                        self.eat_char();
-                        Ok(value)
-                    }
-                    _ => Err(self.error(ErrorCode::ExpectedSomeValue)),
-                }
+        match self.parse_enum_prefix() {
+            EnumResult::Variant(variant) => {
+                let value = tri!(visitor.visit_enum(variant));
+                tri!(self.parse_enum_suffix());
+                Ok(value)
             }
-            b'"' => visitor.visit_enum(UnitVariantAccess::new(self)),
-            _ => Err(self.peek_error(ErrorCode::ExpectedSomeValue)),
+            EnumResult::Unit(unit) => visitor.visit_enum(unit),
+            EnumResult::Error(err) => Err(err),
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -220,6 +220,13 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         Ok(tri!(self.next_char()).unwrap_or(b'\x00'))
     }
 
+    fn next_char_or_error(&mut self) -> Result<u8> {
+        match tri!(self.read.next()) {
+            Some(next) => Ok(next),
+            None => Err(self.error(ErrorCode::EofWhileParsingValue)),
+        }
+    }
+
     /// Error caused by a byte from next_char().
     #[cold]
     fn error(&self, reason: ErrorCode) -> Error {
@@ -374,15 +381,9 @@ impl<'de, R: Read<'de>> Deserializer<R> {
 
     fn parse_ident(&mut self, ident: &[u8]) -> Result<()> {
         for expected in ident {
-            match tri!(self.next_char()) {
-                None => {
-                    return Err(self.error(ErrorCode::EofWhileParsingValue));
-                }
-                Some(next) => {
-                    if next != *expected {
-                        return Err(self.error(ErrorCode::ExpectedSomeIdent));
-                    }
-                }
+            let next = tri!(self.next_char_or_error());
+            if next != *expected {
+                return Err(self.error(ErrorCode::ExpectedSomeIdent));
             }
         }
 
@@ -390,12 +391,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     }
 
     fn parse_integer(&mut self, positive: bool) -> Result<ParserNumber> {
-        let next = match tri!(self.next_char()) {
-            Some(b) => b,
-            None => {
-                return Err(self.error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let next = tri!(self.next_char_or_error());
 
         match next {
             b'0' => {
@@ -511,12 +507,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             _ => true,
         };
 
-        let next = match tri!(self.next_char()) {
-            Some(b) => b,
-            None => {
-                return Err(self.error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let next = tri!(self.next_char_or_error());
 
         // Make sure a digit follows the exponent place.
         let mut exp = match next {
@@ -703,12 +694,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             _ => true,
         };
 
-        let next = match tri!(self.next_char()) {
-            Some(b) => b,
-            None => {
-                return Err(self.error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let next = tri!(self.next_char_or_error());
 
         // Make sure a digit follows the exponent place.
         let mut exp = match next {
@@ -873,13 +859,9 @@ impl<'de, R: Read<'de>> Deserializer<R> {
 
     #[cfg(feature = "arbitrary_precision")]
     fn scan_or_eof(&mut self, buf: &mut String) -> Result<u8> {
-        match tri!(self.next_char()) {
-            Some(b) => {
-                buf.push(b as char);
-                Ok(b)
-            }
-            None => Err(self.error(ErrorCode::EofWhileParsingValue)),
-        }
+        let b = tri!(self.next_char_or_error());
+        buf.push(b as char);
+        Ok(b)
     }
 
     #[cfg(feature = "arbitrary_precision")]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1934,11 +1934,11 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        match self.parse_element_prefix() {
-            ElementResult::Field => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
-            ElementResult::Done => Ok(None),
-            ElementResult::Error(err) => Err(err),
-        }
+        Ok(match self.parse_element_prefix() {
+            ElementResult::Field => Some(tri!(seed.deserialize(&mut *self.de))),
+            ElementResult::Done => None,
+            ElementResult::Error(err) => return Err(err),
+        })
     }
 }
 
@@ -1996,11 +1996,11 @@ impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
     where
         K: de::DeserializeSeed<'de>,
     {
-        match self.parse_key_prefix() {
-            KeyResult::Key => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
-            KeyResult::Done => Ok(None),
-            KeyResult::Error(err) => Err(err),
-        }
+        Ok(match self.parse_key_prefix() {
+            KeyResult::Key => Some(tri!(seed.deserialize(MapKey { de: &mut *self.de }))),
+            KeyResult::Done => None,
+            KeyResult::Error(err) => return Err(err),
+        })
     }
 
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>

--- a/src/de.rs
+++ b/src/de.rs
@@ -1844,6 +1844,51 @@ impl<'a, R: 'a> SeqAccess<'a, R> {
     }
 }
 
+enum FieldResult {
+    Error(Error),
+    Field,
+    Done,
+}
+
+impl<'de, 'a, R: Read<'de> + 'a> SeqAccess<'a, R> {
+    fn parse_field_prefix(&mut self) -> FieldResult {
+        let peek = match self.de.parse_whitespace() {
+            Ok(Some(peek)) => peek,
+            Ok(None) => {
+                return FieldResult::Error(self.de.peek_error(ErrorCode::EofWhileParsingList));
+            }
+            Err(err) => return FieldResult::Error(err),
+        };
+        let peek = match peek {
+            b']' => {
+                return FieldResult::Done;
+            }
+            b',' if !self.first => {
+                self.de.eat_char();
+                match self.de.parse_whitespace_in_value() {
+                    Ok(peek) => peek,
+                    Err(err) => return FieldResult::Error(err),
+                }
+            }
+            b => {
+                if self.first {
+                    self.first = false;
+                    b
+                } else {
+                    return FieldResult::Error(
+                        self.de.peek_error(ErrorCode::ExpectedListCommaOrEnd),
+                    );
+                }
+            }
+        };
+
+        match peek {
+            b']' => FieldResult::Error(self.de.peek_error(ErrorCode::TrailingComma)),
+            _ => FieldResult::Field,
+        }
+    }
+}
+
 impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
     type Error = Error;
 
@@ -1851,30 +1896,10 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        let peek = match tri!(self.de.parse_whitespace()) {
-            Some(b']') => {
-                return Ok(None);
-            }
-            Some(b',') if !self.first => {
-                self.de.eat_char();
-                tri!(self.de.parse_whitespace_in_value())
-            }
-            Some(b) => {
-                if self.first {
-                    self.first = false;
-                    b
-                } else {
-                    return Err(self.de.peek_error(ErrorCode::ExpectedListCommaOrEnd));
-                }
-            }
-            None => {
-                return Err(self.de.peek_error(ErrorCode::EofWhileParsingList));
-            }
-        };
-
-        match peek {
-            b']' => Err(self.de.peek_error(ErrorCode::TrailingComma)),
-            _ => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
+        match self.parse_field_prefix() {
+            FieldResult::Field => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
+            FieldResult::Done => Ok(None),
+            FieldResult::Error(err) => Err(err),
         }
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -176,11 +176,12 @@ macro_rules! check_recursion {
     };
 }
 
-enum AnyResult {
+enum AnyResult<'de, 's> {
     Null,
     Bool(bool),
     Number(bool),
-    String,
+    BorrowedString(&'de str),
+    CopiedString(&'s str),
     Array,
     Map,
     Error(Error),
@@ -303,7 +304,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         Error::syntax(reason, position.line, position.column)
     }
 
-    fn parse_any_prefix(&mut self) -> AnyResult {
+    fn parse_any_prefix(&mut self) -> AnyResult<'de, '_> {
         match try_with!(self.parse_whitespace_in_value(), AnyResult::Error) {
             b'n' => {
                 self.eat_char();
@@ -328,7 +329,10 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             b'"' => {
                 self.eat_char();
                 self.scratch.clear();
-                AnyResult::String
+                match try_with!(self.read.parse_str(&mut self.scratch), AnyResult::Error) {
+                    Reference::Borrowed(s) => AnyResult::BorrowedString(s),
+                    Reference::Copied(s) => AnyResult::CopiedString(s),
+                }
             }
             b'[' => {
                 self.eat_char();
@@ -1424,10 +1428,8 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
             AnyResult::Null => visitor.visit_unit(),
             AnyResult::Bool(b) => visitor.visit_bool(b),
             AnyResult::Number(positive) => tri!(self.parse_any_number(positive)).visit(visitor),
-            AnyResult::String => match tri!(self.read.parse_str(&mut self.scratch)) {
-                Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
-                Reference::Copied(s) => visitor.visit_str(s),
-            },
+            AnyResult::BorrowedString(s) => visitor.visit_borrowed_str(s),
+            AnyResult::CopiedString(s) => visitor.visit_str(s),
             AnyResult::Array => {
                 let ret = visitor.visit_seq(SeqAccess::new(self));
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -124,6 +124,13 @@ impl ParserNumber {
     }
 }
 
+/// Flattened `Result<b'[' | b'{'), Error>`. Helps llvm when optimizing
+enum StructResult {
+    Array,
+    Map,
+    Error(Error),
+}
+
 impl<'de, R: Read<'de>> Deserializer<R> {
     /// The `Deserializer::end` method should be called after a value has been fully deserialized.
     /// This allows the `Deserializer` to validate that the input stream is at the end or that it
@@ -239,6 +246,24 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     fn peek_error(&self, reason: ErrorCode) -> Error {
         let position = self.read.peek_position();
         Error::syntax(reason, position.line, position.column)
+    }
+
+    fn parse_struct_prefix(&mut self, exp: &dyn Expected) -> StructResult {
+        match self.parse_whitespace_in_value() {
+            Ok(b'[') => {
+                self.eat_char();
+                StructResult::Array
+            }
+            Ok(b'{') => {
+                self.eat_char();
+                StructResult::Map
+            }
+            Ok(_) => {
+                let err = self.peek_invalid_type(exp);
+                StructResult::Error(self.fix_position(err))
+            }
+            Err(err) => StructResult::Error(err),
+        }
     }
 
     /// Returns the first non-whitespace byte without consuming it, or `Err` if
@@ -1715,11 +1740,8 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = tri!(self.parse_whitespace_in_value());
-
-        let (ret, ret2) = match peek {
-            b'[' => {
-                self.eat_char();
+        let (ret, ret2) = match self.parse_struct_prefix(&visitor) {
+            StructResult::Array => {
                 check_recursion! {
                     self;
                     let ret = visitor.visit_seq(SeqAccess::new(self));
@@ -1727,8 +1749,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
                 (ret, self.end_seq())
             }
-            b'{' => {
-                self.eat_char();
+            StructResult::Map => {
                 check_recursion! {
                     self;
                     let ret = visitor.visit_map(MapAccess::new(self));
@@ -1736,7 +1757,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
                 (ret, self.end_map())
             }
-            _ => (Err(self.peek_invalid_type(&visitor)), Ok(())),
+            StructResult::Error(err) => return Err(err),
         };
 
         match (ret, ret2) {

--- a/src/de.rs
+++ b/src/de.rs
@@ -354,6 +354,19 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    fn parse_str<'s>(&'s mut self) -> Result<Reference<'de, 's, str>> {
+        self.eat_char();
+        self.scratch.clear();
+        self.read.parse_str(&mut self.scratch)
+    }
+
+    fn parse_str_prefix<'s>(&'s mut self, exp: &dyn Expected) -> Result<Reference<'de, 's, str>> {
+        tri!(self.parse_whitespace_until(b'"', exp));
+
+        self.scratch.clear();
+        self.read.parse_str(&mut self.scratch)
+    }
+
     fn parse_struct_prefix(&mut self, exp: &dyn Expected) -> StructResult {
         match self.parse_whitespace_in_value() {
             Ok(b'[') => {
@@ -461,14 +474,10 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 Ok(n) => n.invalid_type(exp),
                 Err(err) => return err,
             },
-            b'"' => {
-                self.eat_char();
-                self.scratch.clear();
-                match self.read.parse_str(&mut self.scratch) {
-                    Ok(s) => de::Error::invalid_type(Unexpected::Str(&s), exp),
-                    Err(err) => return err,
-                }
-            }
+            b'"' => match self.parse_str() {
+                Ok(s) => de::Error::invalid_type(Unexpected::Str(&s), exp),
+                Err(err) => return err,
+            },
             b'[' => de::Error::invalid_type(Unexpected::Seq, exp),
             b'{' => de::Error::invalid_type(Unexpected::Map, exp),
             _ => self.peek_error(ErrorCode::ExpectedSomeValue),
@@ -1567,10 +1576,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        tri!(self.parse_whitespace_until(b'"', &visitor));
-
-        self.scratch.clear();
-        let value = match tri!(self.read.parse_str(&mut self.scratch)) {
+        let value = match tri!(self.parse_str_prefix(&visitor)) {
             Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
             Reference::Copied(s) => visitor.visit_str(s),
         };
@@ -2139,9 +2145,7 @@ macro_rules! deserialize_integer_key {
         where
             V: de::Visitor<'de>,
         {
-            self.de.eat_char();
-            self.de.scratch.clear();
-            let string = tri!(self.de.read.parse_str(&mut self.de.scratch));
+            let string = tri!(self.de.parse_str());
             match (string.parse(), string) {
                 (Ok(integer), _) => visitor.$visit(integer),
                 (Err(_), Reference::Borrowed(s)) => visitor.visit_borrowed_str(s),
@@ -2162,9 +2166,7 @@ where
     where
         V: de::Visitor<'de>,
     {
-        self.de.eat_char();
-        self.de.scratch.clear();
-        match tri!(self.de.read.parse_str(&mut self.de.scratch)) {
+        match tri!(self.de.parse_str()) {
             Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
             Reference::Copied(s) => visitor.visit_str(s),
         }

--- a/src/de.rs
+++ b/src/de.rs
@@ -422,6 +422,12 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    fn parse_whitespace_until_null(&mut self, visitor: &dyn Expected) -> Result<()> {
+        tri!(self.parse_whitespace_until(b'n', visitor));
+
+        self.parse_ident(b"ull")
+    }
+
     fn parse_whitespace_until(&mut self, expected: u8, visitor: &dyn Expected) -> Result<()> {
         if tri!(self.parse_whitespace_in_value()) == expected {
             self.eat_char();
@@ -1728,9 +1734,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        tri!(self.parse_whitespace_until(b'n', &visitor));
-
-        tri!(self.parse_ident(b"ull"));
+        tri!(self.parse_whitespace_until_null(&visitor));
 
         match visitor.visit_unit() {
             Ok(value) => Ok(value),

--- a/src/de.rs
+++ b/src/de.rs
@@ -415,7 +415,6 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
-    #[inline]
     fn parse_enum_prefix(&mut self) -> EnumResult<'_, R> {
         match try_with!(self.parse_whitespace_in_value(), EnumResult::Error) {
             b'{' => {
@@ -466,6 +465,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         self.parse_ident(b"ull")
     }
 
+    #[inline]
     fn parse_whitespace_until(&mut self, expected: u8, visitor: &dyn Expected) -> Result<()> {
         if tri!(self.parse_whitespace_in_value()) == expected {
             self.eat_char();
@@ -1621,6 +1621,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         self.deserialize_str(visitor)
     }
 
+    #[inline]
     fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -1760,6 +1761,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         }
     }
 
+    #[inline]
     fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
@@ -1849,6 +1851,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         }
     }
 
+    #[inline]
     fn deserialize_struct<V>(
         self,
         _name: &'static str,
@@ -1966,6 +1969,7 @@ impl<'de, 'a, R: Read<'de> + 'a> SeqAccess<'a, R> {
 impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
     type Error = Error;
 
+    #[inline]
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
     where
         T: de::DeserializeSeed<'de>,
@@ -2028,6 +2032,7 @@ impl<'de, 'a, R: Read<'de> + 'a> MapAccess<'a, R> {
 impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
     type Error = Error;
 
+    #[inline]
     fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
     where
         K: de::DeserializeSeed<'de>,
@@ -2039,6 +2044,7 @@ impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
         })
     }
 
+    #[inline]
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
     where
         V: de::DeserializeSeed<'de>,

--- a/src/de.rs
+++ b/src/de.rs
@@ -401,6 +401,18 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    #[inline]
+    fn parse_option(&mut self) -> Result<Option<()>> {
+        match tri!(self.parse_whitespace()) {
+            Some(b'n') => {
+                self.eat_char();
+                tri!(self.parse_ident(b"ull"));
+                Ok(None)
+            }
+            _ => Ok(Some(())),
+        }
+    }
+
     /// Returns the first non-whitespace byte without consuming it, or `Err` if
     /// EOF is encountered.
     fn parse_whitespace_in_value(&mut self) -> Result<u8> {
@@ -1706,13 +1718,9 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        match tri!(self.parse_whitespace()) {
-            Some(b'n') => {
-                self.eat_char();
-                tri!(self.parse_ident(b"ull"));
-                visitor.visit_none()
-            }
-            _ => visitor.visit_some(self),
+        match tri!(self.parse_option()) {
+            Some(()) => visitor.visit_some(self),
+            None => visitor.visit_none(),
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1833,6 +1833,18 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     }
 }
 
+macro_rules! try_with {
+    ($e:expr, $wrap:expr) => {
+        match $e {
+            crate::lib::Result::Ok(val) => val,
+            crate::lib::Result::Err(err) => return $wrap(err),
+        }
+    };
+    ($e:expr, $wrap:expr,) => {
+        try_with!($e, $wrap)
+    };
+}
+
 struct SeqAccess<'a, R: 'a> {
     de: &'a mut Deserializer<R>,
     first: bool,
@@ -1852,12 +1864,11 @@ enum FieldResult {
 
 impl<'de, 'a, R: Read<'de> + 'a> SeqAccess<'a, R> {
     fn parse_field_prefix(&mut self) -> FieldResult {
-        let peek = match self.de.parse_whitespace() {
-            Ok(Some(peek)) => peek,
-            Ok(None) => {
+        let peek = match try_with!(self.de.parse_whitespace(), FieldResult::Error) {
+            Some(peek) => peek,
+            None => {
                 return FieldResult::Error(self.de.peek_error(ErrorCode::EofWhileParsingList));
             }
-            Err(err) => return FieldResult::Error(err),
         };
         let peek = match peek {
             b']' => {
@@ -1865,10 +1876,7 @@ impl<'de, 'a, R: Read<'de> + 'a> SeqAccess<'a, R> {
             }
             b',' if !self.first => {
                 self.de.eat_char();
-                match self.de.parse_whitespace_in_value() {
-                    Ok(peek) => peek,
-                    Err(err) => return FieldResult::Error(err),
-                }
+                try_with!(self.de.parse_whitespace_in_value(), FieldResult::Error)
             }
             b => {
                 if self.first {
@@ -1913,18 +1921,6 @@ impl<'a, R: 'a> MapAccess<'a, R> {
     fn new(de: &'a mut Deserializer<R>) -> Self {
         MapAccess { de, first: true }
     }
-}
-
-macro_rules! try_with {
-    ($e:expr, $wrap:expr) => {
-        match $e {
-            crate::lib::Result::Ok(val) => val,
-            crate::lib::Result::Err(err) => return $wrap(err),
-        }
-    };
-    ($e:expr, $wrap:expr,) => {
-        try_with!($e, $wrap)
-    };
 }
 
 enum KeyResult {

--- a/src/de.rs
+++ b/src/de.rs
@@ -234,6 +234,24 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         Error::syntax(reason, position.line, position.column)
     }
 
+    /// Returns the first non-whitespace byte without consuming it, or `Err` if
+    /// EOF is encountered.
+    fn parse_whitespace_in_value(&mut self) -> Result<u8> {
+        match tri!(self.parse_whitespace()) {
+            Some(b) => Ok(b),
+            None => Err(self.peek_error(ErrorCode::EofWhileParsingValue)),
+        }
+    }
+
+    /// Returns the first non-whitespace byte without consuming it, or `Err` if
+    /// EOF is encountered.
+    fn parse_whitespace_in_object(&mut self) -> Result<u8> {
+        match tri!(self.parse_whitespace()) {
+            Some(b) => Ok(b),
+            None => Err(self.peek_error(ErrorCode::EofWhileParsingObject)),
+        }
+    }
+
     /// Returns the first non-whitespace byte without consuming it, or `None` if
     /// EOF is encountered.
     fn parse_whitespace(&mut self) -> Result<Option<u8>> {
@@ -304,12 +322,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'-' => {
@@ -961,13 +974,12 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     }
 
     fn parse_object_colon(&mut self) -> Result<()> {
-        match tri!(self.parse_whitespace()) {
-            Some(b':') => {
+        match tri!(self.parse_whitespace_in_object()) {
+            b':' => {
                 self.eat_char();
                 Ok(())
             }
-            Some(_) => Err(self.peek_error(ErrorCode::ExpectedColon)),
-            None => Err(self.peek_error(ErrorCode::EofWhileParsingObject)),
+            _ => Err(self.peek_error(ErrorCode::ExpectedColon)),
         }
     }
 
@@ -990,14 +1002,13 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     }
 
     fn end_map(&mut self) -> Result<()> {
-        match tri!(self.parse_whitespace()) {
-            Some(b'}') => {
+        match tri!(self.parse_whitespace_in_object()) {
+            b'}' => {
                 self.eat_char();
                 Ok(())
             }
-            Some(b',') => Err(self.peek_error(ErrorCode::TrailingComma)),
-            Some(_) => Err(self.peek_error(ErrorCode::TrailingCharacters)),
-            None => Err(self.peek_error(ErrorCode::EofWhileParsingObject)),
+            b',' => Err(self.peek_error(ErrorCode::TrailingComma)),
+            _ => Err(self.peek_error(ErrorCode::TrailingCharacters)),
         }
     }
 
@@ -1006,12 +1017,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         let mut enclosing = None;
 
         loop {
-            let peek = match tri!(self.parse_whitespace()) {
-                Some(b) => b,
-                None => {
-                    return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-                }
-            };
+            let peek = tri!(self.parse_whitespace_in_value());
 
             let frame = match peek {
                 b'n' => {
@@ -1099,16 +1105,14 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             }
 
             if frame == b'{' {
-                match tri!(self.parse_whitespace()) {
-                    Some(b'"') => self.eat_char(),
-                    Some(_) => return Err(self.peek_error(ErrorCode::KeyMustBeAString)),
-                    None => return Err(self.peek_error(ErrorCode::EofWhileParsingObject)),
+                match tri!(self.parse_whitespace_in_object()) {
+                    b'"' => self.eat_char(),
+                    _ => return Err(self.peek_error(ErrorCode::KeyMustBeAString)),
                 }
                 tri!(self.read.ignore_str());
-                match tri!(self.parse_whitespace()) {
-                    Some(b':') => self.eat_char(),
-                    Some(_) => return Err(self.peek_error(ErrorCode::ExpectedColon)),
-                    None => return Err(self.peek_error(ErrorCode::EofWhileParsingObject)),
+                match tri!(self.parse_whitespace_in_object()) {
+                    b':' => self.eat_char(),
+                    _ => return Err(self.peek_error(ErrorCode::ExpectedColon)),
                 }
             }
 
@@ -1292,12 +1296,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'n' => {
@@ -1368,12 +1367,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b't' => {
@@ -1425,15 +1419,12 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         {
             let mut buf = String::new();
 
-            match tri!(self.parse_whitespace()) {
-                Some(b'-') => {
+            match tri!(self.parse_whitespace_in_value()) {
+                b'-' => {
                     self.eat_char();
                     buf.push('-');
                 }
-                Some(_) => {}
-                None => {
-                    return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-                }
+                _ => {}
             };
 
             tri!(self.scan_integer128(&mut buf));
@@ -1455,14 +1446,11 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         where
             V: de::Visitor<'de>,
         {
-            match tri!(self.parse_whitespace()) {
-                Some(b'-') => {
+            match tri!(self.parse_whitespace_in_value()) {
+                b'-' => {
                     return Err(self.peek_error(ErrorCode::NumberOutOfRange));
                 }
-                Some(_) => {}
-                None => {
-                    return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-                }
+                _ => {}
             }
 
             let mut buf = String::new();
@@ -1493,12 +1481,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'"' => {
@@ -1600,12 +1583,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'"' => {
@@ -1654,12 +1632,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'n' => {
@@ -1704,12 +1677,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'[' => {
@@ -1755,12 +1723,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'{' => {
@@ -1792,12 +1755,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = match tri!(self.parse_whitespace()) {
-            Some(b) => b,
-            None => {
-                return Err(self.peek_error(ErrorCode::EofWhileParsingValue));
-            }
-        };
+        let peek = tri!(self.parse_whitespace_in_value());
 
         let value = match peek {
             b'[' => {
@@ -1843,25 +1801,23 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        match tri!(self.parse_whitespace()) {
-            Some(b'{') => {
+        match tri!(self.parse_whitespace_in_value()) {
+            b'{' => {
                 check_recursion! {
                     self.eat_char();
                     let value = tri!(visitor.visit_enum(VariantAccess::new(self)));
                 }
 
-                match tri!(self.parse_whitespace()) {
-                    Some(b'}') => {
+                match tri!(self.parse_whitespace_in_object()) {
+                    b'}' => {
                         self.eat_char();
                         Ok(value)
                     }
-                    Some(_) => Err(self.error(ErrorCode::ExpectedSomeValue)),
-                    None => Err(self.error(ErrorCode::EofWhileParsingObject)),
+                    _ => Err(self.error(ErrorCode::ExpectedSomeValue)),
                 }
             }
-            Some(b'"') => visitor.visit_enum(UnitVariantAccess::new(self)),
-            Some(_) => Err(self.peek_error(ErrorCode::ExpectedSomeValue)),
-            None => Err(self.peek_error(ErrorCode::EofWhileParsingValue)),
+            b'"' => visitor.visit_enum(UnitVariantAccess::new(self)),
+            _ => Err(self.peek_error(ErrorCode::ExpectedSomeValue)),
         }
     }
 
@@ -1905,12 +1861,12 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
             }
             Some(b',') if !self.first => {
                 self.de.eat_char();
-                tri!(self.de.parse_whitespace())
+                tri!(self.de.parse_whitespace_in_value())
             }
             Some(b) => {
                 if self.first {
                     self.first = false;
-                    Some(b)
+                    b
                 } else {
                     return Err(self.de.peek_error(ErrorCode::ExpectedListCommaOrEnd));
                 }
@@ -1921,9 +1877,8 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
         };
 
         match peek {
-            Some(b']') => Err(self.de.peek_error(ErrorCode::TrailingComma)),
-            Some(_) => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
-            None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
+            b']' => Err(self.de.peek_error(ErrorCode::TrailingComma)),
+            _ => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
         }
     }
 }
@@ -1946,32 +1901,28 @@ impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
     where
         K: de::DeserializeSeed<'de>,
     {
-        let peek = match tri!(self.de.parse_whitespace()) {
-            Some(b'}') => {
+        let peek = match tri!(self.de.parse_whitespace_in_object()) {
+            b'}' => {
                 return Ok(None);
             }
-            Some(b',') if !self.first => {
+            b',' if !self.first => {
                 self.de.eat_char();
-                tri!(self.de.parse_whitespace())
+                tri!(self.de.parse_whitespace_in_value())
             }
-            Some(b) => {
+            b => {
                 if self.first {
                     self.first = false;
-                    Some(b)
+                    b
                 } else {
                     return Err(self.de.peek_error(ErrorCode::ExpectedObjectCommaOrEnd));
                 }
             }
-            None => {
-                return Err(self.de.peek_error(ErrorCode::EofWhileParsingObject));
-            }
         };
 
         match peek {
-            Some(b'"') => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
-            Some(b'}') => Err(self.de.peek_error(ErrorCode::TrailingComma)),
-            Some(_) => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
-            None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
+            b'"' => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
+            b'}' => Err(self.de.peek_error(ErrorCode::TrailingComma)),
+            _ => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -252,6 +252,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
 
     fn parse_whitespace_until(&mut self, expected: u8, visitor: &dyn Expected) -> Result<()> {
         if tri!(self.parse_whitespace_in_value()) == expected {
+            self.eat_char();
             Ok(())
         } else {
             Err(self.peek_invalid_type(visitor))
@@ -1262,15 +1263,15 @@ macro_rules! if_checking_recursion_limit {
 }
 
 macro_rules! check_recursion {
-    ($this:ident $($body:tt)*) => {
+    ($this:ident; $($body:tt)*) => {
         if_checking_recursion_limit! {
             $this.remaining_depth -= 1;
             if $this.remaining_depth == 0 {
-                return Err($this.peek_error(ErrorCode::RecursionLimitExceeded));
+                return Err($this.error(ErrorCode::RecursionLimitExceeded));
             }
         }
 
-        $this $($body)*
+        $($body)*
 
         if_checking_recursion_limit! {
             $this.remaining_depth += 1;
@@ -1318,8 +1319,9 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                 }
             }
             b'[' => {
+                self.eat_char();
                 check_recursion! {
-                    self.eat_char();
+                    self;
                     let ret = visitor.visit_seq(SeqAccess::new(self));
                 }
 
@@ -1329,8 +1331,9 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                 }
             }
             b'{' => {
+                self.eat_char();
                 check_recursion! {
-                    self.eat_char();
+                    self;
                     let ret = visitor.visit_map(MapAccess::new(self));
                 }
 
@@ -1473,7 +1476,6 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     {
         tri!(self.parse_whitespace_until(b'"', &visitor));
 
-        self.eat_char();
         self.scratch.clear();
         let value = match tri!(self.read.parse_str(&mut self.scratch)) {
             Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
@@ -1619,7 +1621,6 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     {
         tri!(self.parse_whitespace_until(b'n', &visitor));
 
-        self.eat_char();
         tri!(self.parse_ident(b"ull"));
 
         match visitor.visit_unit() {
@@ -1659,7 +1660,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         tri!(self.parse_whitespace_until(b'[', &visitor));
 
         check_recursion! {
-            self.eat_char();
+            self;
             let ret = visitor.visit_seq(SeqAccess::new(self));
         }
 
@@ -1695,7 +1696,7 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         tri!(self.parse_whitespace_until(b'{', &visitor));
 
         check_recursion! {
-            self.eat_char();
+            self;
             let ret = visitor.visit_map(MapAccess::new(self));
         }
 
@@ -1718,16 +1719,18 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
         let (ret, ret2) = match peek {
             b'[' => {
+                self.eat_char();
                 check_recursion! {
-                    self.eat_char();
+                    self;
                     let ret = visitor.visit_seq(SeqAccess::new(self));
                 }
 
                 (ret, self.end_seq())
             }
             b'{' => {
+                self.eat_char();
                 check_recursion! {
-                    self.eat_char();
+                    self;
                     let ret = visitor.visit_map(MapAccess::new(self));
                 }
 
@@ -1756,8 +1759,9 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     {
         match tri!(self.parse_whitespace_in_value()) {
             b'{' => {
+                self.eat_char();
                 check_recursion! {
-                    self.eat_char();
+                    self;
                     let value = tri!(visitor.visit_enum(VariantAccess::new(self)));
                 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -165,6 +165,15 @@ macro_rules! if_checking_recursion_limit {
     };
 }
 
+macro_rules! check_recursion_prefix {
+    ($self_: ident, $error: ident) => {
+        $self_.remaining_depth -= 1;
+        if $self_.remaining_depth == 0 {
+            return $error::Error($self_.error(ErrorCode::RecursionLimitExceeded));
+        }
+    };
+}
+
 macro_rules! check_recursion {
     ($this:ident; $($body:tt)*) => {
         if_checking_recursion_limit! {
@@ -342,22 +351,12 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             }
             b'[' => {
                 self.eat_char();
-                if_checking_recursion_limit! {
-                    self.remaining_depth -= 1;
-                    if self.remaining_depth == 0 {
-                        return AnyResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
-                    }
-                }
+                check_recursion_prefix!(self, AnyResult);
                 AnyResult::Array
             }
             b'{' => {
                 self.eat_char();
-                if_checking_recursion_limit! {
-                    self.remaining_depth -= 1;
-                    if self.remaining_depth == 0 {
-                        return AnyResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
-                    }
-                }
+                check_recursion_prefix!(self, AnyResult);
                 AnyResult::Map
             }
             _ => AnyResult::Error(self.peek_error(ErrorCode::ExpectedSomeValue)),
@@ -394,22 +393,12 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         match self.parse_whitespace_in_value() {
             Ok(b'[') => {
                 self.eat_char();
-                if_checking_recursion_limit! {
-                    self.remaining_depth -= 1;
-                    if self.remaining_depth == 0 {
-                        return StructResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
-                    }
-                }
+                check_recursion_prefix!(self, StructResult);
                 StructResult::Array(SeqAccess::new(self))
             }
             Ok(b'{') => {
                 self.eat_char();
-                if_checking_recursion_limit! {
-                    self.remaining_depth -= 1;
-                    if self.remaining_depth == 0 {
-                        return StructResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
-                    }
-                }
+                check_recursion_prefix!(self, StructResult);
                 StructResult::Map(MapAccess::new(self))
             }
             Ok(_) => {
@@ -425,12 +414,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         match try_with!(self.parse_whitespace_in_value(), EnumResult::Error) {
             b'{' => {
                 self.eat_char();
-                if_checking_recursion_limit! {
-                    self.remaining_depth -= 1;
-                    if self.remaining_depth == 0 {
-                        return EnumResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
-                    }
-                }
+                check_recursion_prefix!(self, EnumResult);
                 EnumResult::Variant(VariantAccess::new(self))
             }
             b'"' => EnumResult::Unit(UnitVariantAccess::new(self)),

--- a/src/de.rs
+++ b/src/de.rs
@@ -1886,34 +1886,34 @@ impl<'a, R: 'a> SeqAccess<'a, R> {
     }
 }
 
-enum FieldResult {
+enum ElementResult {
     Error(Error),
     Field,
     Done,
 }
 
 impl<'de, 'a, R: Read<'de> + 'a> SeqAccess<'a, R> {
-    fn parse_field_prefix(&mut self) -> FieldResult {
-        let peek = match try_with!(self.de.parse_whitespace(), FieldResult::Error) {
+    fn parse_element_prefix(&mut self) -> ElementResult {
+        let peek = match try_with!(self.de.parse_whitespace(), ElementResult::Error) {
             Some(peek) => peek,
             None => {
-                return FieldResult::Error(self.de.peek_error(ErrorCode::EofWhileParsingList));
+                return ElementResult::Error(self.de.peek_error(ErrorCode::EofWhileParsingList));
             }
         };
         let peek = match peek {
             b']' => {
-                return FieldResult::Done;
+                return ElementResult::Done;
             }
             b',' if !self.first => {
                 self.de.eat_char();
-                try_with!(self.de.parse_whitespace_in_value(), FieldResult::Error)
+                try_with!(self.de.parse_whitespace_in_value(), ElementResult::Error)
             }
             b => {
                 if self.first {
                     self.first = false;
                     b
                 } else {
-                    return FieldResult::Error(
+                    return ElementResult::Error(
                         self.de.peek_error(ErrorCode::ExpectedListCommaOrEnd),
                     );
                 }
@@ -1921,8 +1921,8 @@ impl<'de, 'a, R: Read<'de> + 'a> SeqAccess<'a, R> {
         };
 
         match peek {
-            b']' => FieldResult::Error(self.de.peek_error(ErrorCode::TrailingComma)),
-            _ => FieldResult::Field,
+            b']' => ElementResult::Error(self.de.peek_error(ErrorCode::TrailingComma)),
+            _ => ElementResult::Field,
         }
     }
 }
@@ -1934,10 +1934,10 @@ impl<'de, 'a, R: Read<'de> + 'a> de::SeqAccess<'de> for SeqAccess<'a, R> {
     where
         T: de::DeserializeSeed<'de>,
     {
-        match self.parse_field_prefix() {
-            FieldResult::Field => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
-            FieldResult::Done => Ok(None),
-            FieldResult::Error(err) => Err(err),
+        match self.parse_element_prefix() {
+            ElementResult::Field => Ok(Some(tri!(seed.deserialize(&mut *self.de)))),
+            ElementResult::Done => Ok(None),
+            ElementResult::Error(err) => Err(err),
         }
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1915,6 +1915,54 @@ impl<'a, R: 'a> MapAccess<'a, R> {
     }
 }
 
+macro_rules! try_with {
+    ($e:expr, $wrap:expr) => {
+        match $e {
+            crate::lib::Result::Ok(val) => val,
+            crate::lib::Result::Err(err) => return $wrap(err),
+        }
+    };
+    ($e:expr, $wrap:expr,) => {
+        try_with!($e, $wrap)
+    };
+}
+
+enum KeyResult {
+    Error(Error),
+    Key,
+    Done,
+}
+
+impl<'de, 'a, R: Read<'de> + 'a> MapAccess<'a, R> {
+    fn parse_key_prefix(&mut self) -> KeyResult {
+        let peek = match try_with!(self.de.parse_whitespace_in_object(), KeyResult::Error) {
+            b'}' => {
+                return KeyResult::Done;
+            }
+            b',' if !self.first => {
+                self.de.eat_char();
+                try_with!(self.de.parse_whitespace_in_value(), KeyResult::Error)
+            }
+            b => {
+                if self.first {
+                    self.first = false;
+                    b
+                } else {
+                    return KeyResult::Error(
+                        self.de.peek_error(ErrorCode::ExpectedObjectCommaOrEnd),
+                    );
+                }
+            }
+        };
+
+        match peek {
+            b'"' => KeyResult::Key,
+            b'}' => KeyResult::Error(self.de.peek_error(ErrorCode::TrailingComma)),
+            _ => KeyResult::Error(self.de.peek_error(ErrorCode::KeyMustBeAString)),
+        }
+    }
+}
+
 impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
     type Error = Error;
 
@@ -1922,28 +1970,10 @@ impl<'de, 'a, R: Read<'de> + 'a> de::MapAccess<'de> for MapAccess<'a, R> {
     where
         K: de::DeserializeSeed<'de>,
     {
-        let peek = match tri!(self.de.parse_whitespace_in_object()) {
-            b'}' => {
-                return Ok(None);
-            }
-            b',' if !self.first => {
-                self.de.eat_char();
-                tri!(self.de.parse_whitespace_in_value())
-            }
-            b => {
-                if self.first {
-                    self.first = false;
-                    b
-                } else {
-                    return Err(self.de.peek_error(ErrorCode::ExpectedObjectCommaOrEnd));
-                }
-            }
-        };
-
-        match peek {
-            b'"' => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
-            b'}' => Err(self.de.peek_error(ErrorCode::TrailingComma)),
-            _ => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
+        match self.parse_key_prefix() {
+            KeyResult::Key => seed.deserialize(MapKey { de: &mut *self.de }).map(Some),
+            KeyResult::Done => Ok(None),
+            KeyResult::Error(err) => Err(err),
         }
     }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -137,9 +137,9 @@ impl ParserNumber {
 }
 
 /// Flattened `Result<b'[' | b'{'), Error>`. Helps llvm when optimizing
-enum StructResult {
-    Array,
-    Map,
+enum StructResult<'a, R> {
+    Array(SeqAccess<'a, R>),
+    Map(MapAccess<'a, R>),
     Error(Error),
 }
 
@@ -367,7 +367,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         self.read.parse_str(&mut self.scratch)
     }
 
-    fn parse_struct_prefix(&mut self, exp: &dyn Expected) -> StructResult {
+    fn parse_struct_prefix(&mut self, exp: &dyn Expected) -> StructResult<'_, R> {
         match self.parse_whitespace_in_value() {
             Ok(b'[') => {
                 self.eat_char();
@@ -377,7 +377,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                         return StructResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
                     }
                 }
-                StructResult::Array
+                StructResult::Array(SeqAccess::new(self))
             }
             Ok(b'{') => {
                 self.eat_char();
@@ -387,7 +387,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                         return StructResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
                     }
                 }
-                StructResult::Map
+                StructResult::Map(MapAccess::new(self))
             }
             Ok(_) => {
                 let err = self.peek_invalid_type(exp);
@@ -1815,14 +1815,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         V: de::Visitor<'de>,
     {
         let (ret, ret2) = match self.parse_struct_prefix(&visitor) {
-            StructResult::Array => (
-                visitor.visit_seq(SeqAccess::new(self)),
-                self.end_recursion_and_seq(),
-            ),
-            StructResult::Map => (
-                visitor.visit_map(MapAccess::new(self)),
-                self.end_recursion_and_map(),
-            ),
+            StructResult::Array(access) => {
+                (visitor.visit_seq(access), self.end_recursion_and_seq())
+            }
+            StructResult::Map(access) => (visitor.visit_map(access), self.end_recursion_and_map()),
             StructResult::Error(err) => return Err(err),
         };
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -358,6 +358,19 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    fn parse_number_prefix(&mut self, exp: &dyn Expected) -> Result<ParserNumber> {
+        let peek = tri!(self.parse_whitespace_in_value());
+
+        match peek {
+            b'-' => {
+                self.eat_char();
+                self.parse_integer(false)
+            }
+            b'0'..=b'9' => self.parse_integer(true),
+            _ => Err(self.peek_invalid_type(exp)),
+        }
+    }
+
     fn parse_str<'s>(&'s mut self) -> Result<Reference<'de, 's, str>> {
         self.eat_char();
         self.scratch.clear();
@@ -512,16 +525,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = tri!(self.parse_whitespace_in_value());
-
-        let value = match peek {
-            b'-' => {
-                self.eat_char();
-                tri!(self.parse_integer(false)).visit(visitor)
-            }
-            b'0'..=b'9' => tri!(self.parse_integer(true)).visit(visitor),
-            _ => Err(self.peek_invalid_type(&visitor)),
-        };
+        let value = tri!(self.parse_number_prefix(&visitor)).visit(visitor);
 
         match value {
             Ok(value) => Ok(value),

--- a/src/de.rs
+++ b/src/de.rs
@@ -131,6 +131,39 @@ enum StructResult {
     Error(Error),
 }
 
+#[cfg(not(feature = "unbounded_depth"))]
+macro_rules! if_checking_recursion_limit {
+    ($($body:tt)*) => {
+        $($body)*
+    };
+}
+
+#[cfg(feature = "unbounded_depth")]
+macro_rules! if_checking_recursion_limit {
+    ($this:ident $($body:tt)*) => {
+        if !$this.disable_recursion_limit {
+            $this $($body)*
+        }
+    };
+}
+
+macro_rules! check_recursion {
+    ($this:ident; $($body:tt)*) => {
+        if_checking_recursion_limit! {
+            $this.remaining_depth -= 1;
+            if $this.remaining_depth == 0 {
+                return Err($this.error(ErrorCode::RecursionLimitExceeded));
+            }
+        }
+
+        $($body)*
+
+        if_checking_recursion_limit! {
+            $this.remaining_depth += 1;
+        }
+    };
+}
+
 impl<'de, R: Read<'de>> Deserializer<R> {
     /// The `Deserializer::end` method should be called after a value has been fully deserialized.
     /// This allows the `Deserializer` to validate that the input stream is at the end or that it
@@ -252,10 +285,22 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         match self.parse_whitespace_in_value() {
             Ok(b'[') => {
                 self.eat_char();
+                if_checking_recursion_limit! {
+                    self.remaining_depth -= 1;
+                    if self.remaining_depth == 0 {
+                        return StructResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
+                    }
+                }
                 StructResult::Array
             }
             Ok(b'{') => {
                 self.eat_char();
+                if_checking_recursion_limit! {
+                    self.remaining_depth -= 1;
+                    if self.remaining_depth == 0 {
+                        return StructResult::Error(self.error(ErrorCode::RecursionLimitExceeded));
+                    }
+                }
                 StructResult::Map
             }
             Ok(_) => {
@@ -999,6 +1044,13 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    fn end_recursion_and_seq(&mut self) -> Result<()> {
+        if_checking_recursion_limit! {
+            self.remaining_depth += 1;
+        }
+        self.end_seq()
+    }
+
     fn end_seq(&mut self) -> Result<()> {
         match tri!(self.parse_whitespace()) {
             Some(b']') => {
@@ -1015,6 +1067,13 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             Some(_) => Err(self.peek_error(ErrorCode::TrailingCharacters)),
             None => Err(self.peek_error(ErrorCode::EofWhileParsingList)),
         }
+    }
+
+    fn end_recursion_and_map(&mut self) -> Result<()> {
+        if_checking_recursion_limit! {
+            self.remaining_depth += 1;
+        }
+        self.end_map()
     }
 
     fn end_map(&mut self) -> Result<()> {
@@ -1267,39 +1326,6 @@ macro_rules! deserialize_number {
             V: de::Visitor<'de>,
         {
             self.deserialize_number(visitor)
-        }
-    };
-}
-
-#[cfg(not(feature = "unbounded_depth"))]
-macro_rules! if_checking_recursion_limit {
-    ($($body:tt)*) => {
-        $($body)*
-    };
-}
-
-#[cfg(feature = "unbounded_depth")]
-macro_rules! if_checking_recursion_limit {
-    ($this:ident $($body:tt)*) => {
-        if !$this.disable_recursion_limit {
-            $this $($body)*
-        }
-    };
-}
-
-macro_rules! check_recursion {
-    ($this:ident; $($body:tt)*) => {
-        if_checking_recursion_limit! {
-            $this.remaining_depth -= 1;
-            if $this.remaining_depth == 0 {
-                return Err($this.error(ErrorCode::RecursionLimitExceeded));
-            }
-        }
-
-        $($body)*
-
-        if_checking_recursion_limit! {
-            $this.remaining_depth += 1;
         }
     };
 }
@@ -1741,22 +1767,14 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
         V: de::Visitor<'de>,
     {
         let (ret, ret2) = match self.parse_struct_prefix(&visitor) {
-            StructResult::Array => {
-                check_recursion! {
-                    self;
-                    let ret = visitor.visit_seq(SeqAccess::new(self));
-                }
-
-                (ret, self.end_seq())
-            }
-            StructResult::Map => {
-                check_recursion! {
-                    self;
-                    let ret = visitor.visit_map(MapAccess::new(self));
-                }
-
-                (ret, self.end_map())
-            }
+            StructResult::Array => (
+                visitor.visit_seq(SeqAccess::new(self)),
+                self.end_recursion_and_seq(),
+            ),
+            StructResult::Map => (
+                visitor.visit_map(MapAccess::new(self)),
+                self.end_recursion_and_map(),
+            ),
             StructResult::Error(err) => return Err(err),
         };
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -250,6 +250,14 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    fn parse_whitespace_until(&mut self, expected: u8, visitor: &dyn Expected) -> Result<()> {
+        if tri!(self.parse_whitespace_in_value()) == expected {
+            Ok(())
+        } else {
+            Err(self.peek_invalid_type(visitor))
+        }
+    }
+
     /// Returns the first non-whitespace byte without consuming it, or `Err` if
     /// EOF is encountered.
     fn parse_whitespace_in_object(&mut self) -> Result<u8> {
@@ -1463,18 +1471,13 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = tri!(self.parse_whitespace_in_value());
+        tri!(self.parse_whitespace_until(b'"', &visitor));
 
-        let value = match peek {
-            b'"' => {
-                self.eat_char();
-                self.scratch.clear();
-                match tri!(self.read.parse_str(&mut self.scratch)) {
-                    Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
-                    Reference::Copied(s) => visitor.visit_str(s),
-                }
-            }
-            _ => Err(self.peek_invalid_type(&visitor)),
+        self.eat_char();
+        self.scratch.clear();
+        let value = match tri!(self.read.parse_str(&mut self.scratch)) {
+            Reference::Borrowed(s) => visitor.visit_borrowed_str(s),
+            Reference::Copied(s) => visitor.visit_str(s),
         };
 
         match value {
@@ -1614,18 +1617,12 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = tri!(self.parse_whitespace_in_value());
+        tri!(self.parse_whitespace_until(b'n', &visitor));
 
-        let value = match peek {
-            b'n' => {
-                self.eat_char();
-                tri!(self.parse_ident(b"ull"));
-                visitor.visit_unit()
-            }
-            _ => Err(self.peek_invalid_type(&visitor)),
-        };
+        self.eat_char();
+        tri!(self.parse_ident(b"ull"));
 
-        match value {
+        match visitor.visit_unit() {
             Ok(value) => Ok(value),
             Err(err) => Err(self.fix_position(err)),
         }
@@ -1659,26 +1656,16 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = tri!(self.parse_whitespace_in_value());
+        tri!(self.parse_whitespace_until(b'[', &visitor));
 
-        let value = match peek {
-            b'[' => {
-                check_recursion! {
-                    self.eat_char();
-                    let ret = visitor.visit_seq(SeqAccess::new(self));
-                }
+        check_recursion! {
+            self.eat_char();
+            let ret = visitor.visit_seq(SeqAccess::new(self));
+        }
 
-                match (ret, self.end_seq()) {
-                    (Ok(ret), Ok(())) => Ok(ret),
-                    (Err(err), _) | (_, Err(err)) => Err(err),
-                }
-            }
-            _ => Err(self.peek_invalid_type(&visitor)),
-        };
-
-        match value {
-            Ok(value) => Ok(value),
-            Err(err) => Err(self.fix_position(err)),
+        match (ret, self.end_seq()) {
+            (Ok(ret), Ok(())) => Ok(ret),
+            (Err(err), _) | (_, Err(err)) => Err(self.fix_position(err)),
         }
     }
 
@@ -1705,26 +1692,16 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     where
         V: de::Visitor<'de>,
     {
-        let peek = tri!(self.parse_whitespace_in_value());
+        tri!(self.parse_whitespace_until(b'{', &visitor));
 
-        let value = match peek {
-            b'{' => {
-                check_recursion! {
-                    self.eat_char();
-                    let ret = visitor.visit_map(MapAccess::new(self));
-                }
+        check_recursion! {
+            self.eat_char();
+            let ret = visitor.visit_map(MapAccess::new(self));
+        }
 
-                match (ret, self.end_map()) {
-                    (Ok(ret), Ok(())) => Ok(ret),
-                    (Err(err), _) | (_, Err(err)) => Err(err),
-                }
-            }
-            _ => Err(self.peek_invalid_type(&visitor)),
-        };
-
-        match value {
-            Ok(value) => Ok(value),
-            Err(err) => Err(self.fix_position(err)),
+        match (ret, self.end_map()) {
+            (Ok(ret), Ok(())) => Ok(ret),
+            (Err(err), _) | (_, Err(err)) => Err(self.fix_position(err)),
         }
     }
 
@@ -1739,17 +1716,14 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     {
         let peek = tri!(self.parse_whitespace_in_value());
 
-        let value = match peek {
+        let (ret, ret2) = match peek {
             b'[' => {
                 check_recursion! {
                     self.eat_char();
                     let ret = visitor.visit_seq(SeqAccess::new(self));
                 }
 
-                match (ret, self.end_seq()) {
-                    (Ok(ret), Ok(())) => Ok(ret),
-                    (Err(err), _) | (_, Err(err)) => Err(err),
-                }
+                (ret, self.end_seq())
             }
             b'{' => {
                 check_recursion! {
@@ -1757,17 +1731,14 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                     let ret = visitor.visit_map(MapAccess::new(self));
                 }
 
-                match (ret, self.end_map()) {
-                    (Ok(ret), Ok(())) => Ok(ret),
-                    (Err(err), _) | (_, Err(err)) => Err(err),
-                }
+                (ret, self.end_map())
             }
-            _ => Err(self.peek_invalid_type(&visitor)),
+            _ => (Err(self.peek_invalid_type(&visitor)), Ok(())),
         };
 
-        match value {
-            Ok(value) => Ok(value),
-            Err(err) => Err(self.fix_position(err)),
+        match (ret, ret2) {
+            (Ok(ret), Ok(())) => Ok(ret),
+            (Err(err), _) | (_, Err(err)) => Err(self.fix_position(err)),
         }
     }
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -172,47 +172,37 @@ where
 
     #[inline]
     fn serialize_bool(self, value: bool) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_bool(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i8(self, value: i8) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i8(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i16(self, value: i16) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i16(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i32(self, value: i32) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i32(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_i64(self, value: i64) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_i64(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     serde_if_integer128! {
@@ -225,38 +215,30 @@ where
 
     #[inline]
     fn serialize_u8(self, value: u8) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u8(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_u16(self, value: u16) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u16(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_u32(self, value: u32) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u32(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<()> {
-        tri!(self
-            .formatter
+        self.formatter
             .write_u64(&mut self.writer, value)
-            .map_err(Error::io));
-        Ok(())
+            .map_err(Error::io)
     }
 
     serde_if_integer128! {
@@ -270,33 +252,23 @@ where
     #[inline]
     fn serialize_f32(self, value: f32) -> Result<()> {
         match value.classify() {
-            FpCategory::Nan | FpCategory::Infinite => {
-                tri!(self.write_null());
-            }
-            _ => {
-                tri!(self
-                    .formatter
-                    .write_f32(&mut self.writer, value)
-                    .map_err(Error::io));
-            }
+            FpCategory::Nan | FpCategory::Infinite => self.write_null(),
+            _ => self
+                .formatter
+                .write_f32(&mut self.writer, value)
+                .map_err(Error::io),
         }
-        Ok(())
     }
 
     #[inline]
     fn serialize_f64(self, value: f64) -> Result<()> {
         match value.classify() {
-            FpCategory::Nan | FpCategory::Infinite => {
-                tri!(self.write_null());
-            }
-            _ => {
-                tri!(self
-                    .formatter
-                    .write_f64(&mut self.writer, value)
-                    .map_err(Error::io));
-            }
+            FpCategory::Nan | FpCategory::Infinite => self.write_null(),
+            _ => self
+                .formatter
+                .write_f64(&mut self.writer, value)
+                .map_err(Error::io),
         }
-        Ok(())
     }
 
     #[inline]
@@ -308,8 +280,7 @@ where
 
     #[inline]
     fn serialize_str(self, value: &str) -> Result<()> {
-        tri!(format_escaped_str(&mut self.writer, &mut self.formatter, value).map_err(Error::io));
-        Ok(())
+        format_escaped_str(&mut self.writer, &mut self.formatter, value).map_err(Error::io)
     }
 
     #[inline]
@@ -324,8 +295,7 @@ where
 
     #[inline]
     fn serialize_unit(self) -> Result<()> {
-        tri!(self.write_null());
-        Ok(())
+        self.write_null()
     }
 
     #[inline]
@@ -366,8 +336,7 @@ where
         tri!(self.serialize_variant(variant));
         tri!(value.serialize(&mut *self));
         tri!(self.end_object_value());
-        tri!(self.end_object());
-        Ok(())
+        self.end_object()
     }
 
     #[inline]
@@ -568,13 +537,10 @@ where
     #[inline]
     fn end(self) -> Result<()> {
         match self {
-            Compound::Map { ser, state } => {
-                match state {
-                    State::Empty => {}
-                    _ => tri!(ser.end_array()),
-                }
-                Ok(())
-            }
+            Compound::Map { ser, state } => match state {
+                State::Empty => Ok(()),
+                _ => ser.end_array(),
+            },
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
             #[cfg(feature = "raw_value")]
@@ -652,8 +618,7 @@ where
                     _ => tri!(ser.end_array()),
                 }
                 tri!(ser.end_object_value());
-                tri!(ser.end_object());
-                Ok(())
+                ser.end_object()
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -746,8 +711,7 @@ where
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { ref mut ser, .. } => {
                 if key == crate::number::TOKEN {
-                    tri!(value.serialize(NumberStrEmitter(&mut *ser)));
-                    Ok(())
+                    value.serialize(NumberStrEmitter(&mut *ser))
                 } else {
                     Err(invalid_number())
                 }
@@ -755,8 +719,7 @@ where
             #[cfg(feature = "raw_value")]
             Compound::RawValue { ref mut ser, .. } => {
                 if key == crate::raw::TOKEN {
-                    tri!(value.serialize(RawValueStrEmitter(&mut *ser)));
-                    Ok(())
+                    value.serialize(RawValueStrEmitter(&mut *ser))
                 } else {
                     Err(invalid_raw_value())
                 }
@@ -807,8 +770,7 @@ where
                     _ => tri!(ser.end_object()),
                 }
                 tri!(ser.end_object_value());
-                tri!(ser.end_object());
-                Ok(())
+                ser.end_object()
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -886,8 +848,7 @@ where
             .formatter
             .write_i8(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     fn serialize_i16(self, value: i16) -> Result<()> {
@@ -897,8 +858,7 @@ where
             .formatter
             .write_i16(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     fn serialize_i32(self, value: i32) -> Result<()> {
@@ -908,8 +868,7 @@ where
             .formatter
             .write_i32(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     fn serialize_i64(self, value: i64) -> Result<()> {
@@ -919,8 +878,7 @@ where
             .formatter
             .write_i64(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     serde_if_integer128! {
@@ -931,8 +889,7 @@ where
                 .formatter
                 .write_number_str(&mut self.ser.writer, &value.to_string())
                 .map_err(Error::io));
-            tri!(self.ser.end_string());
-            Ok(())
+            self.ser.end_string()
         }
     }
 
@@ -943,8 +900,7 @@ where
             .formatter
             .write_u8(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     fn serialize_u16(self, value: u16) -> Result<()> {
@@ -954,8 +910,7 @@ where
             .formatter
             .write_u16(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     fn serialize_u32(self, value: u32) -> Result<()> {
@@ -965,8 +920,7 @@ where
             .formatter
             .write_u32(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     fn serialize_u64(self, value: u64) -> Result<()> {
@@ -976,8 +930,7 @@ where
             .formatter
             .write_u64(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self.ser.end_string());
-        Ok(())
+        self.ser.end_string()
     }
 
     serde_if_integer128! {
@@ -988,8 +941,7 @@ where
                 .formatter
                 .write_number_str(&mut self.ser.writer, &value.to_string())
                 .map_err(Error::io));
-            tri!(self.ser.end_string());
-            Ok(())
+            self.ser.end_string()
         }
     }
 
@@ -1891,8 +1843,7 @@ impl<'a> Formatter for PrettyFormatter<'a> {
         W: ?Sized + io::Write,
     {
         tri!(writer.write_all(if first { b"\n" } else { b",\n" }));
-        tri!(indent(writer, self.current_indent, self.indent));
-        Ok(())
+        indent(writer, self.current_indent, self.indent)
     }
 
     #[inline]
@@ -1963,8 +1914,7 @@ where
 {
     tri!(formatter.begin_string(writer));
     tri!(format_escaped_str_contents(writer, formatter, value));
-    tri!(formatter.end_string(writer));
-    Ok(())
+    formatter.end_string(writer)
 }
 
 fn format_escaped_str_contents<W, F>(
@@ -2048,8 +1998,7 @@ where
     T: ?Sized + Serialize,
 {
     let mut ser = Serializer::new(writer);
-    tri!(value.serialize(&mut ser));
-    Ok(())
+    value.serialize(&mut ser)
 }
 
 /// Serialize the given data structure as pretty-printed JSON into the IO
@@ -2066,8 +2015,7 @@ where
     T: ?Sized + Serialize,
 {
     let mut ser = Serializer::pretty(writer);
-    tri!(value.serialize(&mut ser));
-    Ok(())
+    value.serialize(&mut ser)
 }
 
 /// Serialize the given data structure as a JSON byte vector.

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -53,6 +53,18 @@ where
         self.writer
     }
 
+    fn begin_string(&mut self) -> Result<()> {
+        self.formatter
+            .begin_string(&mut self.writer)
+            .map_err(Error::io)
+    }
+
+    fn end_string(&mut self) -> Result<()> {
+        self.formatter
+            .end_string(&mut self.writer)
+            .map_err(Error::io)
+    }
+
     fn serialize_variant(&mut self, variant: &'static str) -> Result<()> {
         tri!(self
             .formatter
@@ -449,10 +461,7 @@ where
             }
         }
 
-        tri!(self
-            .formatter
-            .begin_string(&mut self.writer)
-            .map_err(Error::io));
+        tri!(self.begin_string());
         {
             let mut adapter = Adapter {
                 writer: &mut self.writer,
@@ -856,195 +865,115 @@ where
     }
 
     fn serialize_i8(self, value: i8) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_i8(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     fn serialize_i16(self, value: i16) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_i16(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     fn serialize_i32(self, value: i32) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_i32(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     fn serialize_i64(self, value: i64) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_i64(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     serde_if_integer128! {
         fn serialize_i128(self, value: i128) -> Result<()> {
-            tri!(self
-                .ser
-                .formatter
-                .begin_string(&mut self.ser.writer)
-                .map_err(Error::io));
+            tri!(self.ser.begin_string());
             tri!(self
                 .ser
                 .formatter
                 .write_number_str(&mut self.ser.writer, &value.to_string())
                 .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .end_string(&mut self.ser.writer)
-                .map_err(Error::io));
+            tri!(self.ser.end_string());
             Ok(())
         }
     }
 
     fn serialize_u8(self, value: u8) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_u8(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     fn serialize_u16(self, value: u16) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_u16(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     fn serialize_u32(self, value: u32) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_u32(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     fn serialize_u64(self, value: u64) -> Result<()> {
-        tri!(self
-            .ser
-            .formatter
-            .begin_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.begin_string());
         tri!(self
             .ser
             .formatter
             .write_u64(&mut self.ser.writer, value)
             .map_err(Error::io));
-        tri!(self
-            .ser
-            .formatter
-            .end_string(&mut self.ser.writer)
-            .map_err(Error::io));
+        tri!(self.ser.end_string());
         Ok(())
     }
 
     serde_if_integer128! {
         fn serialize_u128(self, value: u128) -> Result<()> {
-            tri!(self
-                .ser
-                .formatter
-                .begin_string(&mut self.ser.writer)
-                .map_err(Error::io));
+            tri!(self.ser.begin_string());
             tri!(self
                 .ser
                 .formatter
                 .write_number_str(&mut self.ser.writer, &value.to_string())
                 .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .end_string(&mut self.ser.writer)
-                .map_err(Error::io));
+            tri!(self.ser.end_string());
             Ok(())
         }
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -683,17 +683,12 @@ where
             } => {
                 tri!(ser
                     .formatter
-                    .begin_object_key(&mut ser.writer, *state == State::First)
-                    .map_err(Error::io));
+                    .begin_object_key_io(&mut ser.writer, *state == State::First));
                 *state = State::Rest;
 
                 tri!(key.serialize(MapKeySerializer { ser: *ser }));
 
-                tri!(ser
-                    .formatter
-                    .end_object_key(&mut ser.writer)
-                    .map_err(Error::io));
-                Ok(())
+                ser.formatter.end_object_key_io(&mut ser.writer)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -709,16 +704,9 @@ where
     {
         match *self {
             Compound::Map { ref mut ser, .. } => {
-                tri!(ser
-                    .formatter
-                    .begin_object_value(&mut ser.writer)
-                    .map_err(Error::io));
+                tri!(ser.formatter.begin_object_value_io(&mut ser.writer));
                 tri!(value.serialize(&mut **ser));
-                tri!(ser
-                    .formatter
-                    .end_object_value(&mut ser.writer)
-                    .map_err(Error::io));
-                Ok(())
+                ser.formatter.end_object_value_io(&mut ser.writer)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
@@ -730,13 +718,10 @@ where
     #[inline]
     fn end(self) -> Result<()> {
         match self {
-            Compound::Map { ser, state } => {
-                match state {
-                    State::Empty => {}
-                    _ => tri!(ser.formatter.end_object(&mut ser.writer).map_err(Error::io)),
-                }
-                Ok(())
-            }
+            Compound::Map { ser, state } => match state {
+                State::Empty => Ok(()),
+                _ => ser.formatter.end_object(&mut ser.writer).map_err(Error::io),
+            },
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),
             #[cfg(feature = "raw_value")]
@@ -1921,6 +1906,42 @@ pub trait Formatter {
         writer.write_all(fragment.as_bytes())
     }
 }
+
+trait FormatterExt: Formatter {
+    #[inline]
+    fn begin_object_key_io<W>(&mut self, writer: &mut W, first: bool) -> Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.begin_object_key(writer, first).map_err(Error::io)
+    }
+
+    #[inline]
+    fn end_object_key_io<W>(&mut self, writer: &mut W) -> Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.end_object_key(writer).map_err(Error::io)
+    }
+
+    #[inline]
+    fn begin_object_value_io<W>(&mut self, writer: &mut W) -> Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.begin_object_value(writer).map_err(Error::io)
+    }
+
+    #[inline]
+    fn end_object_value_io<W>(&mut self, writer: &mut W) -> Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        self.end_object_value(writer).map_err(Error::io)
+    }
+}
+
+impl<T> FormatterExt for T where T: Formatter {}
 
 /// This structure compacts a JSON value with no extra whitespace.
 #[derive(Clone, Debug)]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -529,11 +529,9 @@ where
                     .map_err(Error::io));
                 *state = State::Rest;
                 tri!(value.serialize(&mut **ser));
-                tri!(ser
-                    .formatter
+                ser.formatter
                     .end_array_value(&mut ser.writer)
-                    .map_err(Error::io));
-                Ok(())
+                    .map_err(Error::io)
             }
             #[cfg(feature = "arbitrary_precision")]
             Compound::Number { .. } => unreachable!(),


### PR DESCRIPTION
An attempt to replicate the wins in #687 without using unsafe or losing any performance. To achieve this, all commonly duplicated methods have been extracted to less generic methods (only generic on `R`)  which parse up to the visit method and returns an `enum` to indicate how to proceed. Specifically these enums hold the `Error` themselves instead of being wrapped in a `Result´ since that helps codegen slightly.

I unfortunately only have access to a laptop prone to throttling during benchmarking atm, so I don't have reliable measurements but this does seem to give no difference in performance or a couple of percent slowdown so I'd appreciate if someone could attempt to run this independently. (To get some more precise measurements in `json-benchmark` [I hacked in criterion](https://github.com/Marwes/json-benchmark/tree/test) which can run with this command ` cargo run --release --features lib-serde,all-files,parse-struct,parse
-dom,serde_json,criterion --no-default-features -- --bench`)

```
cargo llvm-lines  --bin json-benchmark --no-default-features --features lib-serde,file-twitter,performance  | head -30
```

## Before 
```
  Lines          Copies       Function name
  -----          ------       -------------
  111368 (100%)  1640 (100%)  (TOTAL)
   13186 (11.8%)   43 (2.6%)  <serde_json::de::SeqAccess<R> as serde::de::SeqAccess>::next_element_seed
    9397 (8.4%)    15 (0.9%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_struct
    5430 (4.9%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::User>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    4267 (3.8%)    15 (0.9%)  <serde_json::de::MapAccess<R> as serde::de::MapAccess>::next_key_seed
    3939 (3.5%)    39 (2.4%)  <serde_json::ser::Compound<W,F> as serde::ser::SerializeMap>::serialize_value
    3262 (2.9%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Status>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    3151 (2.8%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::User>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
    2722 (2.4%)     7 (0.4%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_seq
    2353 (2.1%)    38 (2.3%)  <serde_json::de::MapAccess<R> as serde::de::MapAccess>::next_value_seed
    2162 (1.9%)   119 (7.3%)  core::ptr::drop_in_place
    1947 (1.7%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Status>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
    1888 (1.7%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Media>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    1864 (1.7%)    15 (0.9%)  <serde_json::de::MapKey<R> as serde::de::Deserializer>::deserialize_any
    1789 (1.6%)     7 (0.4%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_str
    1626 (1.5%)     6 (0.4%)  serde_json::de::Deserializer<R>::deserialize_number
    1557 (1.4%)    39 (2.4%)  serde::ser::SerializeMap::serialize_entry
    1422 (1.3%)     6 (0.4%)  serde::ser::Serializer::collect_seq
    1330 (1.2%)    25 (1.5%)  core::result::Result<T,E>::map
    1321 (1.2%)    10 (0.6%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_option
    1291 (1.2%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::SearchMetadata>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    1013 (0.9%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Media>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
     988 (0.9%)    28 (1.7%)  <serde::private::de::missing_field::MissingFieldDeserializer<E> as serde::de::Deserializer>::deserialize_any
     946 (0.8%)    38 (2.3%)  serde::private::de::missing_field
     910 (0.8%)     5 (0.3%)  alloc::raw_vec::RawVec<T,A>::grow_amortized
     867 (0.8%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::StatusEntities>::deserialize::__Visitor as serde::de::Visitor>::visit_map
     854 (0.8%)     1 (0.1%)  json_benchmark::copy::twitter::_::<impl serde::ser::Serialize for json_benchmark::copy::twitter::User>::serialize
     817 (0.7%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::UserMention>::deserialize::__Visitor as serde::de::Visitor>::visit_map
```

## After

```
  Lines         Copies       Function name
  -----         ------       -------------
  90777 (100%)  1617 (100%)  (TOTAL)
   5430 (6.0%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::User>::deserialize::__Visitor as serde::de::Visitor>::visit_map
   5118 (5.6%)    43 (2.7%)  <serde_json::de::SeqAccess<R> as serde::de::SeqAccess>::next_element_seed
   4885 (5.4%)    15 (0.9%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_struct
   3262 (3.6%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Status>::deserialize::__Visitor as serde::de::Visitor>::visit_map
   3151 (3.5%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::User>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
   2353 (2.6%)    38 (2.4%)  <serde_json::de::MapAccess<R> as serde::de::MapAccess>::next_value_seed
   2301 (2.5%)    39 (2.4%)  <serde_json::ser::Compound<W,F> as serde::ser::SerializeMap>::serialize_value
   2183 (2.4%)     7 (0.4%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_seq
   2162 (2.4%)   119 (7.4%)  core::ptr::drop_in_place
   1947 (2.1%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Status>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
   1888 (2.1%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Media>::deserialize::__Visitor as serde::de::Visitor>::visit_map
   1785 (2.0%)    15 (0.9%)  <serde_json::de::MapAccess<R> as serde::de::MapAccess>::next_key_seed
   1744 (1.9%)    15 (0.9%)  <serde_json::de::MapKey<R> as serde::de::Deserializer>::deserialize_any
   1557 (1.7%)    39 (2.4%)  serde::ser::SerializeMap::serialize_entry
   1422 (1.6%)     6 (0.4%)  serde::ser::Serializer::collect_seq
   1299 (1.4%)     7 (0.4%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_str
   1291 (1.4%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::SearchMetadata>::deserialize::__Visitor as serde::de::Visitor>::visit_map
   1013 (1.1%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Media>::deserialize::__Visitor as serde::de::Visitor>::visit_seq
    988 (1.1%)    28 (1.7%)  <serde::private::de::missing_field::MissingFieldDeserializer<E> as serde::de::Deserializer>::deserialize_any
    946 (1.0%)    38 (2.4%)  serde::private::de::missing_field
    910 (1.0%)     5 (0.3%)  alloc::raw_vec::RawVec<T,A>::grow_amortized
    894 (1.0%)     6 (0.4%)  serde_json::de::Deserializer<R>::deserialize_number
    867 (1.0%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::StatusEntities>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    854 (0.9%)     1 (0.1%)  json_benchmark::copy::twitter::_::<impl serde::ser::Serialize for json_benchmark::copy::twitter::User>::serialize
    817 (0.9%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::UserMention>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    769 (0.8%)     1 (0.1%)  <json_benchmark::copy::twitter::_::<impl serde::de::Deserialize for json_benchmark::copy::twitter::Url>::deserialize::__Visitor as serde::de::Visitor>::visit_map
    741 (0.8%)    10 (0.6%)  <&mut serde_json::de::Deserializer<R> as serde::de::Deserializer>::deserialize_option
```