### PR TITLE
feat: impl `From<[(K, V); N]>` for `Map` and `Value`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -32,6 +32,12 @@ fn main() {
         println!("cargo:rustc-cfg=no_btreemap_remove_entry");
     }
 
+    // Const generics
+    // https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#const-generics-mvp
+    if minor < 51 {
+        println!("cargo:rustc-cfg=no_const_generics");
+    }
+
     // BTreeMap::retain
     // https://blog.rust-lang.org/2021/06/17/Rust-1.53.0.html#stabilized-apis
     if minor < 53 {

--- a/src/map.rs
+++ b/src/map.rs
@@ -14,7 +14,7 @@ use core::hash::Hash;
 use core::iter::{FromIterator, FusedIterator};
 #[cfg(feature = "preserve_order")]
 use core::mem;
-use core::ops;
+use core::{array, ops};
 use serde::de;
 
 #[cfg(not(feature = "preserve_order"))]
@@ -427,6 +427,13 @@ impl<'de> de::Deserialize<'de> for Map<String, Value> {
         }
 
         deserializer.deserialize_map(Visitor)
+    }
+}
+
+#[cfg(not(no_const_generics))]
+impl<const N: usize> From<[(String, Value); N]> for Map<String, Value> {
+    fn from(arr: [(String, Value); N]) -> Self {
+        array::IntoIter::new(arr).collect()
     }
 }
 

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -4,6 +4,7 @@ use crate::number::Number;
 use alloc::borrow::Cow;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use core::array;
 use core::iter::FromIterator;
 
 #[cfg(feature = "arbitrary_precision")]
@@ -230,6 +231,23 @@ impl<T: Into<Value>> FromIterator<T> for Value {
     /// ```
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         Value::Array(iter.into_iter().map(Into::into).collect())
+    }
+}
+
+#[cfg(not(no_const_generics))]
+impl<K: Into<String>, V: Into<Value>, const N: usize> From<[(K, V); N]> for Value {
+    /// Convert a list of map entry tuples to `Value`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use serde_json::Value;
+    ///
+    /// let v = [("lorem", 40), ("ipsum", 2)];
+    /// let x: Value = v.into();
+    /// ```
+    fn from(arr: [(K, V); N]) -> Self {
+        array::IntoIter::new(arr).collect()
     }
 }
 


### PR DESCRIPTION
This PR implements `From<[(K, V); N]>` for `Map` and `Value`, enabling things like:
```rs
let map = Map::from([("lorem", 40), ("ipsum", 2)]);
```
or
```rs
let v = [("lorem", 40), ("ipsum", 2)];
let x: Value = v.into();
```

Relevant PRs:
- https://github.com/rust-lang/rust/pull/84111 implemented it for the collections in `std`
- https://github.com/bluss/indexmap/pull/205 implemented it for `IndexMap`
