### PR TITLE
Delete 1.36+ caveat from descriptions of alloc feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ std = ["serde/std"]
 # Provide integration for heap-allocated collections without depending on the
 # rest of the Rust standard library.
 # NOTE: Disabling both `std` *and* `alloc` features is not supported yet.
-# Available on Rust 1.36+.
 alloc = ["serde/alloc"]
 
 # Make serde_json::Map use a representation which maintains insertion order.

--- a/README.md
+++ b/README.md
@@ -350,8 +350,8 @@ closed without a response after some time.
 ## No-std support
 
 As long as there is a memory allocator, it is possible to use serde_json without
-the rest of the Rust standard library. This is supported on Rust 1.36+. Disable
-the default "std" feature and enable the "alloc" feature:
+the rest of the Rust standard library. Disable the default "std" feature and
+enable the "alloc" feature:
 
 ```toml
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,8 +279,8 @@
 //! # No-std support
 //!
 //! As long as there is a memory allocator, it is possible to use serde_json
-//! without the rest of the Rust standard library. This is supported on Rust
-//! 1.36+. Disable the default "std" feature and enable the "alloc" feature:
+//! without the rest of the Rust standard library. Disable the default "std"
+//! feature and enable the "alloc" feature:
 //!
 //! ```toml
 //! [dependencies]


### PR DESCRIPTION
Back when `features = ["alloc"]` got added, serde_json with default features supported Rust 1.30, so it made sense to call out that alloc was limited to a more recent compiler than that. Now only 1.36+ is supported in general so alloc is no longer special.