### PR TITLE
Deserialize lone surrogates into byte bufs

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1581,18 +1581,18 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     ///
     /// Backslash escape sequences like `\n` are still interpreted and required
     /// to be valid. `\u` escape sequences are required to represent valid
-    /// Unicode code points, except in the case of lone surrogate pairs.
+    /// Unicode code points, except in the case of lone surrogates.
     ///
     /// ```
     /// use serde_bytes::ByteBuf;
     ///
     /// fn look_at_bytes() {
-    ///     let json_data = b"\"lone surrogate pair: \\uD801\"";
+    ///     let json_data = b"\"lone surrogate: \\uD801\"";
     ///     let parsed: Result<ByteBuf, _> = serde_json::from_slice(json_data);
     ///
     ///     assert!(parsed.is_ok());
     ///
-    ///     let expected = b"lone surrogate pair: \xED\xA0\x81";
+    ///     let expected = b"lone surrogate: \xED\xA0\x81";
     ///     let bytes: ByteBuf = parsed.unwrap();
     ///     assert_eq!(expected, &bytes[..]);
     /// }

--- a/src/de.rs
+++ b/src/de.rs
@@ -1580,20 +1580,21 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     /// ```
     ///
     /// Backslash escape sequences like `\n` are still interpreted and required
-    /// to be valid, and `\u` escape sequences are required to represent valid
-    /// Unicode code points.
+    /// to be valid. `\u` escape sequences are required to represent valid
+    /// Unicode code points, except in the case of lone surrogate pairs.
     ///
     /// ```
     /// use serde_bytes::ByteBuf;
     ///
     /// fn look_at_bytes() {
-    ///     let json_data = b"\"invalid unicode surrogate: \\uD801\"";
+    ///     let json_data = b"\"lone surrogate pair: \\uD801\"";
     ///     let parsed: Result<ByteBuf, _> = serde_json::from_slice(json_data);
     ///
-    ///     assert!(parsed.is_err());
+    ///     assert!(parsed.is_ok());
     ///
-    ///     let expected_msg = "unexpected end of hex escape at line 1 column 35";
-    ///     assert_eq!(expected_msg, parsed.unwrap_err().to_string());
+    ///     let expected = b"lone surrogate pair: \xED\xA0\x81";
+    ///     let bytes: ByteBuf = parsed.unwrap();
+    ///     assert_eq!(expected, &bytes[..]);
     /// }
     /// #
     /// # look_at_bytes();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1715,6 +1715,13 @@ fn test_byte_buf_de() {
 }
 
 #[test]
+fn test_byte_buf_de_invalid_escape_sequence() {
+    let bytes = ByteBuf::from(vec![237, 160, 188]);
+    let v: ByteBuf = from_str(r#""\ud83c""#).unwrap();
+    assert_eq!(v, bytes);
+}
+
+#[test]
 fn test_byte_buf_de_multiple() {
     let s: Vec<ByteBuf> = from_str(r#"["ab\nc", "cd\ne"]"#).unwrap();
     let a = ByteBuf::from(b"ab\nc".to_vec());

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1715,10 +1715,31 @@ fn test_byte_buf_de() {
 }
 
 #[test]
-fn test_byte_buf_de_invalid_escape_sequence() {
+fn test_byte_buf_de_lone_surrogate() {
     let bytes = ByteBuf::from(vec![237, 160, 188]);
     let v: ByteBuf = from_str(r#""\ud83c""#).unwrap();
     assert_eq!(v, bytes);
+
+    let bytes = ByteBuf::from(vec![237, 160, 188, 10]);
+    let v: ByteBuf = from_str(r#""\ud83c\n""#).unwrap();
+    assert_eq!(v, bytes);
+
+    let bytes = ByteBuf::from(vec![237, 160, 188, 32]);
+    let v: ByteBuf = from_str(r#""\ud83c ""#).unwrap();
+    assert_eq!(v, bytes);
+
+    let bytes = ByteBuf::from(vec![237, 176, 129]);
+    let v: ByteBuf = from_str(r#""\udc01""#).unwrap();
+    assert_eq!(v, bytes);
+
+    let res = from_str::<ByteBuf>(r#""\ud83c\!""#);
+    assert!(res.is_err());
+
+    let res = from_str::<ByteBuf>(r#""\ud83c\u""#);
+    assert!(res.is_err());
+
+    let res = from_str::<ByteBuf>(r#""\ud83c\ud83c""#);
+    assert!(res.is_err());
 }
 
 #[test]


### PR DESCRIPTION
This commit deserializes lone surrogates in strings that are encoded in
escape sequences instead of erroring on them.

As per https://github.com/serde-rs/json/issues/827#issuecomment-976983620

---

Note the implementation here is ugly & unoptimized. I'll go fix this after
an initial review of the functionality.