### PR TITLE
Make arbitrary_precision preserve the exact string representation

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -898,7 +898,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     fn scan_number(&mut self, buf: &mut String) -> Result<()> {
         match tri!(self.peek_or_null()) {
             b'.' => self.scan_decimal(buf),
-            b'e' | b'E' => self.scan_exponent(buf),
+            c @ (b'e' | b'E') => self.scan_exponent(c as char, buf),
             _ => Ok(()),
         }
     }
@@ -923,19 +923,20 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
 
         match tri!(self.peek_or_null()) {
-            b'e' | b'E' => self.scan_exponent(buf),
+            c @ (b'e' | b'E') => self.scan_exponent(c as char, buf),
             _ => Ok(()),
         }
     }
 
     #[cfg(feature = "arbitrary_precision")]
-    fn scan_exponent(&mut self, buf: &mut String) -> Result<()> {
+    fn scan_exponent(&mut self, e: char, buf: &mut String) -> Result<()> {
         self.eat_char();
-        buf.push('e');
+        buf.push(e);
 
         match tri!(self.peek_or_null()) {
             b'+' => {
                 self.eat_char();
+                buf.push('+');
             }
             b'-' => {
                 self.eat_char();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1007,8 +1007,14 @@ fn test_parse_number() {
     #[cfg(feature = "arbitrary_precision")]
     test_parse_ok(vec![
         ("1e999", Number::from_string_unchecked("1e999".to_owned())),
+        ("1e+999", Number::from_string_unchecked("1e+999".to_owned())),
         ("-1e999", Number::from_string_unchecked("-1e999".to_owned())),
         ("1e-999", Number::from_string_unchecked("1e-999".to_owned())),
+        ("1E999", Number::from_string_unchecked("1E999".to_owned())),
+        ("1E+999", Number::from_string_unchecked("1E+999".to_owned())),
+        ("-1E999", Number::from_string_unchecked("-1E999".to_owned())),
+        ("1E-999", Number::from_string_unchecked("1E-999".to_owned())),
+        ("1E+000", Number::from_string_unchecked("1E+000".to_owned())),
         (
             "2.3e999",
             Number::from_string_unchecked("2.3e999".to_owned()),


### PR DESCRIPTION
Fixes #785.

Now the exact representation of the input JSON is preserved in the internal representation, and thus really makes "JSON -> Number -> JSON" produce output identical to the input (as described in [Cargo.toml](https://github.com/serde-rs/json/blob/ea39063f9c8c7dde4ac43bbd9843287bece59b1a/Cargo.toml#L71)).