### PR TITLE
Use `NotNan<f64>` to implement `Eq`, `Hash`, `PartialOrd` and `Ord` for `Number`, `Map` and `Value`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.5", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
+ordered-float = "2.7"
 
 [dev-dependencies]
 automod = "1.0"

--- a/src/map.rs
+++ b/src/map.rs
@@ -11,6 +11,8 @@ use crate::lib::iter::FromIterator;
 use crate::lib::*;
 use crate::value::Value;
 use serde::de;
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};
@@ -277,6 +279,27 @@ impl PartialEq for Map<String, Value> {
 }
 
 impl Eq for Map<String, Value> {}
+
+impl Hash for Map<String, Value> {
+    #[inline]
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        self.map.hash(h)
+    }
+}
+
+impl PartialOrd for Map<String, Value> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.map.partial_cmp(&other.map)
+    }
+}
+
+impl Ord for Map<String, Value> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.map.cmp(&other.map)
+    }
+}
 
 /// Access an element of this map. Panics if the given key is not present in the
 /// map.

--- a/src/map.rs
+++ b/src/map.rs
@@ -11,7 +11,10 @@ use crate::lib::iter::FromIterator;
 use crate::lib::*;
 use crate::value::Value;
 use serde::de;
+
+#[cfg(not(feature = "preserve_order"))]
 use std::cmp::Ordering;
+#[cfg(not(feature = "preserve_order"))]
 use std::hash::{Hash, Hasher};
 
 #[cfg(feature = "preserve_order")]
@@ -280,6 +283,7 @@ impl PartialEq for Map<String, Value> {
 
 impl Eq for Map<String, Value> {}
 
+#[cfg(not(feature = "preserve_order"))]
 impl Hash for Map<String, Value> {
     #[inline]
     fn hash<H: Hasher>(&self, h: &mut H) {
@@ -287,6 +291,7 @@ impl Hash for Map<String, Value> {
     }
 }
 
+#[cfg(not(feature = "preserve_order"))]
 impl PartialOrd for Map<String, Value> {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
@@ -294,6 +299,7 @@ impl PartialOrd for Map<String, Value> {
     }
 }
 
+#[cfg(not(feature = "preserve_order"))]
 impl Ord for Map<String, Value> {
     #[inline]
     fn cmp(&self, other: &Self) -> Ordering {

--- a/src/map.rs
+++ b/src/map.rs
@@ -13,9 +13,9 @@ use crate::value::Value;
 use serde::de;
 
 #[cfg(not(feature = "preserve_order"))]
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 #[cfg(not(feature = "preserve_order"))]
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 #[cfg(feature = "preserve_order")]
 use indexmap::{self, IndexMap};

--- a/src/map.rs
+++ b/src/map.rs
@@ -287,7 +287,7 @@ impl Eq for Map<String, Value> {}
 impl Hash for Map<String, Value> {
     #[inline]
     fn hash<H: Hasher>(&self, h: &mut H) {
-        self.map.hash(h)
+        self.map.hash(h);
     }
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,12 +1,14 @@
 use crate::de::ParserNumber;
 use crate::error::Error;
 use crate::lib::*;
-use ordered_float::NotNan;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{
     forward_to_deserialize_any, serde_if_integer128, Deserialize, Deserializer, Serialize,
     Serializer,
 };
+
+#[cfg(not(feature = "arbitrary_precision"))]
+use ordered_float::NotNan;
 
 #[cfg(feature = "arbitrary_precision")]
 use crate::error::ErrorCode;
@@ -282,7 +284,7 @@ impl Debug for Number {
                 debug.field(&i);
             }
             N::Float(f) => {
-                debug.field(&f);
+                debug.field(&f.into_inner());
             }
         }
         debug.finish()

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,6 +1,7 @@
 use crate::de::ParserNumber;
 use crate::error::Error;
 use crate::lib::*;
+use ordered_float::NotNan;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{
     forward_to_deserialize_any, serde_if_integer128, Deserialize, Deserializer, Serialize,
@@ -16,24 +17,20 @@ use serde::de::{IntoDeserializer, MapAccess};
 pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct Number {
     n: N,
 }
 
 #[cfg(not(feature = "arbitrary_precision"))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 enum N {
     PosInt(u64),
     /// Always less than zero.
     NegInt(i64),
     /// Always finite.
-    Float(f64),
+    Float(NotNan<f64>),
 }
-
-// Implementing Eq is fine since any float values are always finite.
-#[cfg(not(feature = "arbitrary_precision"))]
-impl Eq for N {}
 
 #[cfg(feature = "arbitrary_precision")]
 type N = String;
@@ -208,7 +205,7 @@ impl Number {
         match self.n {
             N::PosInt(n) => Some(n as f64),
             N::NegInt(n) => Some(n as f64),
-            N::Float(n) => Some(n),
+            N::Float(n) => Some(n.into_inner()),
         }
         #[cfg(feature = "arbitrary_precision")]
         self.n.parse::<f64>().ok().filter(|float| float.is_finite())
@@ -232,7 +229,10 @@ impl Number {
             let n = {
                 #[cfg(not(feature = "arbitrary_precision"))]
                 {
-                    N::Float(f)
+                    N::Float(unsafe {
+                        // This is safe since `f64::is_finite` returns `false` if `f` is `NaN`.
+                        NotNan::new_unchecked(f)
+                    })
                 }
                 #[cfg(feature = "arbitrary_precision")]
                 {
@@ -307,7 +307,7 @@ impl Serialize for Number {
         match self.n {
             N::PosInt(u) => serializer.serialize_u64(u),
             N::NegInt(i) => serializer.serialize_i64(i),
-            N::Float(f) => serializer.serialize_f64(f),
+            N::Float(f) => serializer.serialize_f64(f.into_inner()),
         }
     }
 
@@ -461,7 +461,7 @@ macro_rules! deserialize_any {
             match self.n {
                 N::PosInt(u) => visitor.visit_u64(u),
                 N::NegInt(i) => visitor.visit_i64(i),
-                N::Float(f) => visitor.visit_f64(f),
+                N::Float(f) => visitor.visit_f64(f.into_inner()),
             }
         }
 
@@ -625,7 +625,10 @@ impl From<ParserNumber> for Number {
             ParserNumber::F64(f) => {
                 #[cfg(not(feature = "arbitrary_precision"))]
                 {
-                    N::Float(f)
+                    N::Float(unsafe {
+                        // This is safe since `ParserNumber::F64` is never `NaN`.
+                        NotNan::new_unchecked(f)
+                    })
                 }
                 #[cfg(feature = "arbitrary_precision")]
                 {
@@ -736,7 +739,7 @@ impl Number {
         match self.n {
             N::PosInt(u) => Unexpected::Unsigned(u),
             N::NegInt(i) => Unexpected::Signed(i),
-            N::Float(f) => Unexpected::Float(f),
+            N::Float(f) => Unexpected::Float(f.into_inner()),
         }
     }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -107,7 +107,7 @@ pub use crate::raw::{to_raw_value, RawValue};
 /// Represents any valid JSON value.
 ///
 /// See the [`serde_json::value` module documentation](self) for usage examples.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum Value {
     /// Represents a JSON null value.
     ///

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -107,7 +107,8 @@ pub use crate::raw::{to_raw_value, RawValue};
 /// Represents any valid JSON value.
 ///
 /// See the [`serde_json::value` module documentation](self) for usage examples.
-#[derive(Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(not(feature = "preserve_order"), derive(Hash, PartialOrd, Ord))]
 pub enum Value {
     /// Represents a JSON null value.
     ///


### PR DESCRIPTION
Float values in JSON can never be `NaN`, and thus can always be compared and hashed. I exploited this property with the [`ordered-float` crate](https://crates.io/crates/ordered-float) to implement `Eq`, `Hash`, `PartialOrd` and `Ord` for the `Number`, `Map` and `Value` types.