### PR TITLE
Make use of nightly doc_cfg on docs.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@clippy
       - run: cargo clippy
 
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo doc --features raw_value,unbounded_depth
+        env:
+          RUSTDOCFLAGS: --cfg docsrs
+
   fuzz:
     name: Fuzz
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = ["tests/crate"]
 [package.metadata.docs.rs]
 features = ["raw_value", "unbounded_depth"]
 targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
 features = ["raw_value"]

--- a/src/de.rs
+++ b/src/de.rs
@@ -2492,6 +2492,7 @@ where
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn from_reader<R, T>(rdr: R) -> Result<T>
 where
     R: crate::io::Read,

--- a/src/de.rs
+++ b/src/de.rs
@@ -163,9 +163,6 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     /// completed, including, but not limited to, Display and Debug and Drop
     /// impls.
     ///
-    /// *This method is only available if serde_json is built with the
-    /// `"unbounded_depth"` feature.*
-    ///
     /// # Examples
     ///
     /// ```
@@ -196,6 +193,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     /// }
     /// ```
     #[cfg(feature = "unbounded_depth")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "unbounded_depth")))]
     pub fn disable_recursion_limit(&mut self) {
         self.disable_recursion_limit = true;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,7 @@
 #![allow(non_upper_case_globals)]
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,7 @@ pub mod de;
 pub mod error;
 pub mod map;
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod ser;
 #[cfg(not(feature = "std"))]
 mod ser;

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -18,16 +18,6 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 /// When serializing, a value of this type will retain its original formatting
 /// and will not be minified or pretty-printed.
 ///
-/// # Note
-///
-/// `RawValue` is only available if serde\_json is built with the `"raw_value"`
-/// feature.
-///
-/// ```toml
-/// [dependencies]
-/// serde_json = { version = "1.0", features = ["raw_value"] }
-/// ```
-///
 /// # Example
 ///
 /// ```
@@ -109,6 +99,7 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 /// }
 /// ```
 #[repr(C)]
+#[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 pub struct RawValue {
     json: str,
 }
@@ -267,6 +258,7 @@ impl RawValue {
 ///
 /// println!("{}", serde_json::value::to_raw_value(&map).unwrap_err());
 /// ```
+#[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 pub fn to_raw_value<T>(value: &T) -> Result<Box<RawValue>, Error>
 where
     T: Serialize,

--- a/src/read.rs
+++ b/src/read.rs
@@ -140,6 +140,7 @@ where
 
 /// JSON input source that reads from a std::io input stream.
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct IoRead<R>
 where
     R: io::Read,

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,6 +8,7 @@ use serde::ser::{self, Impossible, Serialize};
 use serde::serde_if_integer128;
 
 /// A structure for serializing Rust values into JSON.
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct Serializer<W, F = CompactFormatter> {
     writer: W,
     formatter: F,
@@ -2141,6 +2142,7 @@ static ESCAPE: [u8; 256] = [
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
 where
     W: io::Write,
@@ -2159,6 +2161,7 @@ where
 /// Serialization can fail if `T`'s implementation of `Serialize` decides to
 /// fail, or if `T` contains a map with non-string keys.
 #[inline]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub fn to_writer_pretty<W, T>(writer: W, value: &T) -> Result<()>
 where
     W: io::Write,


### PR DESCRIPTION
I think this will make it much easier to tell at a glance that the `RawValue` API is not provided by default. While I was at it, I also added the attribute for other things where it seemed to make sense. Let me know what you think!