### PR TITLE
Eliminate all use of ref keyword

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -284,9 +284,9 @@ impl Error {
 
 impl Display for ErrorCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ErrorCode::Message(ref msg) => f.write_str(msg),
-            ErrorCode::Io(ref err) => Display::fmt(err, f),
+        match self {
+            ErrorCode::Message(msg) => f.write_str(msg),
+            ErrorCode::Io(err) => Display::fmt(err, f),
             ErrorCode::EofWhileParsingList => f.write_str("EOF while parsing a list"),
             ErrorCode::EofWhileParsingObject => f.write_str("EOF while parsing an object"),
             ErrorCode::EofWhileParsingString => f.write_str("EOF while parsing a string"),
@@ -318,8 +318,8 @@ impl Display for ErrorCode {
 impl serde::de::StdError for Error {
     #[cfg(feature = "std")]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match self.err.code {
-            ErrorCode::Io(ref err) => Some(err),
+        match &self.err.code {
+            ErrorCode::Io(err) => Some(err),
             _ => None,
         }
     }

--- a/src/map.rs
+++ b/src/map.rs
@@ -323,10 +323,10 @@ impl Eq for Map<String, Value> {}
 /// #
 /// # let val = &Value::String("".to_owned());
 /// # let _ =
-/// match *val {
-///     Value::String(ref s) => Some(s.as_str()),
-///     Value::Array(ref arr) => arr[0].as_str(),
-///     Value::Object(ref map) => map["type"].as_str(),
+/// match val {
+///     Value::String(s) => Some(s.as_str()),
+///     Value::Array(arr) => arr[0].as_str(),
+///     Value::Object(map) => map["type"].as_str(),
 ///     _ => None,
 /// }
 /// # ;
@@ -530,9 +530,9 @@ impl<'a> Entry<'a> {
     /// assert_eq!(map.entry("serde").key(), &"serde");
     /// ```
     pub fn key(&self) -> &String {
-        match *self {
-            Entry::Vacant(ref e) => e.key(),
-            Entry::Occupied(ref e) => e.key(),
+        match self {
+            Entry::Vacant(e) => e.key(),
+            Entry::Occupied(e) => e.key(),
         }
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -252,7 +252,7 @@ where
             Some(ch) => {
                 #[cfg(feature = "raw_value")]
                 {
-                    if let Some(ref mut buf) = self.raw_buffer {
+                    if let Some(buf) = &mut self.raw_buffer {
                         buf.push(ch);
                     }
                 }
@@ -263,7 +263,7 @@ where
                 Some(Ok(ch)) => {
                     #[cfg(feature = "raw_value")]
                     {
-                        if let Some(ref mut buf) = self.raw_buffer {
+                        if let Some(buf) = &mut self.raw_buffer {
                             buf.push(ch);
                         }
                     }
@@ -298,7 +298,7 @@ where
     #[cfg(feature = "raw_value")]
     fn discard(&mut self) {
         if let Some(ch) = self.ch.take() {
-            if let Some(ref mut buf) = self.raw_buffer {
+            if let Some(buf) = &mut self.raw_buffer {
                 buf.push(ch);
             }
         }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -533,11 +533,8 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            Compound::Map {
-                ref mut ser,
-                ref mut state,
-            } => {
+        match self {
+            Compound::Map { ser, state } => {
                 tri!(ser
                     .formatter
                     .begin_array_value(&mut ser.writer, *state == State::First)
@@ -671,11 +668,8 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            Compound::Map {
-                ref mut ser,
-                ref mut state,
-            } => {
+        match self {
+            Compound::Map { ser, state } => {
                 tri!(ser
                     .formatter
                     .begin_object_key(&mut ser.writer, *state == State::First)
@@ -702,8 +696,8 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            Compound::Map { ref mut ser, .. } => {
+        match self {
+            Compound::Map { ser, .. } => {
                 tri!(ser
                     .formatter
                     .begin_object_value(&mut ser.writer)
@@ -753,10 +747,10 @@ where
     where
         T: ?Sized + Serialize,
     {
-        match *self {
+        match self {
             Compound::Map { .. } => ser::SerializeMap::serialize_entry(self, key, value),
             #[cfg(feature = "arbitrary_precision")]
-            Compound::Number { ref mut ser, .. } => {
+            Compound::Number { ser, .. } => {
                 if key == crate::number::TOKEN {
                     tri!(value.serialize(NumberStrEmitter(ser)));
                     Ok(())
@@ -765,7 +759,7 @@ where
                 }
             }
             #[cfg(feature = "raw_value")]
-            Compound::RawValue { ref mut ser, .. } => {
+            Compound::RawValue { ser, .. } => {
                 if key == crate::raw::TOKEN {
                     tri!(value.serialize(RawValueStrEmitter(ser)));
                     Ok(())

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -648,8 +648,8 @@ macro_rules! deserialize_value_ref_number {
         where
             V: Visitor<'de>,
         {
-            match *self {
-                Value::Number(ref n) => n.deserialize_any(visitor),
+            match self {
+                Value::Number(n) => n.deserialize_any(visitor),
                 _ => Err(self.invalid_type(&visitor)),
             }
         }
@@ -659,8 +659,8 @@ macro_rules! deserialize_value_ref_number {
         where
             V: Visitor<'de>,
         {
-            match *self {
-                Value::Number(ref n) => n.$method(visitor),
+            match self {
+                Value::Number(n) => n.$method(visitor),
                 _ => self.deserialize_any(visitor),
             }
         }
@@ -710,13 +710,13 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
+        match self {
             Value::Null => visitor.visit_unit(),
-            Value::Bool(v) => visitor.visit_bool(v),
-            Value::Number(ref n) => n.deserialize_any(visitor),
-            Value::String(ref v) => visitor.visit_borrowed_str(v),
-            Value::Array(ref v) => visit_array_ref(v, visitor),
-            Value::Object(ref v) => visit_object_ref(v, visitor),
+            Value::Bool(v) => visitor.visit_bool(*v),
+            Value::Number(n) => n.deserialize_any(visitor),
+            Value::String(v) => visitor.visit_borrowed_str(v),
+            Value::Array(v) => visit_array_ref(v, visitor),
+            Value::Object(v) => visit_object_ref(v, visitor),
         }
     }
 
@@ -755,8 +755,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        let (variant, value) = match *self {
-            Value::Object(ref value) => {
+        let (variant, value) = match self {
+            Value::Object(value) => {
                 let mut iter = value.into_iter();
                 let (variant, value) = match iter.next() {
                     Some(v) => v,
@@ -776,8 +776,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
                 }
                 (variant, Some(value))
             }
-            Value::String(ref variant) => (variant, None),
-            ref other => {
+            Value::String(variant) => (variant, None),
+            other => {
                 return Err(serde::de::Error::invalid_type(
                     other.unexpected(),
                     &"string or map",
@@ -831,8 +831,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::String(ref v) => visitor.visit_borrowed_str(v),
+        match self {
+            Value::String(v) => visitor.visit_borrowed_str(v),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -848,9 +848,9 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::String(ref v) => visitor.visit_borrowed_str(v),
-            Value::Array(ref v) => visit_array_ref(v, visitor),
+        match self {
+            Value::String(v) => visitor.visit_borrowed_str(v),
+            Value::Array(v) => visit_array_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -883,8 +883,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::Array(ref v) => visit_array_ref(v, visitor),
+        match self {
+            Value::Array(v) => visit_array_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -912,8 +912,8 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::Object(ref v) => visit_object_ref(v, visitor),
+        match self {
+            Value::Object(v) => visit_object_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -927,9 +927,9 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        match *self {
-            Value::Array(ref v) => visit_array_ref(v, visitor),
-            Value::Object(ref v) => visit_object_ref(v, visitor),
+        match self {
+            Value::Array(v) => visit_array_ref(v, visitor),
+            Value::Object(v) => visit_object_ref(v, visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -1274,11 +1274,11 @@ impl Value {
 
     #[cold]
     fn unexpected(&self) -> Unexpected {
-        match *self {
+        match self {
             Value::Null => Unexpected::Unit,
-            Value::Bool(b) => Unexpected::Bool(b),
-            Value::Number(ref n) => n.unexpected(),
-            Value::String(ref s) => Unexpected::Str(s),
+            Value::Bool(b) => Unexpected::Bool(*b),
+            Value::Number(n) => n.unexpected(),
+            Value::String(s) => Unexpected::Str(s),
             Value::Array(_) => Unexpected::Seq,
             Value::Object(_) => Unexpected::Map,
         }

--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -53,20 +53,20 @@ pub trait Index: private::Sealed {
 
 impl Index for usize {
     fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
-        match *v {
-            Value::Array(ref vec) => vec.get(*self),
+        match v {
+            Value::Array(vec) => vec.get(*self),
             _ => None,
         }
     }
     fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value> {
-        match *v {
-            Value::Array(ref mut vec) => vec.get_mut(*self),
+        match v {
+            Value::Array(vec) => vec.get_mut(*self),
             _ => None,
         }
     }
     fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value {
-        match *v {
-            Value::Array(ref mut vec) => {
+        match v {
+            Value::Array(vec) => {
                 let len = vec.len();
                 vec.get_mut(*self).unwrap_or_else(|| {
                     panic!(
@@ -82,23 +82,23 @@ impl Index for usize {
 
 impl Index for str {
     fn index_into<'v>(&self, v: &'v Value) -> Option<&'v Value> {
-        match *v {
-            Value::Object(ref map) => map.get(self),
+        match v {
+            Value::Object(map) => map.get(self),
             _ => None,
         }
     }
     fn index_into_mut<'v>(&self, v: &'v mut Value) -> Option<&'v mut Value> {
-        match *v {
-            Value::Object(ref mut map) => map.get_mut(self),
+        match v {
+            Value::Object(map) => map.get_mut(self),
             _ => None,
         }
     }
     fn index_or_insert<'v>(&self, v: &'v mut Value) -> &'v mut Value {
-        if let Value::Null = *v {
+        if let Value::Null = v {
             *v = Value::Object(Map::new());
         }
-        match *v {
-            Value::Object(ref mut map) => map.entry(self.to_owned()).or_insert(Value::Null),
+        match v {
+            Value::Object(map) => map.entry(self.to_owned()).or_insert(Value::Null),
             _ => panic!("cannot access key {:?} in JSON {}", self, Type(v)),
         }
     }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -176,17 +176,17 @@ pub enum Value {
 
 impl Debug for Value {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Value::Null => formatter.debug_tuple("Null").finish(),
-            Value::Bool(v) => formatter.debug_tuple("Bool").field(&v).finish(),
-            Value::Number(ref v) => Debug::fmt(v, formatter),
-            Value::String(ref v) => formatter.debug_tuple("String").field(v).finish(),
-            Value::Array(ref v) => {
+            Value::Bool(v) => formatter.debug_tuple("Bool").field(v).finish(),
+            Value::Number(v) => Debug::fmt(v, formatter),
+            Value::String(v) => formatter.debug_tuple("String").field(v).finish(),
+            Value::Array(v) => {
                 formatter.write_str("Array(")?;
                 Debug::fmt(v, formatter)?;
                 formatter.write_str(")")
             }
-            Value::Object(ref v) => {
+            Value::Object(v) => {
                 formatter.write_str("Object(")?;
                 Debug::fmt(v, formatter)?;
                 formatter.write_str(")")
@@ -365,8 +365,8 @@ impl Value {
     /// assert_eq!(v["b"].as_object(), None);
     /// ```
     pub fn as_object(&self) -> Option<&Map<String, Value>> {
-        match *self {
-            Value::Object(ref map) => Some(map),
+        match self {
+            Value::Object(map) => Some(map),
             _ => None,
         }
     }
@@ -383,8 +383,8 @@ impl Value {
     /// assert_eq!(v, json!({ "a": {} }));
     /// ```
     pub fn as_object_mut(&mut self) -> Option<&mut Map<String, Value>> {
-        match *self {
-            Value::Object(ref mut map) => Some(map),
+        match self {
+            Value::Object(map) => Some(map),
             _ => None,
         }
     }
@@ -424,8 +424,8 @@ impl Value {
     /// assert_eq!(v["b"].as_array(), None);
     /// ```
     pub fn as_array(&self) -> Option<&Vec<Value>> {
-        match *self {
-            Value::Array(ref array) => Some(array),
+        match self {
+            Value::Array(array) => Some(array),
             _ => None,
         }
     }
@@ -442,8 +442,8 @@ impl Value {
     /// assert_eq!(v, json!({ "a": [] }));
     /// ```
     pub fn as_array_mut(&mut self) -> Option<&mut Vec<Value>> {
-        match *self {
-            Value::Array(ref mut list) => Some(list),
+        match self {
+            Value::Array(list) => Some(list),
             _ => None,
         }
     }
@@ -491,8 +491,8 @@ impl Value {
     /// println!("The value is: {}", v["a"].as_str().unwrap());
     /// ```
     pub fn as_str(&self) -> Option<&str> {
-        match *self {
-            Value::String(ref s) => Some(s),
+        match self {
+            Value::String(s) => Some(s),
             _ => None,
         }
     }
@@ -537,8 +537,8 @@ impl Value {
     /// assert!(!v["c"].is_i64());
     /// ```
     pub fn is_i64(&self) -> bool {
-        match *self {
-            Value::Number(ref n) => n.is_i64(),
+        match self {
+            Value::Number(n) => n.is_i64(),
             _ => false,
         }
     }
@@ -562,8 +562,8 @@ impl Value {
     /// assert!(!v["c"].is_u64());
     /// ```
     pub fn is_u64(&self) -> bool {
-        match *self {
-            Value::Number(ref n) => n.is_u64(),
+        match self {
+            Value::Number(n) => n.is_u64(),
             _ => false,
         }
     }
@@ -588,8 +588,8 @@ impl Value {
     /// assert!(!v["c"].is_f64());
     /// ```
     pub fn is_f64(&self) -> bool {
-        match *self {
-            Value::Number(ref n) => n.is_f64(),
+        match self {
+            Value::Number(n) => n.is_f64(),
             _ => false,
         }
     }
@@ -608,8 +608,8 @@ impl Value {
     /// assert_eq!(v["c"].as_i64(), None);
     /// ```
     pub fn as_i64(&self) -> Option<i64> {
-        match *self {
-            Value::Number(ref n) => n.as_i64(),
+        match self {
+            Value::Number(n) => n.as_i64(),
             _ => None,
         }
     }
@@ -627,8 +627,8 @@ impl Value {
     /// assert_eq!(v["c"].as_u64(), None);
     /// ```
     pub fn as_u64(&self) -> Option<u64> {
-        match *self {
-            Value::Number(ref n) => n.as_u64(),
+        match self {
+            Value::Number(n) => n.as_u64(),
             _ => None,
         }
     }
@@ -646,8 +646,8 @@ impl Value {
     /// assert_eq!(v["c"].as_f64(), Some(-64.0));
     /// ```
     pub fn as_f64(&self) -> Option<f64> {
-        match *self {
-            Value::Number(ref n) => n.as_f64(),
+        match self {
+            Value::Number(n) => n.as_f64(),
             _ => None,
         }
     }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -18,14 +18,14 @@ impl Serialize for Value {
     where
         S: ::serde::Serializer,
     {
-        match *self {
+        match self {
             Value::Null => serializer.serialize_unit(),
-            Value::Bool(b) => serializer.serialize_bool(b),
-            Value::Number(ref n) => n.serialize(serializer),
-            Value::String(ref s) => serializer.serialize_str(s),
-            Value::Array(ref v) => v.serialize(serializer),
+            Value::Bool(b) => serializer.serialize_bool(*b),
+            Value::Number(n) => n.serialize(serializer),
+            Value::String(s) => serializer.serialize_str(s),
+            Value::Array(v) => v.serialize(serializer),
             #[cfg(any(feature = "std", feature = "alloc"))]
-            Value::Object(ref m) => {
+            Value::Object(m) => {
                 use serde::ser::SerializeMap;
                 let mut map = tri!(serializer.serialize_map(Some(m.len())));
                 for (k, v) in m {
@@ -384,10 +384,8 @@ impl serde::ser::SerializeMap for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            SerializeMap::Map {
-                ref mut next_key, ..
-            } => {
+        match self {
+            SerializeMap::Map { next_key, .. } => {
                 *next_key = Some(tri!(key.serialize(MapKeySerializer)));
                 Ok(())
             }
@@ -402,11 +400,8 @@ impl serde::ser::SerializeMap for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        match *self {
-            SerializeMap::Map {
-                ref mut map,
-                ref mut next_key,
-            } => {
+        match self {
+            SerializeMap::Map { map, next_key } => {
                 let key = next_key.take();
                 // Panic because this indicates a bug in the program rather than an
                 // expected failure.
@@ -622,10 +617,10 @@ impl serde::ser::SerializeStruct for SerializeMap {
     where
         T: ?Sized + Serialize,
     {
-        match *self {
+        match self {
             SerializeMap::Map { .. } => serde::ser::SerializeMap::serialize_entry(self, key, value),
             #[cfg(feature = "arbitrary_precision")]
-            SerializeMap::Number { ref mut out_value } => {
+            SerializeMap::Number { out_value } => {
                 if key == crate::number::TOKEN {
                     *out_value = Some(value.serialize(NumberValueEmitter)?);
                     Ok(())
@@ -634,7 +629,7 @@ impl serde::ser::SerializeStruct for SerializeMap {
                 }
             }
             #[cfg(feature = "raw_value")]
-            SerializeMap::RawValue { ref mut out_value } => {
+            SerializeMap::RawValue { out_value } => {
                 if key == crate::raw::TOKEN {
                     *out_value = Some(value.serialize(RawValueEmitter)?);
                     Ok(())


### PR DESCRIPTION
`ref` is largely superseded by "match ergonomics" in modern versions of Rust.