### PR TITLE
Add clone_from and use IndexMap::extend

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -197,9 +197,8 @@ impl Map<String, Value> {
     #[inline]
     pub fn append(&mut self, other: &mut Self) {
         #[cfg(feature = "preserve_order")]
-        for (k, v) in mem::replace(&mut other.map, MapImpl::default()) {
-            self.map.insert(k, v);
-        }
+        self.map
+            .extend(mem::replace(&mut other.map, MapImpl::default()));
         #[cfg(not(feature = "preserve_order"))]
         self.map.append(&mut other.map);
     }
@@ -303,6 +302,11 @@ impl Clone for Map<String, Value> {
         Map {
             map: self.map.clone(),
         }
+    }
+
+    #[inline]
+    fn clone_from(&mut self, source: &Self) {
+        self.map.clone_from(&source.map)
     }
 }
 


### PR DESCRIPTION
This PR adds `clone_from` to `Map`'s `Clone` implementation, so that clones can take advantage of existing storage. Additionally, `Map::append` now uses `IndexMap::extend`, to take advantage of reservation logic.