### PR TITLE
allow parsing empty array into unit

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1685,6 +1685,19 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
                 tri!(self.parse_ident(b"ull"));
                 visitor.visit_unit()
             }
+            b'[' => {
+                self.eat_char();
+                match tri!(self.parse_whitespace()) {
+                    Some(b']') => {
+                        self.eat_char();
+                        visitor.visit_unit()
+                    }
+                    Some(_) => return Err(self.peek_invalid_type(&visitor)),
+                    None => {
+                        return Err(self.peek_error(ErrorCode::EofWhileParsingList));
+                    }
+                }
+            }
             _ => Err(self.peek_invalid_type(&visitor)),
         };
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1144,6 +1144,10 @@ fn test_parse_list() {
 
     test_parse_ok(vec![("[[3], [1, 2]]", vec![vec![3u64], vec![1, 2]])]);
 
+    test_parse_unusual_ok(vec![("[]", ())]);
+
+    test_parse_unusual_ok(vec![("[ ]", ())]);
+
     test_parse_ok(vec![("[1]", (1u64,))]);
 
     test_parse_ok(vec![("[1, 2]", (1u64, 2u64))]);


### PR DESCRIPTION
While working on JS <-> rust interop crate, I'm trying to serialize function arguments on the javascript side and deserialize into a tuple with appropriate number of elements on the rust side. Unfortunately I found that it doesn't work for functions with no arguments.

```rust
serde_json::from_str::<(u8,u8)>("[1, 2]").unwrap(); // is fine
serde_json::from_str::<(u8,)>("[1]").unwrap(); // is fine
serde_json::from_str::<()>("[]").unwrap(); // currently fails
```
This PR allows the last line to pass.