### PR TITLE
Adding serde_json::Error::code() functionnality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,7 +373,7 @@ pub use crate::de::from_reader;
 #[doc(inline)]
 pub use crate::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]
-pub use crate::error::{Error, Result};
+pub use crate::error::{Error, ErrorCode, Result};
 #[doc(inline)]
 pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty};
 #[cfg(feature = "std")]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2384,3 +2384,99 @@ fn hash_positive_and_negative_zero() {
         assert_eq!(hash(k1), hash(k2));
     }
 }
+
+#[test]
+fn test_error_codes() {
+    use serde::Deserializer;
+    use serde_json::ErrorCode;
+
+    fn contains_test<'de, D>(deserializer: D) -> Result<String, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let v = String::deserialize(deserializer)?;
+        if v.contains("test") {
+            Ok(v)
+        } else {
+            Err(serde::de::Error::invalid_value(
+                serde::de::Unexpected::Str(&v),
+                &"a string containing the substring `test`",
+            ))
+        }
+    }
+
+    #[derive(Deserialize, Debug)]
+    #[serde(deny_unknown_fields)]
+    struct Test {
+        #[serde(deserialize_with = "contains_test")]
+        #[allow(dead_code)]
+        required: String,
+        #[allow(dead_code)]
+        seq: Option<[u8; 2]>,
+        #[allow(dead_code)]
+        en: Option<Enum>,
+    }
+
+    #[derive(Deserialize, Debug)]
+    enum Enum {
+        Variant1,
+        Variant2,
+    }
+
+    assert_eq!(
+        serde_json::from_str::<Test>(r#"{"required":1}"#)
+            .unwrap_err()
+            .code(),
+        &ErrorCode::InvalidType(
+            "integer `1`".to_string().into_boxed_str(),
+            "a string".to_string().into_boxed_str()
+        )
+    );
+    assert_eq!(
+        serde_json::from_str::<Test>(r#"{"required":"ok"}"#)
+            .unwrap_err()
+            .code(),
+        &ErrorCode::InvalidValue(
+            "string \"ok\"".to_string().into_boxed_str(),
+            "a string containing the substring `test`"
+                .to_string()
+                .into_boxed_str()
+        )
+    );
+    // SHOULD PROBABLY BE
+    // &ErrorCode::InvalidLength(3, "an array of length 2".to_string().into_boxed_str())
+    assert_eq!(
+        serde_json::from_str::<Test>(r#"{"required":"test","seq":[0,1,2]}"#)
+            .unwrap_err()
+            .code(),
+        &ErrorCode::TrailingCharacters
+    );
+    assert_eq!(
+        serde_json::from_str::<Test>(r#"{"required":"test","seq":[0]}"#)
+            .unwrap_err()
+            .code(),
+        &ErrorCode::InvalidLength(1, "an array of length 2".to_string().into_boxed_str())
+    );
+    assert_eq!(
+        serde_json::from_str::<Test>(r#"{"en":"Variant3"}"#)
+            .unwrap_err()
+            .code(),
+        &ErrorCode::UnknownVariant(
+            "Variant3".to_string().into_boxed_str(),
+            &["Variant1", "Variant2"]
+        )
+    );
+    assert_eq!(
+        serde_json::from_str::<Test>(r#"{"required":"test","unknown":1}"#)
+            .unwrap_err()
+            .code(),
+        &ErrorCode::UnknownField(
+            "unknown".to_string().into_boxed_str(),
+            &["required", "seq", "en"]
+        )
+    );
+    assert_eq!(
+        serde_json::from_str::<Test>(r#"{}"#).unwrap_err().code(),
+        &ErrorCode::MissingField("required".to_string().into_boxed_str())
+    );
+}


### PR DESCRIPTION
Hi,
With this commit, I'm trying to add the ability to identify the precise error that occurred during de/serialization. There should be no breaking change and a new method serde_json::Error::Code() now exposes the internal code of the error.

The original purpose is to provide translated information on the error (for API body request validation for example) as well as handling errors more precisely.

It is not yet perfect as serde injects some data (eg. [https://github.com/serde-rs/serde](https://github.com/serde-rs/serde/blob/7e19ae8c9486a3bbbe51f1befb05edee94c454f9/serde/src/de/impls.rs#L1174-L1176))  and changing this behavior would probably be breaking.

A simple example of the new functionality would be :
```rs
match err.code() {
    ErrorCode::InvalidType(unexp, exp) => {
        println!("Type invalide: `{}` au lieu de `{}`", unexp, exp);
    }
    ErrorCode::InvalidValue(unexp, exp) => {
        println!("Valeur invalide: `{}` au lieu de `{}`", unexp, exp);
    }
    ErrorCode::InvalidLength(len, exp) => {
        println!("Taille invalide: `{}` au lieu de `{}`", len, exp);
    }
    e => {
        println!("Other error: {}", e);
    }
}
```