### PR TITLE
Make fmt::Debug impl of Value more compact

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -307,27 +307,16 @@ impl Display for Number {
 impl Debug for Number {
     #[cfg(not(feature = "arbitrary_precision"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut debug = formatter.debug_tuple("Number");
         match self.n {
-            N::PosInt(i) => {
-                debug.field(&i);
-            }
-            N::NegInt(i) => {
-                debug.field(&i);
-            }
-            N::Float(f) => {
-                debug.field(&f);
-            }
+            N::PosInt(i) => Debug::fmt(&i, formatter),
+            N::NegInt(i) => Debug::fmt(&i, formatter),
+            N::Float(f) => Debug::fmt(&f, formatter),
         }
-        debug.finish()
     }
 
     #[cfg(feature = "arbitrary_precision")]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter
-            .debug_tuple("Number")
-            .field(&format_args!("{}", self.n))
-            .finish()
+        write!(formatter, "{}", self.n)
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -177,12 +177,30 @@ pub enum Value {
 impl Debug for Value {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Value::Null => formatter.write_str("null"),
-            Value::Bool(v) => Debug::fmt(v, formatter),
-            Value::Number(v) => Debug::fmt(v, formatter),
-            Value::String(v) => Debug::fmt(v, formatter),
-            Value::Array(v) => Debug::fmt(v, formatter),
-            Value::Object(v) => Debug::fmt(v, formatter),
+            Value::Null => formatter.write_str("Null"),
+            Value::Bool(v) => {
+                formatter.write_str("Bool(")?;
+                Debug::fmt(v, formatter)?;
+                formatter.write_str(")")
+            }
+            Value::Number(v) => {
+                formatter.write_str("Number(")?;
+                Debug::fmt(v, formatter)?;
+                formatter.write_str(")")
+            }
+            Value::String(v) => {
+                formatter.write_str("String(")?;
+                Debug::fmt(v, formatter)?;
+                formatter.write_str(")")
+            }
+            Value::Array(v) => {
+                formatter.write_str("Array ")?;
+                Debug::fmt(v, formatter)
+            }
+            Value::Object(v) => {
+                formatter.write_str("Object ")?;
+                Debug::fmt(v, formatter)
+            }
         }
     }
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -177,20 +177,12 @@ pub enum Value {
 impl Debug for Value {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Value::Null => formatter.debug_tuple("Null").finish(),
-            Value::Bool(v) => formatter.debug_tuple("Bool").field(v).finish(),
+            Value::Null => formatter.write_str("null"),
+            Value::Bool(v) => Debug::fmt(v, formatter),
             Value::Number(v) => Debug::fmt(v, formatter),
-            Value::String(v) => formatter.debug_tuple("String").field(v).finish(),
-            Value::Array(v) => {
-                formatter.write_str("Array(")?;
-                Debug::fmt(v, formatter)?;
-                formatter.write_str(")")
-            }
-            Value::Object(v) => {
-                formatter.write_str("Object(")?;
-                Debug::fmt(v, formatter)?;
-                formatter.write_str(")")
-            }
+            Value::String(v) => Debug::fmt(v, formatter),
+            Value::Array(v) => Debug::fmt(v, formatter),
+            Value::Object(v) => Debug::fmt(v, formatter),
         }
     }
 }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -2,45 +2,42 @@ use serde_json::{json, Number, Value};
 
 #[test]
 fn number() {
-    assert_eq!(format!("{:?}", Number::from(1)), "Number(1)");
-    assert_eq!(format!("{:?}", Number::from(-1)), "Number(-1)");
-    assert_eq!(
-        format!("{:?}", Number::from_f64(1.0).unwrap()),
-        "Number(1.0)"
-    );
+    assert_eq!(format!("{:?}", Number::from(1)), "1");
+    assert_eq!(format!("{:?}", Number::from(-1)), "-1");
+    assert_eq!(format!("{:?}", Number::from_f64(1.0).unwrap()), "1.0");
 }
 
 #[test]
 fn value_null() {
-    assert_eq!(format!("{:?}", json!(null)), "Null");
+    assert_eq!(format!("{:?}", json!(null)), "null");
 }
 
 #[test]
 fn value_bool() {
-    assert_eq!(format!("{:?}", json!(true)), "Bool(true)");
-    assert_eq!(format!("{:?}", json!(false)), "Bool(false)");
+    assert_eq!(format!("{:?}", json!(true)), "true");
+    assert_eq!(format!("{:?}", json!(false)), "false");
 }
 
 #[test]
 fn value_number() {
-    assert_eq!(format!("{:?}", json!(1)), "Number(1)");
-    assert_eq!(format!("{:?}", json!(-1)), "Number(-1)");
-    assert_eq!(format!("{:?}", json!(1.0)), "Number(1.0)");
+    assert_eq!(format!("{:?}", json!(1)), "1");
+    assert_eq!(format!("{:?}", json!(-1)), "-1");
+    assert_eq!(format!("{:?}", json!(1.0)), "1.0");
 }
 
 #[test]
 fn value_string() {
-    assert_eq!(format!("{:?}", json!("s")), "String(\"s\")");
+    assert_eq!(format!("{:?}", json!("s")), "\"s\"");
 }
 
 #[test]
 fn value_array() {
-    assert_eq!(format!("{:?}", json!([])), "Array([])");
+    assert_eq!(format!("{:?}", json!([])), "[]");
 }
 
 #[test]
 fn value_object() {
-    assert_eq!(format!("{:?}", json!({})), "Object({})");
+    assert_eq!(format!("{:?}", json!({})), "{}");
 }
 
 #[test]
@@ -50,16 +47,12 @@ fn error() {
     assert_eq!(format!("{:?}", err), expected);
 }
 
-const INDENTED_EXPECTED: &str = r#"Object({
-    "array": Array([
-        Number(
-            0,
-        ),
-        Number(
-            1,
-        ),
-    ]),
-})"#;
+const INDENTED_EXPECTED: &str = r#"{
+    "array": [
+        0,
+        1,
+    ],
+}"#;
 
 #[test]
 fn indented() {

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -9,35 +9,35 @@ fn number() {
 
 #[test]
 fn value_null() {
-    assert_eq!(format!("{:?}", json!(null)), "null");
+    assert_eq!(format!("{:?}", json!(null)), "Null");
 }
 
 #[test]
 fn value_bool() {
-    assert_eq!(format!("{:?}", json!(true)), "true");
-    assert_eq!(format!("{:?}", json!(false)), "false");
+    assert_eq!(format!("{:?}", json!(true)), "Bool(true)");
+    assert_eq!(format!("{:?}", json!(false)), "Bool(false)");
 }
 
 #[test]
 fn value_number() {
-    assert_eq!(format!("{:?}", json!(1)), "1");
-    assert_eq!(format!("{:?}", json!(-1)), "-1");
-    assert_eq!(format!("{:?}", json!(1.0)), "1.0");
+    assert_eq!(format!("{:?}", json!(1)), "Number(1)");
+    assert_eq!(format!("{:?}", json!(-1)), "Number(-1)");
+    assert_eq!(format!("{:?}", json!(1.0)), "Number(1.0)");
 }
 
 #[test]
 fn value_string() {
-    assert_eq!(format!("{:?}", json!("s")), "\"s\"");
+    assert_eq!(format!("{:?}", json!("s")), "String(\"s\")");
 }
 
 #[test]
 fn value_array() {
-    assert_eq!(format!("{:?}", json!([])), "[]");
+    assert_eq!(format!("{:?}", json!([])), "Array []");
 }
 
 #[test]
 fn value_object() {
-    assert_eq!(format!("{:?}", json!({})), "{}");
+    assert_eq!(format!("{:?}", json!({})), "Object {}");
 }
 
 #[test]
@@ -47,10 +47,10 @@ fn error() {
     assert_eq!(format!("{:?}", err), expected);
 }
 
-const INDENTED_EXPECTED: &str = r#"{
-    "array": [
-        0,
-        1,
+const INDENTED_EXPECTED: &str = r#"Object {
+    "array": Array [
+        Number(0),
+        Number(1),
     ],
 }"#;
 


### PR DESCRIPTION
This changes fmt::Debug impl of Value (and Number) to be more compact
and in doing so slightly closer to JSON.

Below are two diffs of the same two objects printed using the fmt::Debug
implementation. The first diff uses the old implementation (99 lines),
the second the implementation in this commit (42 lines). I'm of the
opinion that the second diff is far easier to read due to it's more
compact nature, e.g. one line for a strings compared to three.

I've added these diffs because I look at these kinds of diffs a lot and
that lead to this change.

```
Diff < left / right > :
 Object({
     "contact": String(
         "mailto:thomas@slight.dev",
     ),
     "created_at": String(
         "2022-04-30T13:00:00Z",
     ),
     "default_read_connection": Object({
         "created_at": String(
             "2022-05-30T11:00:00Z",
         ),
         "description": String(
             "Usable PostgreSQL connection",
         ),
         "details": Object({
             "dbname": String(
                 "test_pgsql",
             ),
             "host": String(
                 "localhost",
             ),
             "kind": String(
                 "postgres",
             ),
             "port": Number(
                 5432,
             ),
<            "sslmode": String(
<                "disable",
>        }),
>        "name": String(
>            "pg",
>        ),
>        "updated_at": String(
>            "2022-05-30T11:00:00Z",
>        ),
>        "uuid": String(
>            "173140a2-6a7b-4f77-b998-924fb6fc0000",
>        ),
>    }),
>    "default_write_connection": Object({
>        "created_at": String(
>            "2022-05-30T11:00:00Z",
>        ),
>        "description": String(
>            "Usable PostgreSQL connection",
>        ),
>        "details": Object({
>            "dbname": String(
>                "test_pgsql",
>            ),
>            "host": String(
>                "localhost",
>            ),
>            "kind": String(
>                "postgres",
>            ),
>            "port": Number(
>                5432,
             ),
         }),
         "name": String(
             "pg",
         ),
         "updated_at": String(
             "2022-05-30T11:00:00Z",
         ),
         "uuid": String(
             "173140a2-6a7b-4f77-b998-924fb6fc0000",
         ),
     }),
     "description": String(
         "Testing using PostgreSQL",
     ),
     "details": Object({
         "dbname": String(
             "test_pgsql",
         ),
         "host": String(
             "localhost",
         ),
         "kind": String(
             "postgres",
         ),
         "port": Number(
             5432,
         ),
     }),
     "name": String(
         "test_pgsql",
     ),
     "updated_at": String(
         "2022-04-30T13:00:00Z",
     ),
     "uuid": String(
         "3012e874-56f7-4b43-9a6f-627dbdfb12a1",
     ),
 })
```

```
Diff < left / right > :
 {
     "contact": "mailto:thomas@slight.dev",
     "created_at": "2022-04-30T13:00:00Z",
     "default_read_connection": {
         "created_at": "2022-05-30T11:00:00Z",
         "description": "Usable PostgreSQL connection",
         "details": {
             "dbname": "test_pgsql",
             "host": "localhost",
             "kind": "postgres",
             "port": 5432,
<            "sslmode": "disable",
>        },
>        "name": "pg",
>        "updated_at": "2022-05-30T11:00:00Z",
>        "uuid": "173140a2-6a7b-4f77-b998-924fb6fc0000",
>    },
>    "default_write_connection": {
>        "created_at": "2022-05-30T11:00:00Z",
>        "description": "Usable PostgreSQL connection",
>        "details": {
>            "dbname": "test_pgsql",
>            "host": "localhost",
>            "kind": "postgres",
>            "port": 5432,
         },
         "name": "pg",
         "updated_at": "2022-05-30T11:00:00Z",
         "uuid": "173140a2-6a7b-4f77-b998-924fb6fc0000",
     },
     "description": "Testing using PostgreSQL",
     "details": {
         "dbname": "test_pgsql",
         "host": "localhost",
         "kind": "postgres",
         "port": 5432,
     },
     "name": "test_pgsql",
     "updated_at": "2022-04-30T13:00:00Z",
     "uuid": "3012e874-56f7-4b43-9a6f-627dbdfb12a1",
 }
```