### PR TITLE
Make Value be From<Option<T>>

### DIFF
--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -275,7 +275,7 @@ where
 {
     fn from(opt: Option<T>) -> Self {
         match opt {
-            None => Self::Null,
+            None => Value::Null,
             Some(value) => Into::into(value),
         }
     }

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -268,3 +268,15 @@ impl From<()> for Value {
         Value::Null
     }
 }
+
+impl<T> From<Option<T>> for Value
+where
+    T: Into<Value>,
+{
+    fn from(opt: Option<T>) -> Self {
+        match opt {
+            None => Self::Null,
+            Some(value) => Into::into(value),
+        }
+    }
+}


### PR DESCRIPTION
Adds an implementation for `From<Option<T>>` for all `T` where `T: Into<Value>`

Use case: Ergonomics for manually constructing values for insertion into `BTreeMap` (sentry does this)

I have no idea where / how the tests happen. If this is an acceptable change, could someone point me in the direction of the tests?
