### PR TITLE
Add Entry::and_modify

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -542,6 +542,40 @@ impl<'a> Entry<'a> {
             Entry::Occupied(entry) => entry.into_mut(),
         }
     }
+
+    /// Provides in-place mutable access to an occupied entry before any
+    /// potential inserts into the map.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// #
+    /// let mut map = serde_json::Map::new();
+    /// map.entry("serde")
+    ///     .and_modify(|e| { *e = json!("rust") })
+    ///     .or_insert(json!("cpp"));
+    ///
+    /// assert_eq!(map["serde"], "cpp".to_owned());
+    ///
+    /// map.entry("serde")
+    ///     .and_modify(|e| { *e = json!("rust") })
+    ///     .or_insert(json!("cpp"));
+    ///
+    /// assert_eq!(map["serde"], "rust".to_owned());
+    /// ```
+    pub fn and_modify<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&mut Value),
+    {
+        match self {
+            Entry::Occupied(mut entry) => {
+                f(entry.get_mut());
+                Entry::Occupied(entry)
+            }
+            Entry::Vacant(entry) => Entry::Vacant(entry),
+        }
+    }
 }
 
 impl<'a> VacantEntry<'a> {


### PR DESCRIPTION
Like `std::collections::hash_map::Entry`, I guess the `Entry` defined in this crate can provide `and_modify`.