### PR TITLE
Add a `Positioned` type to fix `RawValue` error position.

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -5,6 +5,8 @@ use crate::error::{Error, ErrorCode, Result};
 use crate::lexical;
 use crate::number::Number;
 use crate::read::{self, Fused, Reference};
+#[cfg(feature = "raw_value")]
+use crate::Position;
 use alloc::string::String;
 use alloc::vec::Vec;
 #[cfg(feature = "float_roundtrip")]
@@ -1759,13 +1761,58 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
 
     fn deserialize_tuple_struct<V>(
         self,
-        _name: &'static str,
-        _len: usize,
+        #[cfg(feature = "raw_value")] name: &'static str,
+        #[cfg(feature = "raw_value")] len: usize,
+        #[cfg(not(feature = "raw_value"))] _name: &'static str,
+        #[cfg(not(feature = "raw_value"))] _len: usize,
         visitor: V,
     ) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
+        #[cfg(feature = "raw_value")]
+        {
+            if name == crate::read::TOKEN && len == 2 {
+                struct PosAccess(u8, Position);
+                impl<'de> serde::de::SeqAccess<'de> for PosAccess {
+                    type Error = Error;
+                    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+                    where
+                        T: de::DeserializeSeed<'de>,
+                    {
+                        let res = match self.0 {
+                            0 => seed.deserialize(serde::de::value::UsizeDeserializer::new(
+                                self.1.line,
+                            ))?,
+                            1 => seed.deserialize(serde::de::value::UsizeDeserializer::new(
+                                self.1.column,
+                            ))?,
+                            _ => return Ok(None),
+                        };
+                        self.0 += 1;
+                        Ok(Some(res))
+                    }
+                }
+                return visitor.visit_seq(PosAccess(0, self.read.position()));
+            } else if name == crate::positioned::TOKEN && len == 2 {
+                struct PosAccess<'a, R: 'a>(u8, &'a mut Deserializer<R>);
+                impl<'de, 'a, R: Read<'de> + 'a> serde::de::SeqAccess<'de> for PosAccess<'a, R> {
+                    type Error = Error;
+                    fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
+                    where
+                        T: de::DeserializeSeed<'de>,
+                    {
+                        let res = match self.0 {
+                            0 | 1 => seed.deserialize(&mut *self.1)?,
+                            _ => return Ok(None),
+                        };
+                        self.0 += 1;
+                        Ok(Some(res))
+                    }
+                }
+                return visitor.visit_seq(PosAccess(0, self));
+            }
+        }
         self.deserialize_seq(visitor)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -418,4 +418,11 @@ mod number;
 mod read;
 
 #[cfg(feature = "raw_value")]
+mod positioned;
+#[cfg(feature = "raw_value")]
 mod raw;
+
+#[cfg(feature = "raw_value")]
+pub use positioned::Positioned;
+#[cfg(feature = "raw_value")]
+pub use read::Position;

--- a/src/positioned.rs
+++ b/src/positioned.rs
@@ -1,0 +1,76 @@
+use core::marker::PhantomData;
+
+use serde::{
+    de::{SeqAccess, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
+use crate::read::Position;
+#[cfg(feature = "raw_value")]
+use crate::{de::StrRead, read::PositionedRead, value::RawValue};
+
+pub const TOKEN: &str = "$serde_json::private::Positioned";
+
+/// A value that is saved together with its position in the input.
+pub struct Positioned<T> {
+    /// The position in the input.
+    pub position: Position,
+    /// The actual deserialized value.
+    pub value: T,
+}
+
+impl<'de, T> Deserialize<'de> for Positioned<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct PosVisitor<T>(PhantomData<T>);
+
+        impl<'de, T: Deserialize<'de>> Visitor<'de> for PosVisitor<T> {
+            type Value = Positioned<T>;
+            fn expecting(&self, formatter: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
+                write!(formatter, "positioned value")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                Ok(Positioned {
+                    position: seq.next_element()?.unwrap(),
+                    value: seq.next_element()?.unwrap(),
+                })
+            }
+        }
+
+        deserializer.deserialize_tuple_struct(TOKEN, 2, PosVisitor(PhantomData))
+    }
+}
+
+impl<T: Serialize> Serialize for Positioned<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.value.serialize(serializer)
+    }
+}
+
+#[cfg(feature = "raw_value")]
+impl Positioned<Box<RawValue>> {
+    /// Read from a positioned RawValue.
+    pub fn read(&self) -> PositionedRead<StrRead<'_>> {
+        PositionedRead::new(self.position.clone(), StrRead::new(self.value.get()))
+    }
+}
+
+#[cfg(feature = "raw_value")]
+impl<'a> Positioned<&'a RawValue> {
+    /// Read from a positioned RawValue.
+    pub fn read(&self) -> PositionedRead<StrRead<'a>> {
+        PositionedRead::new(self.position.clone(), StrRead::new(self.value.get()))
+    }
+}

--- a/src/read.rs
+++ b/src/read.rs
@@ -4,6 +4,14 @@ use core::char;
 use core::cmp;
 use core::ops::Deref;
 use core::str;
+#[cfg(feature = "raw_value")]
+use serde::de::SeqAccess;
+#[cfg(feature = "raw_value")]
+use serde::ser::SerializeStruct;
+#[cfg(feature = "raw_value")]
+use serde::Deserialize;
+#[cfg(feature = "raw_value")]
+use serde::Serialize;
 
 #[cfg(feature = "std")]
 use crate::io;
@@ -114,8 +122,12 @@ pub trait Read<'de>: private::Sealed {
     fn set_failed(&mut self, failed: &mut bool);
 }
 
+/// The position in the input stream.
+#[derive(Clone)]
 pub struct Position {
+    /// The current line number.
     pub line: usize,
+    /// The current column number.
     pub column: usize,
 }
 
@@ -1000,5 +1012,147 @@ fn decode_hex_val(val: u8) -> Option<u16> {
         None
     } else {
         Some(n)
+    }
+}
+
+#[cfg(feature = "raw_value")]
+pub(crate) const TOKEN: &str = "$serde_json::private::Position";
+
+#[cfg(feature = "raw_value")]
+impl<'de> Deserialize<'de> for Position {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct PosVisitor;
+
+        impl<'de> Visitor<'de> for PosVisitor {
+            type Value = Position;
+
+            fn expecting(&self, f: &mut alloc::fmt::Formatter) -> alloc::fmt::Result {
+                write!(f, "position indicator")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                Ok(Position {
+                    line: seq.next_element()?.unwrap(),
+                    column: seq.next_element()?.unwrap(),
+                })
+            }
+        }
+
+        deserializer.deserialize_tuple_struct(TOKEN, 2, PosVisitor)
+    }
+}
+
+#[cfg(feature = "raw_value")]
+impl Serialize for Position {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut s = serializer.serialize_struct("position", 2)?;
+        s.serialize_field("line", &self.line)?;
+        s.serialize_field("column", &self.column)?;
+        s.end()
+    }
+}
+
+#[cfg(feature = "raw_value")]
+pub struct PositionedRead<R> {
+    start: Position,
+    read: R,
+}
+
+#[cfg(feature = "raw_value")]
+impl<'de, R: Read<'de>> private::Sealed for PositionedRead<R> {}
+
+#[cfg(feature = "raw_value")]
+impl<'de, R: Read<'de>> PositionedRead<R> {
+    pub fn new(start: Position, read: R) -> Self {
+        Self { start, read }
+    }
+
+    fn adjust_pos(&self, pos: Position) -> Position {
+        match pos.line == 1 {
+            true => Position {
+                line: self.start.line,
+                column: self.start.column + pos.column + 1,
+            },
+            false => Position {
+                line: self.start.line + pos.line - 1,
+                column: pos.column,
+            },
+        }
+    }
+}
+
+#[cfg(feature = "raw_value")]
+impl<'de, R: Read<'de>> Read<'de> for PositionedRead<R> {
+    fn next(&mut self) -> Result<Option<u8>> {
+        self.read.next()
+    }
+
+    fn peek(&mut self) -> Result<Option<u8>> {
+        self.read.peek()
+    }
+
+    fn discard(&mut self) {
+        self.read.discard()
+    }
+
+    fn position(&self) -> Position {
+        self.adjust_pos(self.read.position())
+    }
+
+    fn peek_position(&self) -> Position {
+        self.adjust_pos(self.read.peek_position())
+    }
+
+    fn byte_offset(&self) -> usize {
+        self.read.byte_offset()
+    }
+
+    fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'de, 's, str>> {
+        self.read.parse_str(scratch)
+    }
+
+    fn parse_str_raw<'s>(
+        &'s mut self,
+        scratch: &'s mut Vec<u8>,
+    ) -> Result<Reference<'de, 's, [u8]>> {
+        self.read.parse_str_raw(scratch)
+    }
+
+    fn ignore_str(&mut self) -> Result<()> {
+        self.read.ignore_str()
+    }
+
+    fn decode_hex_escape(&mut self) -> Result<u16> {
+        self.read.decode_hex_escape()
+    }
+
+    #[cfg(feature = "raw_value")]
+    #[doc(hidden)]
+    fn begin_raw_buffering(&mut self) {
+        self.read.begin_raw_buffering()
+    }
+
+    #[cfg(feature = "raw_value")]
+    #[doc(hidden)]
+    fn end_raw_buffering<V>(&mut self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        self.read.end_raw_buffering(visitor)
+    }
+
+    const should_early_return_if_failed: bool = R::should_early_return_if_failed;
+
+    fn set_failed(&mut self, failed: &mut bool) {
+        self.read.set_failed(failed)
     }
 }


### PR DESCRIPTION
`RawValue` can be used to  defer parsing until later, but errors reported during the second parsing step will report line and column numbers relative to the start of the `RawValue`, not to the start of the actual input. This is unhelpful and confusing to users unaware of the inner workings of the deserialization process.

This pull request add a `Positioned` type that can be wrapped around any other deserializable type to save the position in the input stream, and a `PositionedRead` type to allow deserializing from `Positioned` while fixing reported line and column numbers.

This can be used as follows (with the `raw_value` feature enabled):

```rust
use serde::{Deserialize, Serialize};
use serde_json::{value::RawValue, Positioned};

#[derive(Serialize, Deserialize)]
#[serde(bound(deserialize = "'de: 'a"))]
struct DynamicContainer<'a> {
    inner: Positioned<&'a RawValue>,
    fixed: String,
}

#[derive(Serialize, Deserialize)]
struct StaticContainer {
    inner: Inner,
    fixed: String,
}

#[derive(Serialize, Deserialize)]
struct Inner {
    one: String,
    another: String,
}

fn main() {
    let input = r#"{
                "fixed": "Test",
                "inner": {
                        "one": ["oops"]
                }
        }"#;

    let dynamic: DynamicContainer = serde_json::from_str(input).unwrap();
    let inner_decode_err =
        Inner::deserialize(&mut serde_json::Deserializer::new(dynamic.inner.read()))
            .err()
            .unwrap();
    let static_decode_err = serde_json::from_str::<StaticContainer>(input)
        .err()
        .unwrap();

    println!("static: {}", static_decode_err);
    println!("dynamic: {}", inner_decode_err);
}
```

Without `Positioned` this would report an incorrect position for the error during the two-step deserialization:

```
static: invalid type: sequence, expected a string at line 4 column 10
dynamic: invalid type: sequence, expected a string at line 2 column 10
```

With the `Positioned` inner deserialization step, this correctly reports the error position:

```
static: invalid type: sequence, expected a string at line 4 column 10
dynamic: invalid type: sequence, expected a string at line 4 column 10
```
