### PR TITLE
Add support for 'nan'

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -158,6 +158,11 @@ macro_rules! json_internal {
         let _ = $object.insert(($($key)+).into(), $value);
     };
 
+    // Next value is `nan`.
+    (@object $object:ident ($($key:tt)+) (: nan $($rest:tt)*) $copy:tt) => {
+        json_internal!(@object $object [$($key)+] (json_internal!(::std::f64::NAN)) $($rest)*);
+    };
+
     // Next value is `null`.
     (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
         json_internal!(@object $object [$($key)+] (json_internal!(null)) $($rest)*);

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -173,7 +173,13 @@ where
     #[inline]
     fn serialize_f32(self, value: f32) -> Result<()> {
         match value.classify() {
-            FpCategory::Nan | FpCategory::Infinite => {
+            FpCategory::Nan => {
+                tri!(self
+                    .formatter
+                    .write_number_str(&mut self.writer, "nan")
+                    .map_err(Error::io));
+            }
+            FpCategory::Infinite => {
                 tri!(self
                     .formatter
                     .write_null(&mut self.writer)
@@ -192,7 +198,13 @@ where
     #[inline]
     fn serialize_f64(self, value: f64) -> Result<()> {
         match value.classify() {
-            FpCategory::Nan | FpCategory::Infinite => {
+            FpCategory::Nan => {
+                tri!(self
+                    .formatter
+                    .write_number_str(&mut self.writer, "nan")
+                    .map_err(Error::io));
+            }
+            FpCategory::Infinite => {
                 tri!(self
                     .formatter
                     .write_null(&mut self.writer)

--- a/tests/debug.rs
+++ b/tests/debug.rs
@@ -24,6 +24,9 @@ fn value_bool() {
 
 #[test]
 fn value_number() {
+    #[cfg(all(not(feature = "arbitrary_precision"), feature = "std"))]
+    assert_eq!(format!("{:?}", json!(::std::f64::NAN)), "Number(NaN)");
+
     assert_eq!(format!("{:?}", json!(1)), "Number(1)");
     assert_eq!(format!("{:?}", json!(-1)), "Number(-1)");
     assert_eq!(format!("{:?}", json!(1.0)), "Number(1.0)");

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -161,13 +161,21 @@ fn test_write_f64() {
 #[test]
 fn test_encode_nonfinite_float_yields_null() {
     let v = to_value(::std::f64::NAN).unwrap();
-    assert!(v.is_null());
+    if !cfg!(feature = "arbitrary_precision") && cfg!(feature = "std") {
+        assert!(v.is_f64());
+    } else {
+        assert!(v.is_null());
+    }
 
     let v = to_value(::std::f64::INFINITY).unwrap();
     assert!(v.is_null());
 
     let v = to_value(::std::f32::NAN).unwrap();
-    assert!(v.is_null());
+    if !cfg!(feature = "arbitrary_precision") && cfg!(feature = "std") {
+        assert!(v.is_f64());
+    } else {
+        assert!(v.is_null());
+    }
 
     let v = to_value(::std::f32::INFINITY).unwrap();
     assert!(v.is_null());
@@ -691,6 +699,17 @@ fn test_parse_null() {
     ]);
 
     test_parse_ok(vec![("null", ())]);
+}
+
+#[test]
+fn test_parse_nan() {
+    test_parse_err::<()>(&[
+        ("n", "EOF while parsing a value at line 1 column 1"),
+        ("na", "expected ident at line 1 column 2"),
+        ("nana", "expected ident at line 1 column 2"),
+    ]);
+
+    assert!(from_str::<f64>("nan").unwrap().is_nan());
 }
 
 #[test]


### PR DESCRIPTION
This PR allows the usage of 'nan' in json, like `json!(nan)`.
With that.. null could be used as +/-infinity, and that can help people that uses serde serialization for more complex data types and protocol standards. 

To explain a bit better my use case, I'm using serde with json to create a REST API based the [mavlink](https://mavlink.io/en/) protocol standard, but some messages uses `nan` to define some specific behavior for some sensors. 

PS: since this needs `std::f64::NAN` to use it, should I move it as a feature ?

Helps #202 