### PR TITLE
Public ErrorCode getter for Error type

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -104,6 +104,12 @@ impl Error {
     pub fn is_eof(&self) -> bool {
         self.classify() == Category::Eof
     }
+    
+    /// Returns a reference to the ErrorCode that represents the specific cause 
+    /// of this error.
+    pub fn error_core(&self) -> &ErrorCode {
+        &self.err.code
+    }
 }
 
 /// Categorizes the cause of a `serde_json::Error`.


### PR DESCRIPTION
Added a public getter to the ErrorCode enum to facilitate more verbose error handling.

As discussed in #285. 