### PR TITLE
Explicitly enable indexmap/std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.36"
 
 [dependencies]
 serde = { version = "1.0.100", default-features = false }
-indexmap = { version = "1.5", optional = true }
+indexmap = { version = "1.5.2", features = ["std"], optional = true }
 itoa = "1.0"
 ryu = "1.0"
 


### PR DESCRIPTION
`indexmap`'s use of `autocfg` doesn't always properly detect `std`, which is needed if you're using the default `S` hasher. The "indexmap/std" feature will explicitly force it on.

This does mean that `preserve_order` requires `std`, but that was already effectively true by using the default `S`. Alternatively, we could pick a `no_std` hasher crate for this, or implement a simple one locally.