### PR TITLE
Panic on wrong call order to serialize_{key,value} and end

### DIFF
--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -419,6 +419,13 @@ impl serde::ser::SerializeMap for SerializeMap {
 
     fn end(self) -> Result<Value> {
         match self {
+            SerializeMap::Map {
+                next_key: Some(pending),
+                ..
+            } => {
+                // Panic to indicate bug with the custom Serialize implementation
+                panic!("end called before serialize_value: {:?}", pending)
+            }
             SerializeMap::Map { map, .. } => Ok(Value::Object(map)),
             #[cfg(feature = "arbitrary_precision")]
             SerializeMap::Number { .. } => unreachable!(),

--- a/tests/invalid_usage.rs
+++ b/tests/invalid_usage.rs
@@ -2,23 +2,61 @@ use serde::ser::Serializer;
 use serde::Serialize;
 
 #[test]
-fn custom_serialize_with_key_and_no_value_str() {
-    struct Response {
-        id: Option<u32>,
-    }
+#[should_panic = "end called before serialize_value"]
+fn key_and_no_value_str() {
+    let _ = serde_json::to_string(&ForgetsValue { id: None });
+}
 
-    impl Serialize for Response {
-        fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-            use serde::ser::SerializeMap;
-            let mut state = ser.serialize_map(Some(1))?;
-            match self.id {
-                Some(ref x) => state.serialize_entry("id", x)?,
-                None => state.serialize_key("id")?,
+#[test]
+#[should_panic = "end called before serialize_value: \"id\""]
+fn key_and_no_value_val() {
+    let _ = serde_json::value::to_value(&ForgetsValue { id: None });
+}
+
+#[test]
+#[should_panic = "serialize_value called before serialize_key"]
+fn no_key_but_value_str() {
+    let _ = serde_json::to_string(&ForgetsKey { id: Some(42) });
+}
+
+#[test]
+#[should_panic = "serialize_value called before serialize_key"]
+fn no_key_but_value_val() {
+    let _ = serde_json::value::to_value(&ForgetsKey { id: Some(42) });
+}
+
+struct ForgetsKey {
+    id: Option<u32>,
+}
+
+impl Serialize for ForgetsKey {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut state = ser.serialize_map(Some(1))?;
+        match self.id {
+            Some(ref x) => {
+                // should panic here
+                state.serialize_value(x)?
             }
-            state.end()
+            None => {}
         }
+        state.end()
     }
+}
 
-    // this used to return `{"id"}`
-    serde_json::to_string(&Response { id: None }).unwrap_err();
+struct ForgetsValue {
+    id: Option<u32>,
+}
+
+impl Serialize for ForgetsValue {
+    fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut state = ser.serialize_map(Some(1))?;
+        match self.id {
+            Some(ref x) => state.serialize_entry("id", x)?,
+            None => state.serialize_key("id")?,
+        }
+        // should panic here
+        state.end()
+    }
 }

--- a/tests/invalid_usage.rs
+++ b/tests/invalid_usage.rs
@@ -1,0 +1,24 @@
+use serde::ser::Serializer;
+use serde::Serialize;
+
+#[test]
+fn custom_serialize_with_key_and_no_value_str() {
+    struct Response {
+        id: Option<u32>,
+    }
+
+    impl Serialize for Response {
+        fn serialize<S: Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+            use serde::ser::SerializeMap;
+            let mut state = ser.serialize_map(Some(1))?;
+            match self.id {
+                Some(ref x) => state.serialize_entry("id", x)?,
+                None => state.serialize_key("id")?,
+            }
+            state.end()
+        }
+    }
+
+    // this used to return `{"id"}`
+    serde_json::to_string(&Response { id: None }).unwrap_err();
+}


### PR DESCRIPTION
It is possible produce invalid json if one in custom `serde::Serialize` implementation forgets the `SerializeMap::serialize_value` between `SerializeMap::serialize_key` and `SerializeMap::end` as illustrated in the first commit. This was fixed by adding panics to both `src/ser.rs` and `src/value/ser.rs`:

- calling `end` when `serialize_value` was expected
- calling ` serialize_value` when `serialize_key` was expected

Previously:
- the only case for a panic with `serde_json::value` was when `serialize_value` was called before `serialize_key`
- the writer serialization (`src/ser.rs`) allowed producing `{"key"}` or `{:"value"}`

