### PR TITLE
Assume serde_if_integer128 is true

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -12,10 +12,7 @@ use core::hash::{Hash, Hasher};
 use serde::de::{self, Unexpected, Visitor};
 #[cfg(feature = "arbitrary_precision")]
 use serde::de::{IntoDeserializer, MapAccess};
-use serde::{
-    forward_to_deserialize_any, serde_if_integer128, Deserialize, Deserializer, Serialize,
-    Serializer,
-};
+use serde::{forward_to_deserialize_any, Deserialize, Deserializer, Serialize, Serializer};
 
 #[cfg(feature = "arbitrary_precision")]
 pub(crate) const TOKEN: &str = "$serde_json::private::Number";
@@ -540,17 +537,14 @@ impl<'de> Deserializer<'de> for Number {
     deserialize_number!(deserialize_i16 => visit_i16);
     deserialize_number!(deserialize_i32 => visit_i32);
     deserialize_number!(deserialize_i64 => visit_i64);
+    deserialize_number!(deserialize_i128 => visit_i128);
     deserialize_number!(deserialize_u8 => visit_u8);
     deserialize_number!(deserialize_u16 => visit_u16);
     deserialize_number!(deserialize_u32 => visit_u32);
     deserialize_number!(deserialize_u64 => visit_u64);
+    deserialize_number!(deserialize_u128 => visit_u128);
     deserialize_number!(deserialize_f32 => visit_f32);
     deserialize_number!(deserialize_f64 => visit_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128 => visit_i128);
-        deserialize_number!(deserialize_u128 => visit_u128);
-    }
 
     forward_to_deserialize_any! {
         bool char str string bytes byte_buf option unit unit_struct
@@ -568,17 +562,14 @@ impl<'de, 'a> Deserializer<'de> for &'a Number {
     deserialize_number!(deserialize_i16 => visit_i16);
     deserialize_number!(deserialize_i32 => visit_i32);
     deserialize_number!(deserialize_i64 => visit_i64);
+    deserialize_number!(deserialize_i128 => visit_i128);
     deserialize_number!(deserialize_u8 => visit_u8);
     deserialize_number!(deserialize_u16 => visit_u16);
     deserialize_number!(deserialize_u32 => visit_u32);
     deserialize_number!(deserialize_u64 => visit_u64);
+    deserialize_number!(deserialize_u128 => visit_u128);
     deserialize_number!(deserialize_f32 => visit_f32);
     deserialize_number!(deserialize_f64 => visit_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128 => visit_i128);
-        deserialize_number!(deserialize_u128 => visit_u128);
-    }
 
     forward_to_deserialize_any! {
         bool char str string bytes byte_buf option unit unit_struct
@@ -731,10 +722,9 @@ impl_from_unsigned!(u8, u16, u32, u64, usize);
 impl_from_signed!(i8, i16, i32, i64, isize);
 
 #[cfg(feature = "arbitrary_precision")]
-serde_if_integer128! {
-    impl_from_unsigned!(u128);
-    impl_from_signed!(i128);
-}
+impl_from_unsigned!(u128);
+#[cfg(feature = "arbitrary_precision")]
+impl_from_signed!(i128);
 
 impl Number {
     #[cfg(not(feature = "arbitrary_precision"))]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -7,7 +7,6 @@ use alloc::vec::Vec;
 use core::fmt::{self, Display};
 use core::num::FpCategory;
 use serde::ser::{self, Impossible, Serialize};
-use serde::serde_if_integer128;
 
 /// A structure for serializing Rust values into JSON.
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
@@ -118,12 +117,10 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<()> {
-            self.formatter
-                .write_i128(&mut self.writer, value)
-                .map_err(Error::io)
-        }
+    fn serialize_i128(self, value: i128) -> Result<()> {
+        self.formatter
+            .write_i128(&mut self.writer, value)
+            .map_err(Error::io)
     }
 
     #[inline]
@@ -162,12 +159,10 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<()> {
-            self.formatter
-                .write_u128(&mut self.writer, value)
-                .map_err(Error::io)
-        }
+    fn serialize_u128(self, value: u128) -> Result<()> {
+        self.formatter
+            .write_u128(&mut self.writer, value)
+            .map_err(Error::io)
     }
 
     #[inline]
@@ -964,25 +959,23 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<()> {
-            tri!(self
-                .ser
-                .formatter
-                .begin_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .write_i128(&mut self.ser.writer, value)
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .end_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            Ok(())
-        }
+    fn serialize_i128(self, value: i128) -> Result<()> {
+        tri!(self
+            .ser
+            .formatter
+            .begin_string(&mut self.ser.writer)
+            .map_err(Error::io));
+        tri!(self
+            .ser
+            .formatter
+            .write_i128(&mut self.ser.writer, value)
+            .map_err(Error::io));
+        tri!(self
+            .ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io));
+        Ok(())
     }
 
     fn serialize_u8(self, value: u8) -> Result<()> {
@@ -1061,25 +1054,23 @@ where
         Ok(())
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<()> {
-            tri!(self
-                .ser
-                .formatter
-                .begin_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .write_u128(&mut self.ser.writer, value)
-                .map_err(Error::io));
-            tri!(self
-                .ser
-                .formatter
-                .end_string(&mut self.ser.writer)
-                .map_err(Error::io));
-            Ok(())
-        }
+    fn serialize_u128(self, value: u128) -> Result<()> {
+        tri!(self
+            .ser
+            .formatter
+            .begin_string(&mut self.ser.writer)
+            .map_err(Error::io));
+        tri!(self
+            .ser
+            .formatter
+            .write_u128(&mut self.ser.writer, value)
+            .map_err(Error::io));
+        tri!(self
+            .ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io));
+        Ok(())
     }
 
     fn serialize_f32(self, _value: f32) -> Result<()> {
@@ -1218,10 +1209,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, _v: i128) -> Result<()> {
-            Err(invalid_number())
-        }
+    fn serialize_i128(self, _v: i128) -> Result<()> {
+        Err(invalid_number())
     }
 
     fn serialize_u8(self, _v: u8) -> Result<()> {
@@ -1240,10 +1229,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for NumberStrEmitter<'a, W,
         Err(invalid_number())
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, _v: u128) -> Result<()> {
-            Err(invalid_number())
-        }
+    fn serialize_u128(self, _v: u128) -> Result<()> {
+        Err(invalid_number())
     }
 
     fn serialize_f32(self, _v: f32) -> Result<()> {
@@ -1399,10 +1386,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    serde_if_integer128! {
-        fn serialize_i128(self, _v: i128) -> Result<()> {
-            Err(ser::Error::custom("expected RawValue"))
-        }
+    fn serialize_i128(self, _v: i128) -> Result<()> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 
     fn serialize_u8(self, _v: u8) -> Result<()> {
@@ -1421,10 +1406,8 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
         Err(ser::Error::custom("expected RawValue"))
     }
 
-    serde_if_integer128! {
-        fn serialize_u128(self, _v: u128) -> Result<()> {
-            Err(ser::Error::custom("expected RawValue"))
-        }
+    fn serialize_u128(self, _v: u128) -> Result<()> {
+        Err(ser::Error::custom("expected RawValue"))
     }
 
     fn serialize_f32(self, _v: f32) -> Result<()> {

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -14,7 +14,7 @@ use serde::de::{
     self, Deserialize, DeserializeSeed, EnumAccess, Expected, IntoDeserializer, MapAccess,
     SeqAccess, Unexpected, VariantAccess, Visitor,
 };
-use serde::{forward_to_deserialize_any, serde_if_integer128};
+use serde::forward_to_deserialize_any;
 
 #[cfg(feature = "arbitrary_precision")]
 use crate::number::NumberFromString;
@@ -228,17 +228,14 @@ impl<'de> serde::Deserializer<'de> for Value {
     deserialize_number!(deserialize_i16);
     deserialize_number!(deserialize_i32);
     deserialize_number!(deserialize_i64);
+    deserialize_number!(deserialize_i128);
     deserialize_number!(deserialize_u8);
     deserialize_number!(deserialize_u16);
     deserialize_number!(deserialize_u32);
     deserialize_number!(deserialize_u64);
+    deserialize_number!(deserialize_u128);
     deserialize_number!(deserialize_f32);
     deserialize_number!(deserialize_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128);
-        deserialize_number!(deserialize_u128);
-    }
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -724,17 +721,14 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     deserialize_value_ref_number!(deserialize_i16);
     deserialize_value_ref_number!(deserialize_i32);
     deserialize_value_ref_number!(deserialize_i64);
+    deserialize_number!(deserialize_i128);
     deserialize_value_ref_number!(deserialize_u8);
     deserialize_value_ref_number!(deserialize_u16);
     deserialize_value_ref_number!(deserialize_u32);
     deserialize_value_ref_number!(deserialize_u64);
+    deserialize_number!(deserialize_u128);
     deserialize_value_ref_number!(deserialize_f32);
     deserialize_value_ref_number!(deserialize_f64);
-
-    serde_if_integer128! {
-        deserialize_number!(deserialize_i128);
-        deserialize_number!(deserialize_u128);
-    }
 
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
     where
@@ -1156,15 +1150,12 @@ impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
     deserialize_integer_key!(deserialize_i16 => visit_i16);
     deserialize_integer_key!(deserialize_i32 => visit_i32);
     deserialize_integer_key!(deserialize_i64 => visit_i64);
+    deserialize_integer_key!(deserialize_i128 => visit_i128);
     deserialize_integer_key!(deserialize_u8 => visit_u8);
     deserialize_integer_key!(deserialize_u16 => visit_u16);
     deserialize_integer_key!(deserialize_u32 => visit_u32);
     deserialize_integer_key!(deserialize_u64 => visit_u64);
-
-    serde_if_integer128! {
-        deserialize_integer_key!(deserialize_i128 => visit_i128);
-        deserialize_integer_key!(deserialize_u128 => visit_u128);
-    }
+    deserialize_integer_key!(deserialize_u128 => visit_u128);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>

--- a/src/value/from.rs
+++ b/src/value/from.rs
@@ -6,9 +6,6 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::iter::FromIterator;
 
-#[cfg(feature = "arbitrary_precision")]
-use serde::serde_if_integer128;
-
 macro_rules! from_integer {
     ($($ty:ident)*) => {
         $(
@@ -27,10 +24,8 @@ from_integer! {
 }
 
 #[cfg(feature = "arbitrary_precision")]
-serde_if_integer128! {
-    from_integer! {
-        i128 u128
-    }
+from_integer! {
+    i128 u128
 }
 
 impl From<f32> for Value {

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -9,9 +9,6 @@ use core::fmt::Display;
 use core::result;
 use serde::ser::{Impossible, Serialize};
 
-#[cfg(feature = "arbitrary_precision")]
-use serde::serde_if_integer128;
-
 impl Serialize for Value {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
@@ -96,10 +93,8 @@ impl serde::Serializer for Serializer {
     }
 
     #[cfg(feature = "arbitrary_precision")]
-    serde_if_integer128! {
-        fn serialize_i128(self, value: i128) -> Result<Value> {
-            Ok(Value::Number(value.into()))
-        }
+    fn serialize_i128(self, value: i128) -> Result<Value> {
+        Ok(Value::Number(value.into()))
     }
 
     #[inline]
@@ -123,10 +118,8 @@ impl serde::Serializer for Serializer {
     }
 
     #[cfg(feature = "arbitrary_precision")]
-    serde_if_integer128! {
-        fn serialize_u128(self, value: u128) -> Result<Value> {
-            Ok(Value::Number(value.into()))
-        }
+    fn serialize_u128(self, value: u128) -> Result<Value> {
+        Ok(Value::Number(value.into()))
     }
 
     #[inline]


### PR DESCRIPTION
According to https://github.com/serde-rs/serde/blob/v1.0.145/serde/build.rs#L57-L62, it's false on Emscripten older than 1.40 and other targets older than 1.26. Since serde_json currently requires Rust 1.36 or newer, the only effect is dropping support for using Emscripten with Rust 1.36, 1.37, 1.38, 1.39, which are 3-year-old compilers that nobody has any reason to use when building for Emscripten today, given how premature the support for Emscripten was at the time.