### PR TITLE
Add retain to Map

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,12 @@ fn main() {
     if minor < 45 {
         println!("cargo:rustc-cfg=no_btreemap_remove_entry");
     }
+
+    // BTreeMap::retain
+    // https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#library-changes
+    if minor < 53 {
+        println!("cargo:rustc-cfg=no_btreemap_retain");
+    }
 }
 
 fn rustc_minor_version() -> Option<u32> {

--- a/src/map.rs
+++ b/src/map.rs
@@ -247,7 +247,7 @@ impl Map<String, Value> {
         self.map.retain(f);
     }
 
-    #[cfg(not(feature = "preserve_order"))]
+    #[cfg(all(not(feature = "preserve_order"), not(no_btreemap_retain)))]
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.

--- a/src/map.rs
+++ b/src/map.rs
@@ -240,7 +240,7 @@ impl Map<String, Value> {
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
     /// The elements are visited in ascending key order.
     #[inline]
-    pub fn retain<F, K>(&mut self, f: F)
+    pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&String, &mut Value) -> bool,
     {

--- a/src/map.rs
+++ b/src/map.rs
@@ -234,6 +234,32 @@ impl Map<String, Value> {
         }
     }
 
+    #[cfg(feature = "preserve_order")]
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
+    /// The elements are visited in ascending key order.
+    #[inline]
+    pub fn retain<F, K>(&mut self, f: F)
+    where
+        F: FnMut(&String, &mut Value) -> bool,
+    {
+        self.map.retain(f);
+    }
+
+    #[cfg(not(feature = "preserve_order"))]
+    /// Retains only the elements specified by the predicate.
+    ///
+    /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
+    /// The elements are visited in ascending key order.
+    #[inline]
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&String, &mut Value) -> bool,
+    {
+        self.map.retain(f);
+    }
+
     /// Gets an iterator over the values of the map.
     #[inline]
     pub fn values(&self) -> Values {

--- a/src/map.rs
+++ b/src/map.rs
@@ -234,7 +234,7 @@ impl Map<String, Value> {
         }
     }
 
-    #[cfg(feature = "preserve_order")]
+    #[cfg(all(feature = "preserve_order", not(no_btreemap_remove_entry)))]
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.

--- a/src/map.rs
+++ b/src/map.rs
@@ -234,20 +234,7 @@ impl Map<String, Value> {
         }
     }
 
-    #[cfg(all(feature = "preserve_order", not(no_btreemap_retain)))]
-    /// Retains only the elements specified by the predicate.
-    ///
-    /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
-    /// The elements are visited in ascending key order.
-    #[inline]
-    pub fn retain<F>(&mut self, f: F)
-    where
-        F: FnMut(&String, &mut Value) -> bool,
-    {
-        self.map.retain(f);
-    }
-
-    #[cfg(all(not(feature = "preserve_order"), not(no_btreemap_retain)))]
+    #[cfg(not(no_btreemap_retain))]
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.

--- a/src/map.rs
+++ b/src/map.rs
@@ -234,12 +234,12 @@ impl Map<String, Value> {
         }
     }
 
+    #[cfg(all(feature = "preserve_order", not(no_btreemap_retain)))]
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
     /// The elements are visited in ascending key order.
     #[inline]
-    #[cfg(all(feature = "preserve_order", not(no_btreemap_remove_entry)))]
     pub fn retain<F, K>(&mut self, f: F)
     where
         F: FnMut(&String, &mut Value) -> bool,
@@ -247,12 +247,12 @@ impl Map<String, Value> {
         self.map.retain(f);
     }
 
+    #[cfg(not(feature = "preserve_order"))]
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
     /// The elements are visited in ascending key order.
     #[inline]
-    #[cfg(not(feature = "preserve_order"))]
     pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&String, &mut Value) -> bool,

--- a/src/map.rs
+++ b/src/map.rs
@@ -234,12 +234,12 @@ impl Map<String, Value> {
         }
     }
 
-    #[cfg(all(feature = "preserve_order", not(no_btreemap_remove_entry)))]
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
     /// The elements are visited in ascending key order.
     #[inline]
+    #[cfg(all(feature = "preserve_order", not(no_btreemap_remove_entry)))]
     pub fn retain<F, K>(&mut self, f: F)
     where
         F: FnMut(&String, &mut Value) -> bool,
@@ -247,12 +247,12 @@ impl Map<String, Value> {
         self.map.retain(f);
     }
 
-    #[cfg(not(feature = "preserve_order"))]
     /// Retains only the elements specified by the predicate.
     ///
     /// In other words, remove all pairs `(k, v)` such that `f(&k, &mut v)` returns `false`.
     /// The elements are visited in ascending key order.
     #[inline]
+    #[cfg(not(feature = "preserve_order"))]
     pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&String, &mut Value) -> bool,

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -34,3 +34,15 @@ fn test_append() {
     assert_eq!(keys, EXPECTED);
     assert!(val.is_empty());
 }
+
+#[test]
+fn test_retain() {
+    const EXPECTED: &[&str] = &["a", "c"];
+
+    let mut v: Value = from_str(r#"{"b":null,"a":null,"c":null}"#).unwrap();
+    let val = v.as_object_mut().unwrap();
+    val.retain(|k, _| k.as_str() != "b");
+
+    let keys: Vec<_> = val.keys().collect();
+    assert_eq!(keys, EXPECTED);
+}

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -35,6 +35,7 @@ fn test_append() {
     assert!(val.is_empty());
 }
 
+#[cfg(not(no_btreemap_retain))]
 #[test]
 fn test_retain() {
     const EXPECTED: &[&str] = &["a", "c"];


### PR DESCRIPTION
This adds the `retain` function to the Map type which calls the inner
maps, Either `indexmap` or std `BTreeMap`'s, retain.

I'm trying to mutate a `Value::Object`'s Map in-place and could't find a
nice way without the `retain` function.

These new `retain` functions will also only be included when compiling with Rust 1.53.0+ when `retain` was added to the BTreeMap in the std lib https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#stabilized-apis