### PR TITLE
[Bug fix] Preserve order for remove operation

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -138,7 +138,7 @@ impl Map<String, Value> {
         Q: ?Sized + Ord + Eq + Hash,
     {
         #[cfg(feature = "preserve_order")]
-        return self.map.swap_remove(key);
+        return self.map.shift_remove(key);
         #[cfg(not(feature = "preserve_order"))]
         return self.map.remove(key);
     }
@@ -812,7 +812,7 @@ impl<'a> OccupiedEntry<'a> {
     #[inline]
     pub fn remove(self) -> Value {
         #[cfg(feature = "preserve_order")]
-        return self.occupied.swap_remove();
+        return self.occupied.shift_remove();
         #[cfg(not(feature = "preserve_order"))]
         return self.occupied.remove();
     }

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -16,6 +16,23 @@ fn test_preserve_order() {
 }
 
 #[test]
+fn test_preserve_order_with_remove() {
+    // Sorted order
+    #[cfg(not(feature = "preserve_order"))]
+    const EXPECTED: &[&str] = &["a", "c", "d"];
+
+    // Insertion order
+    #[cfg(feature = "preserve_order")]
+    const EXPECTED: &[&str] = &["d", "a", "c"];
+
+    let v: Value = from_str(r#"{"b":null,"d":null,"a":null,"c":null}"#).unwrap();
+    let mut map = v.as_object().unwrap().clone();
+    map.remove("b");
+    let keys: Vec<_> = map.keys().collect();
+    assert_eq!(keys, EXPECTED);
+}
+
+#[test]
 fn test_append() {
     // Sorted order
     #[cfg(not(feature = "preserve_order"))]


### PR DESCRIPTION
Changes in this PR:
- Fixed the bug described in https://github.com/serde-rs/json/issues/807
- Added unit tests

Please note that `shift_remove` is expensive. Ideally, I think we should replace [indexmap](https://crates.io/search?q=indexmap) with [hashlink](https://crates.io/crates/hashlink) which uses doubly-linked lists as internal data structure and can perform `remove`(`shift_remove`) operation much more efficiently.