### PR TITLE
Implement `Hash` for `Number`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.5", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
-ordered-float = "2.8"
+ordered-float = { version = "2.8", default-features = false }
 
 [dev-dependencies]
 automod = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.5", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
+ordered-float = "2.8"
 
 [dev-dependencies]
 automod = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.5", optional = true }
 itoa = { version = "0.4.3", default-features = false }
 ryu = "1.0"
-ordered-float = { version = "2.8", default-features = false }
 
 [dev-dependencies]
 automod = "1.0"

--- a/src/number.rs
+++ b/src/number.rs
@@ -54,7 +54,7 @@ impl core::hash::Hash for N {
             N::PosInt(i) => i.hash(h),
             N::NegInt(i) => i.hash(h),
             N::Float(f) => {
-                // Using `f64::to_bits` here is fine since any float values are never `Nan`.
+                // Using `f64::to_bits` here is fine since any float values are never `NaN`.
                 f.to_bits().hash(h);
             }
         }

--- a/src/number.rs
+++ b/src/number.rs
@@ -22,13 +22,25 @@ pub struct Number {
 }
 
 #[cfg(not(feature = "arbitrary_precision"))]
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone)]
 enum N {
     PosInt(u64),
     /// Always less than zero.
     NegInt(i64),
     /// Always finite.
     Float(f64),
+}
+
+#[cfg(not(feature = "arbitrary_precision"))]
+impl PartialEq for N {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::PosInt(a), Self::PosInt(b)) => a == b,
+            (Self::NegInt(a), Self::NegInt(b)) => a == b,
+            (Self::Float(a), Self::Float(b)) => a == b,
+            _ => false,
+        }
+    }
 }
 
 // Implementing Eq is fine since any float values are always finite.

--- a/src/number.rs
+++ b/src/number.rs
@@ -35,9 +35,9 @@ enum N {
 impl PartialEq for N {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::PosInt(a), Self::PosInt(b)) => a == b,
-            (Self::NegInt(a), Self::NegInt(b)) => a == b,
-            (Self::Float(a), Self::Float(b)) => a == b,
+            (N::PosInt(a), N::PosInt(b)) => a == b,
+            (N::NegInt(a), N::NegInt(b)) => a == b,
+            (N::Float(a), N::Float(b)) => a == b,
             _ => false,
         }
     }
@@ -51,11 +51,11 @@ impl Eq for N {}
 impl core::hash::Hash for N {
     fn hash<H: core::hash::Hasher>(&self, h: &mut H) {
         match self {
-            Self::PosInt(i) => i.hash(h),
-            Self::NegInt(i) => i.hash(h),
-            Self::Float(f) => {
+            N::PosInt(i) => i.hash(h),
+            N::NegInt(i) => i.hash(h),
+            N::Float(f) => {
                 // Using `f64::to_bits` here is fine since any float values are always finite.
-                f.to_bits().hash(h)
+                f.to_bits().hash(h);
             }
         }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -55,7 +55,14 @@ impl core::hash::Hash for N {
             N::NegInt(i) => i.hash(h),
             N::Float(f) => {
                 // Using `f64::to_bits` here is fine since any float values are never `NaN`.
-                f.to_bits().hash(h);
+                if *f == 0.0f64 {
+                    // The IEEE 754 standard has two representations for zero, +0 and -0,
+                    // such that +0 == -0.
+                    // In both cases we use the +0 hash so that hash(+0) == hash(-0).
+                    0.0f64.to_bits().hash(h);
+                } else {
+                    f.to_bits().hash(h);
+                }
             }
         }
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -1,7 +1,6 @@
 use crate::de::ParserNumber;
 use crate::error::Error;
 use crate::lib::*;
-use ordered_float::NotNan;
 use serde::de::{self, Unexpected, Visitor};
 use serde::{
     forward_to_deserialize_any, serde_if_integer128, Deserialize, Deserializer, Serialize,
@@ -12,6 +11,9 @@ use serde::{
 use crate::error::ErrorCode;
 #[cfg(feature = "arbitrary_precision")]
 use serde::de::{IntoDeserializer, MapAccess};
+
+#[cfg(not(feature = "arbitrary_precision"))]
+use ordered_float::NotNan;
 
 #[cfg(feature = "arbitrary_precision")]
 pub(crate) const TOKEN: &str = "$serde_json::private::Number";

--- a/src/number.rs
+++ b/src/number.rs
@@ -54,7 +54,7 @@ impl core::hash::Hash for N {
             N::PosInt(i) => i.hash(h),
             N::NegInt(i) => i.hash(h),
             N::Float(f) => {
-                // Using `f64::to_bits` here is fine since any float values are always finite.
+                // Using `f64::to_bits` here is fine since any float values are never `Nan`.
                 f.to_bits().hash(h);
             }
         }

--- a/src/number.rs
+++ b/src/number.rs
@@ -283,7 +283,7 @@ impl Debug for Number {
                 debug.field(&i);
             }
             N::Float(f) => {
-                debug.field(&f);
+                debug.field(&f.into_inner());
             }
         }
         debug.finish()

--- a/src/number.rs
+++ b/src/number.rs
@@ -36,8 +36,8 @@ enum N {
 impl Eq for N {}
 
 #[cfg(not(feature = "arbitrary_precision"))]
-impl std::hash::Hash for N {
-    fn hash<H: std::hash::Hasher>(&self, h: &mut H) {
+impl core::hash::Hash for N {
+    fn hash<H: core::hash::Hasher>(&self, h: &mut H) {
         match self {
             Self::PosInt(i) => i.hash(h),
             Self::NegInt(i) => i.hash(h),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2284,3 +2284,19 @@ fn test_value_into_deserializer() {
     let outer = Outer::deserialize(map.into_deserializer()).unwrap();
     assert_eq!(outer.inner.string, "Hello World");
 }
+
+#[test]
+fn hash_positive_and_negative_zero() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    fn hash(obj: impl Hash) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        obj.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    let k1 = serde_json::from_str::<Number>("0.0").unwrap();
+    let k2 = serde_json::from_str::<Number>("-0.0").unwrap();
+    assert!(k1 != k2 || hash(k1) == hash(k2));
+}


### PR DESCRIPTION
This is the minimal version of my previous PR #790. I implemented the `Eq` and `Hash` traits for the `Number` type, regardless of its definition. Contrarily to my previous PR, this is strictly limited to the `Number` type.

I was originally going to use the `ordered_float` crate for that, but it turns out it is much simpler to do it manually. It avoids a dependency, and this library is not compatible with Rust 1.31.0 because it uses const parameters somewhere in the code of an optional feature, which has a syntax that is not supported with this version of Rust.

I had to manually implement `PartialEq` for `Number` to please clippy.