### PR TITLE
Deserialize Value as newtype to request numbers in arbitrary precision

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -405,9 +405,25 @@ impl<'de> Deserialize<'de> for Number {
                 let v: NumberFromString = visitor.next_value()?;
                 Ok(v.value)
             }
+
+            #[cfg(feature = "arbitrary_precision")]
+            fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Number, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                deserializer.deserialize_any(self)
+            }
         }
 
-        deserializer.deserialize_any(NumberVisitor)
+        #[cfg(feature = "arbitrary_precision")]
+        {
+            deserializer.deserialize_newtype_struct(crate::value::TOKEN, NumberVisitor)
+        }
+
+        #[cfg(not(feature = "arbitrary_precision"))]
+        {
+            deserializer.deserialize_any(NumberVisitor)
+        }
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -108,6 +108,9 @@ pub use crate::number::Number;
 #[cfg(feature = "raw_value")]
 pub use crate::raw::{to_raw_value, RawValue};
 
+#[cfg(feature = "arbitrary_precision")]
+pub(crate) const TOKEN: &str = "$serde_json::private::Value";
+
 /// Represents any valid JSON value.
 ///
 /// See the [`serde_json::value` module documentation](self) for usage examples.


### PR DESCRIPTION
This PR makes serde_json's `Deserializer` produce numbers in arbitrary precision representation only when deserializing `serde_json::Value` (and `serde_json::Number` of course), not any other type.

This **fixes** code like the following to work even when `serde_json/arbitrary_precision` is enabled. Previously this would fail due to a visit_map call.

```rust
use serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
use std::fmt;

#[derive(Debug)]
pub struct Float(f64);

impl<'de> Deserialize<'de> for Float {
    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
    where
        D: Deserializer<'de>,
    {
        struct FloatVisitor;

        impl<'de> Visitor<'de> for FloatVisitor {
            type Value = Float;

            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                formatter.write_str("float")
            }

            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E> {
                Ok(Float(value))
            }

            fn visit_map<V>(self, _visitor: V) -> Result<Self::Value, V::Error>
            where
                V: MapAccess<'de>,
            {
                panic!(":(");
            }
        }

        deserializer.deserialize_any(FloatVisitor)
    }
}

fn main() {
    println!("{:?}", serde_json::from_str::<Float>("1.0").unwrap());
}
```

but at the same time, **breaks** code like the following, in which the buffer type used internally by `flatten` is not a `serde_json::Value`, and so it no longer would get the numbers in full precision.

```rust
use serde::Deserialize;

#[derive(Deserialize, Debug)]
pub struct Outer {
    #[serde(flatten)]
    pub inner: Inner,
}

#[derive(Deserialize, Debug)]
pub struct Inner {
    pub float: serde_json::Number,
}

fn main() {
    let x: Outer = serde_json::from_str("{\"float\":1.0000000000000001}").unwrap();
    println!("{:?}", x);
    assert_eq!(x.inner.float.to_string(), "1.0000000000000001");
}
```

Overall I'm uncertain whether this change would be a net benefit.

After https://github.com/serde-rs/serde/issues/1183 is fixed I think it would be worth reconsidering, because the interaction with `flatten` would no longer be an issue. Internal buffering would be able to use `serde_json::Value` as its type when deserializing from a JSON `Deserializer`.