### PR TITLE
Add a feature to use std float formatter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,9 @@ float_roundtrip = []
 # produce output identical to the input.
 arbitrary_precision = []
 
+# Uses std formatter instead of ryu's one
+std_float = []
+
 # Provide a RawValue type that can hold unprocessed JSON during deserialization.
 raw_value = []
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1703,6 +1703,7 @@ pub trait Formatter {
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
+    #[cfg(not(feature = "std_float"))]
     #[inline]
     fn write_f32<W>(&mut self, writer: &mut W, value: f32) -> io::Result<()>
     where
@@ -1714,6 +1715,17 @@ pub trait Formatter {
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
+    #[cfg(feature = "std_float")]
+    #[inline]
+    fn write_f32<W>(&mut self, writer: &mut W, value: f32) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        write!(writer, "{:?}", value)
+    }
+
+    /// Writes a floating point value like `-31.26e+12` to the specified writer.
+    #[cfg(not(feature = "std_float"))]
     #[inline]
     fn write_f64<W>(&mut self, writer: &mut W, value: f64) -> io::Result<()>
     where
@@ -1722,6 +1734,16 @@ pub trait Formatter {
         let mut buffer = ryu::Buffer::new();
         let s = buffer.format_finite(value);
         writer.write_all(s.as_bytes())
+    }
+
+    /// Writes a floating point value like `-31.26e+12` to the specified writer.
+    #[cfg(feature = "std_float")]
+    #[inline]
+    fn write_f64<W>(&mut self, writer: &mut W, value: f64) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        write!(writer, "{:?}", value)
     }
 
     /// Writes a number that has already been rendered to a string.


### PR DESCRIPTION
As asked on https://github.com/serde-rs/json/issues/811, this adds a feature to enable std float formatter instead of ryu's one.
This covers the edge cases where scientific notation can't be accepted, at the cost of lower performances.

At the moment this doesn't pass `test_write_f64` test because scientific notation is hardcoded, if this PR is accepted we'll probably need to think at a solution, like changing the test values based on active feature.