### PR TITLE
Add `Map::get_key_value` method.

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -99,6 +99,7 @@ impl Map<String, Value> {
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
     #[inline]
+    #[cfg(any(feature = "preserve_order", not(no_btreemap_get_key_value)))]
     pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&String, &Value)>
     where
         String: Borrow<Q>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -94,6 +94,19 @@ impl Map<String, Value> {
         self.map.get_mut(key)
     }
 
+    /// Returns the key-value pair matching the given key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but the ordering
+    /// on the borrowed form *must* match the ordering on the key type.
+    #[inline]
+    pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&String, &Value)>
+    where
+        String: Borrow<Q>,
+        Q: ?Sized + Ord + Eq + Hash,
+    {
+        self.map.get_key_value(key)
+    }
+
     /// Inserts a key-value pair into the map.
     ///
     /// If the map did not have this key present, `None` is returned.


### PR DESCRIPTION
I have added the `get_key_value` method to the `Map` type. This is useful to get a reference to the matched key that lives as long as the map.