### PR TITLE
Preserve '.0' when Displaying Number

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -292,10 +292,9 @@ impl Display for Number {
     #[cfg(not(feature = "arbitrary_precision"))]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         match self.n {
-            N::PosInt(u) => Display::fmt(&u, formatter),
-            N::NegInt(i) => Display::fmt(&i, formatter),
-            // Preserve `.0` on integral values, which Display hides
-            N::Float(f) => Debug::fmt(&f, formatter),
+            N::PosInt(u) => formatter.write_str(itoa::Buffer::new().format(u)),
+            N::NegInt(i) => formatter.write_str(itoa::Buffer::new().format(i)),
+            N::Float(f) => formatter.write_str(ryu::Buffer::new().format_finite(f)),
         }
     }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -294,7 +294,8 @@ impl Display for Number {
         match self.n {
             N::PosInt(u) => Display::fmt(&u, formatter),
             N::NegInt(i) => Display::fmt(&i, formatter),
-            N::Float(f) => Display::fmt(&f, formatter),
+            // Preserve `.0` on integral values, which Display hides
+            N::Float(f) => Debug::fmt(&f, formatter),
         }
     }
 
@@ -305,15 +306,6 @@ impl Display for Number {
 }
 
 impl Debug for Number {
-    #[cfg(not(feature = "arbitrary_precision"))]
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match self.n {
-            N::PosInt(_) | N::NegInt(_) => write!(formatter, "Number({})", self),
-            N::Float(f) => write!(formatter, "Number({:?})", f),
-        }
-    }
-
-    #[cfg(feature = "arbitrary_precision")]
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
         write!(formatter, "Number({})", self)
     }

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -28,6 +28,7 @@ fn value_number() {
     assert_eq!(format!("{:?}", json!(-1)), "Number(-1)");
     assert_eq!(format!("{:?}", json!(1.0)), "Number(1.0)");
     assert_eq!(Number::from_f64(1.0).unwrap().to_string(), "1.0"); // not just "1"
+    assert_eq!(Number::from_f64(12e40).unwrap().to_string(), "1.2e41");
 }
 
 #[test]

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -27,6 +27,7 @@ fn value_number() {
     assert_eq!(format!("{:?}", json!(1)), "Number(1)");
     assert_eq!(format!("{:?}", json!(-1)), "Number(-1)");
     assert_eq!(format!("{:?}", json!(1.0)), "Number(1.0)");
+    assert_eq!(Number::from_f64(1.0).unwrap().to_string(), "1");
 }
 
 #[test]

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -27,7 +27,7 @@ fn value_number() {
     assert_eq!(format!("{:?}", json!(1)), "Number(1)");
     assert_eq!(format!("{:?}", json!(-1)), "Number(-1)");
     assert_eq!(format!("{:?}", json!(1.0)), "Number(1.0)");
-    assert_eq!(Number::from_f64(1.0).unwrap().to_string(), "1");
+    assert_eq!(Number::from_f64(1.0).unwrap().to_string(), "1.0"); // not just "1"
 }
 
 #[test]


### PR DESCRIPTION
Tiny followup to #918.

```rust
let number: serde_json::Number = serde_json::from_str("1.0").unwrap();
println!("{}", number);
```

Previously: `1`
Now: `1.0`