### PR TITLE
Allow creating `RawValue`s from references to unsized values

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -282,7 +282,7 @@ impl From<Box<RawValue>> for Box<str> {
 #[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 pub fn to_raw_value<T>(value: &T) -> Result<Box<RawValue>, Error>
 where
-    T: Serialize,
+    T: Serialize + ?Sized,
 {
     let json_string = crate::to_string(value)?;
     Ok(RawValue::from_owned(json_string.into_boxed_str()))

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2264,6 +2264,15 @@ fn test_raw_invalid_utf8() {
     );
 }
 
+#[cfg(feature = "raw_value")]
+#[test]
+fn test_serialize_unsized_value_to_raw_value() {
+    assert_eq!(
+        serde_json::value::to_raw_value("foobar").unwrap().get(),
+        r#""foobar""#
+    );
+}
+
 #[test]
 fn test_borrow_in_map_key() {
     #[derive(Deserialize, Debug)]


### PR DESCRIPTION
Currently, we cannot creating `RawValue` from `&str` using `serde_json::value::to_raw_value` since the function requires `Sized` implicitly. This PR removes this restriction.