### PR TITLE
Implement `TryInto` for `Value`

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -880,6 +880,7 @@ mod from;
 mod index;
 mod partial_eq;
 mod ser;
+mod try_into;
 
 /// Convert a `T` into `serde_json::Value` which is an enum that can represent
 /// any valid JSON data.

--- a/src/value/try_into.rs
+++ b/src/value/try_into.rs
@@ -1,0 +1,161 @@
+use core::convert::TryInto;
+use crate::map::Map;
+use crate::error::Error;
+use super::Value;
+
+impl TryInto<String> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<String, Error> {
+        match self {
+            Value::String(s) => Ok(s),
+            _ => Err(<Error as serde::de::Error>::custom("value is not a string")),
+        }
+    }
+}
+
+impl<'a> TryInto<&'a String> for &'a Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<&'a String, Error> {
+        match self {
+            Value::String(s) => Ok(s),
+            _ => Err(<Error as serde::de::Error>::custom("value is not a string")),
+        }
+    }
+}
+
+impl<'a> TryInto<&'a str> for &'a Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<&'a str, Error> {
+        self.as_str().ok_or_else(|| <Error as serde::de::Error>::custom("value is not a string"))
+    }
+}
+
+impl TryInto<f64> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<f64, Error> {
+        self.as_f64().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an f64"))
+    }
+}
+
+
+impl TryInto<f64> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<f64, Error> {
+        self.as_f64().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an f64"))
+    }
+}
+
+impl TryInto<i64> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<i64, Error> {
+        self.as_i64().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an i64"))
+    }
+}
+
+impl TryInto<i64> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<i64, Error> {
+        self.as_i64().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an i64"))
+    }
+}
+
+impl TryInto<u64> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<u64, Error> {
+        self.as_u64().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an u64"))
+    }
+}
+
+impl TryInto<u64> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<u64, Error> {
+        self.as_u64().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an u64"))
+    }
+}
+
+impl TryInto<bool> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<bool, Error> {
+        self.as_bool().ok_or_else(|| <Error as serde::de::Error>::custom("value is not a bool"))
+    }
+}
+
+impl TryInto<bool> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<bool, Error> {
+        self.as_bool().ok_or_else(|| <Error as serde::de::Error>::custom("value is not a bool"))
+    }
+}
+
+impl<'a> TryInto<&'a Vec<Value>> for &'a Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<&'a Vec<Value>, Error> {
+        self.as_array().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an array"))
+    }
+}
+
+impl<'a> TryInto<&'a [Value]> for &'a Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<&'a [Value], Error> {
+        self.as_array().map(|v| v.as_slice()).ok_or_else(|| <Error as serde::de::Error>::custom("value is not an array"))
+    }
+}
+
+impl TryInto<Vec<Value>> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Vec<Value>, Error> {
+        match self {
+            Value::Array(a) => Ok(a),
+            _ => Err(<Error as serde::de::Error>::custom("value is not an array")),
+        }
+    }
+}
+
+impl TryInto<Map<String, Value>> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<Map<String, Value>, Error> {
+        match self {
+            Value::Object(o) => Ok(o),
+            _ => Err(<Error as serde::de::Error>::custom("value is not an object")),
+        }
+    }
+}
+
+impl<'a> TryInto<&'a Map<String, Value>> for &'a Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<&'a Map<String, Value>, Error> {
+        self.as_object().ok_or_else(|| <Error as serde::de::Error>::custom("value is not an object"))
+    }
+}
+
+impl TryInto<()> for Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<(), Error> {
+        self.as_null().ok_or_else(|| <Error as serde::de::Error>::custom("value is not a null"))
+    }
+}
+
+impl TryInto<()> for &Value {
+    type Error = Error;
+
+    fn try_into(self) -> Result<(), Error> {
+        self.as_null().ok_or_else(|| <Error as serde::de::Error>::custom("value is not a null"))
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2060,6 +2060,93 @@ fn test_partialeq_bool() {
     assert_ne!(v, 0);
 }
 
+#[test]
+fn test_tryinto_string() {
+    use std::convert::TryInto;
+    let v = to_value("42").unwrap();
+    let s: &String = (&v).try_into().unwrap();
+    assert_eq!(s, "42");
+    let s: &str = (&v).try_into().unwrap();
+    assert_eq!(s, "42");
+    let s: String = v.clone().try_into().unwrap();
+    assert_eq!(s, "42");
+}
+
+#[test]
+fn test_tryinto_number() {
+    use std::convert::TryInto;
+    let v = to_value(42).unwrap();
+    let n: u64 = (&v).try_into().unwrap();
+    assert_eq!(n, 42);
+    let n: i64 = (&v).try_into().unwrap();
+    assert_eq!(n, 42);
+    let n: f64 = (&v).try_into().unwrap();
+    assert_eq!(n, 42.0);
+    let n: u64 = v.clone().try_into().unwrap();
+    assert_eq!(n, 42);
+    let n: i64 = v.clone().try_into().unwrap();
+    assert_eq!(n, 42);
+    let n: f64 = v.clone().try_into().unwrap();
+    assert_eq!(n, 42.0);
+}
+
+#[test]
+fn test_tryinto_bool() {
+    use std::convert::TryInto;
+    let v = to_value(true).unwrap();
+    let b: bool = (&v).try_into().unwrap();
+    assert_eq!(b, true);
+    let b: bool = v.try_into().unwrap();
+    assert_eq!(b, true);
+
+    let v = to_value(false).unwrap();
+    let b: bool = (&v).try_into().unwrap();
+    assert_eq!(b, false);
+    let b: bool = v.try_into().unwrap();
+    assert_eq!(b, false);
+}
+
+#[test]
+fn test_tryinto_null() {
+    use std::convert::TryInto;
+    let v = to_value(()).unwrap();
+    let n: () = v.try_into().unwrap();
+    assert_eq!(n, ());
+}
+
+#[test]
+fn test_tryinto_array() {
+    use std::convert::TryInto;
+
+    let v = json!([1, 2, 3]);
+    let a: &Vec<Value> = (&v).try_into().unwrap();
+    assert_eq!(a, &vec![1, 2, 3]);
+    let a: &[Value] = (&v).try_into().unwrap();
+    assert_eq!(a, vec![1, 2, 3]);
+    let a: Vec<Value> = v.try_into().unwrap();
+    assert_eq!(a, vec![1, 2, 3]);
+
+    let v = json!([1, 2.0, "foo", { "bar": "baz"}, null, false]);
+    let _a: &Vec<Value> = (&v).try_into().unwrap();
+    let _a: &[Value] = (&v).try_into().unwrap();
+    let _a: Vec<Value> = v.try_into().unwrap();
+}
+
+#[test]
+fn test_tryinto_object() {
+    use std::convert::TryInto;
+    use serde_json::map::Map;
+
+    let mut map = Map::new();
+    map.insert("foo".to_string(), json!("bar"));
+
+    let v = json!({"foo": "bar"});
+    let m: &Map<String, Value> = (&v).try_into().unwrap();
+    assert_eq!(m, &map);
+    let m: Map<String, Value> = v.try_into().unwrap();
+    assert_eq!(m, map);
+}
+
 struct FailReader(io::ErrorKind);
 
 impl io::Read for FailReader {


### PR DESCRIPTION
Fixes #902 

This PR implements `TryInto` for converting `Value` into common types such as `String`, `str`, `u64`, `f64`, `i64`, `()`, `Vec` and `Map`.  I've implemented these both for owned `Value` and borrowed `Value`. 

### Justification and Use Case

I know there's been some skepticism from the maintainer about the need for `TryInto` impls when one can use the full deserialization machinery to retrieve a concrete typed value from a `Value`, but I'd like to justify this PR by pointing to both the ergonomics of having `TryInto` and the efficiency of `TryInto` over full deserialization (especially when borrowing).

For my use-case, I have a struct that looks like this that delays fully deserializing all values until much later in the process. 

```rust
struct Job {
    pub name: String,
    pub inputs: HashMap<String, Value>
}
```

Much deeper in the code, inputs get wrapped into a container like so:

```rust
pub struct Inputs {
    inner: HashMap<String, Value>
}

impl Inputs {

    pub fn get_required<'a, T: ?Sized>(&'a self, key: &str) -> Result<&'a T, Error>
        where &'a Value: TryInto<&'a T>
    {
        match self.inner.get(key) {
            Some(value) => {
                value.try_into()?
            },
            None => Err(Error)
        }
    }

    pub fn get_with_default<'a, 'default: 'a, T: ?Sized>(&'a self, key: &str, default: &'default T) -> Result<&'a T, Error> 
        where &'a Value: TryInto<&'a T> 
    {
        match self.inner.get(key) {
            Some(value) => {
                value.try_into()?
            },
            None => {
                Ok(default)
            }
        }
    }
}

```

All of this machinery provides a really nice interface to calling code, that can simply call into `Inputs` like so:

```rust
let foo: &str = inputs.get_required("foo").unwrap();
let bar: &str = inputs.get_with_default("bar", "baz").unwrap();
```

And importantly, because inputs can be quite large, everything is done via borrows, avoiding unnecessary cloning and allocations. 

This is my specific use-case, but I'm sure there are other use-cases where having reasonable and straightforward `TryInto` impls for Value would be ergonomic and timesaving. 

Thank you. 
