### PR TITLE
Reduce unneeded parens and newlines in Debug for Value

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -307,27 +307,15 @@ impl Display for Number {
 impl Debug for Number {
     #[cfg(not(feature = "arbitrary_precision"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        let mut debug = formatter.debug_tuple("Number");
         match self.n {
-            N::PosInt(i) => {
-                debug.field(&i);
-            }
-            N::NegInt(i) => {
-                debug.field(&i);
-            }
-            N::Float(f) => {
-                debug.field(&f);
-            }
+            N::PosInt(_) | N::NegInt(_) => write!(formatter, "Number({})", self),
+            N::Float(f) => write!(formatter, "Number({:?})", f),
         }
-        debug.finish()
     }
 
     #[cfg(feature = "arbitrary_precision")]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter
-            .debug_tuple("Number")
-            .field(&format_args!("{}", self.n))
-            .finish()
+        write!(formatter, "Number({})", self)
     }
 }
 

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -177,19 +177,17 @@ pub enum Value {
 impl Debug for Value {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Value::Null => formatter.debug_tuple("Null").finish(),
-            Value::Bool(v) => formatter.debug_tuple("Bool").field(v).finish(),
-            Value::Number(v) => Debug::fmt(v, formatter),
-            Value::String(v) => formatter.debug_tuple("String").field(v).finish(),
-            Value::Array(v) => {
-                formatter.write_str("Array(")?;
-                Debug::fmt(v, formatter)?;
-                formatter.write_str(")")
+            Value::Null => formatter.write_str("Null"),
+            Value::Bool(boolean) => write!(formatter, "Bool({})", boolean),
+            Value::Number(number) => Debug::fmt(number, formatter),
+            Value::String(string) => write!(formatter, "String({:?})", string),
+            Value::Array(vec) => {
+                formatter.write_str("Array ")?;
+                Debug::fmt(vec, formatter)
             }
-            Value::Object(v) => {
-                formatter.write_str("Object(")?;
-                Debug::fmt(v, formatter)?;
-                formatter.write_str(")")
+            Value::Object(map) => {
+                formatter.write_str("Object ")?;
+                Debug::fmt(map, formatter)
             }
         }
     }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -36,12 +36,12 @@ fn value_string() {
 
 #[test]
 fn value_array() {
-    assert_eq!(format!("{:?}", json!([])), "Array([])");
+    assert_eq!(format!("{:?}", json!([])), "Array []");
 }
 
 #[test]
 fn value_object() {
-    assert_eq!(format!("{:?}", json!({})), "Object({})");
+    assert_eq!(format!("{:?}", json!({})), "Object {}");
 }
 
 #[test]
@@ -63,25 +63,17 @@ fn indented() {
         "String": "...",
     });
     let expected = indoc! {r#"
-        Object({
-            "Array": Array([
-                Bool(
-                    true,
-                ),
-            ]),
-            "Bool": Bool(
-                true,
-            ),
-            "EmptyArray": Array([]),
-            "EmptyObject": Object({}),
+        Object {
+            "Array": Array [
+                Bool(true),
+            ],
+            "Bool": Bool(true),
+            "EmptyArray": Array [],
+            "EmptyObject": Object {},
             "Null": Null,
-            "Number": Number(
-                1,
-            ),
-            "String": String(
-                "...",
-            ),
-        })"#
+            "Number": Number(1),
+            "String": String("..."),
+        }"#
     };
     assert_eq!(format!("{:#?}", j), expected);
 }


### PR DESCRIPTION
**Before:**

```rust
println!("{:#?}", value);
```

```rust
Object({
    "Array": Array([
        Bool(
            true,
        ),
    ]),
    "Bool": Bool(
        true,
    ),
    "EmptyArray": Array([]),
    "EmptyObject": Object({}),
    "Null": Null,
    "Number": Number(
        1,
    ),
    "String": String(
        "...",
    ),
})
```

**After:**

```rust
Object {
    "Array": Array [
        Bool(true),
    ],
    "Bool": Bool(true),
    "EmptyArray": Array [],
    "EmptyObject": Object {},
    "Null": Null,
    "Number": Number(1),
    "String": String("..."),
}
```