### PR TITLE
Add support for arbitrary crate to Value.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
         run: cargo check --manifest-path tests/crate/Cargo.toml --target ${{matrix.target}} --no-default-features --features alloc
         if: matrix.target
       - run: cargo check --features arbitrary_value
+        if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
       - run: cargo check --features arbitrary_value,preserve_order
         if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
       - run: cargo test --features float_roundtrip,arbitrary_precision --tests -- --skip ui --exact
       - run: cargo test --features raw_value --tests -- --skip ui --exact
       - run: cargo test --features unbounded_depth --tests -- --skip ui --exact
+      - run: cargo test --features arbitrary --tests -- --skip ui --exact
+      - run: cargo test --features arbitrary,preserve_order --tests -- --skip ui --exact
 
   build:
     name: Rust ${{matrix.rust}} ${{matrix.os == 'windows' && '(windows)' || ''}}
@@ -67,6 +69,9 @@ jobs:
       - name: Build without std
         run: cargo check --manifest-path tests/crate/Cargo.toml --target ${{matrix.target}} --no-default-features --features alloc
         if: matrix.target
+      - run: cargo check --features arbitrary
+      - run: cargo check --features arbitrary,preserve_order
+        if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
 
   miri:
     name: Miri
@@ -98,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo doc --features raw_value,unbounded_depth
+      - run: cargo doc --features raw_value,unbounded_depth,arbitrary
         env:
           RUSTDOCFLAGS: --cfg docsrs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       - run: cargo test --features float_roundtrip,arbitrary_precision --tests -- --skip ui --exact
       - run: cargo test --features raw_value --tests -- --skip ui --exact
       - run: cargo test --features unbounded_depth --tests -- --skip ui --exact
-      - run: cargo test --features arbitrary --tests -- --skip ui --exact
-      - run: cargo test --features arbitrary,preserve_order --tests -- --skip ui --exact
+      - run: cargo test --features arbitrary_value --tests -- --skip ui --exact
+      - run: cargo test --features arbitrary_value,preserve_order --tests -- --skip ui --exact
 
   build:
     name: Rust ${{matrix.rust}} ${{matrix.os == 'windows' && '(windows)' || ''}}
@@ -69,8 +69,8 @@ jobs:
       - name: Build without std
         run: cargo check --manifest-path tests/crate/Cargo.toml --target ${{matrix.target}} --no-default-features --features alloc
         if: matrix.target
-      - run: cargo check --features arbitrary
-      - run: cargo check --features arbitrary,preserve_order
+      - run: cargo check --features arbitrary_value
+      - run: cargo check --features arbitrary_value,preserve_order
         if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
 
   miri:
@@ -103,7 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly
-      - run: cargo doc --features raw_value,unbounded_depth,arbitrary
+      - run: cargo doc --features raw_value,unbounded_depth,arbitrary_value
         env:
           RUSTDOCFLAGS: --cfg docsrs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,9 @@ jobs:
         run: cargo check --manifest-path tests/crate/Cargo.toml --target ${{matrix.target}} --no-default-features --features alloc
         if: matrix.target
       - run: cargo check --features arbitrary_value
-        if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
+        if: matrix.rust != '1.56.1' && matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
       - run: cargo check --features arbitrary_value,preserve_order
-        if: matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
+        if: matrix.rust != '1.56.1' && matrix.rust != '1.53.0' && matrix.rust != '1.46.0' && matrix.rust != '1.45.0' && matrix.rust != '1.40.0' && matrix.rust != '1.38.0' && matrix.rust != '1.36.0'
 
   miri:
     name: Miri

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.100", default-features = false }
 indexmap = { version = "1.5.2", features = ["std"], optional = true }
 itoa = "1.0"
 ryu = "1.0"
+arbitrary = { version="1.2.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 automod = "1.0"
@@ -89,3 +90,6 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+# Add support for the arbitrary crate to Value.
+arbitrary = ["dep:arbitrary", "indexmap/arbitrary", "std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,4 @@ raw_value = []
 unbounded_depth = []
 
 # Add support for the arbitrary crate to Value.
-arbitrary = ["dep:arbitrary", "indexmap/arbitrary", "std"]
+arbitrary_value = ["arbitrary", "indexmap/arbitrary", "std"]

--- a/src/map.rs
+++ b/src/map.rs
@@ -23,19 +23,19 @@ use alloc::collections::{btree_map, BTreeMap};
 use indexmap::{self, IndexMap};
 
 /// Represents a JSON key/value type.
-#[cfg(not(feature = "arbitrary"))]
+#[cfg(not(feature = "arbitrary_value"))]
 pub struct Map<K, V> {
     map: MapImpl<K, V>,
 }
 
 /// Represents a JSON key/value type.
-#[cfg(all(feature = "arbitrary", not(feature = "preserve_order")))]
+#[cfg(all(feature = "arbitrary_value", not(feature = "preserve_order")))]
 #[derive(arbitrary::Arbitrary)]
 pub struct Map<K: Ord, V> {
     map: MapImpl<K, V>,
 }
 /// Represents a JSON key/value type.
-#[cfg(all(feature = "arbitrary", feature = "preserve_order"))]
+#[cfg(all(feature = "arbitrary_value", feature = "preserve_order"))]
 #[derive(arbitrary::Arbitrary)]
 pub struct Map<K: Hash + Eq, V> {
     map: MapImpl<K, V>,

--- a/src/map.rs
+++ b/src/map.rs
@@ -23,7 +23,21 @@ use alloc::collections::{btree_map, BTreeMap};
 use indexmap::{self, IndexMap};
 
 /// Represents a JSON key/value type.
+#[cfg(not(feature = "arbitrary"))]
 pub struct Map<K, V> {
+    map: MapImpl<K, V>,
+}
+
+/// Represents a JSON key/value type.
+#[cfg(all(feature = "arbitrary", not(feature = "preserve_order")))]
+#[derive(arbitrary::Arbitrary)]
+pub struct Map<K: Ord, V> {
+    map: MapImpl<K, V>,
+}
+/// Represents a JSON key/value type.
+#[cfg(all(feature = "arbitrary", feature = "preserve_order"))]
+#[derive(arbitrary::Arbitrary)]
+pub struct Map<K: Hash + Eq, V> {
     map: MapImpl<K, V>,
 }
 

--- a/src/number.rs
+++ b/src/number.rs
@@ -19,12 +19,14 @@ pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
 #[derive(Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Number {
     n: N,
 }
 
 #[cfg(not(feature = "arbitrary_precision"))]
 #[derive(Copy, Clone)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 enum N {
     PosInt(u64),
     /// Always less than zero.

--- a/src/number.rs
+++ b/src/number.rs
@@ -19,14 +19,14 @@ pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary_value", derive(arbitrary::Arbitrary))]
 pub struct Number {
     n: N,
 }
 
 #[cfg(not(feature = "arbitrary_precision"))]
 #[derive(Copy, Clone)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary_value", derive(arbitrary::Arbitrary))]
 enum N {
     PosInt(u64),
     /// Always less than zero.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -112,7 +112,7 @@ pub use crate::raw::{to_raw_value, RawValue};
 ///
 /// See the [`serde_json::value` module documentation](self) for usage examples.
 #[derive(Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary_value", derive(arbitrary::Arbitrary))]
 pub enum Value {
     /// Represents a JSON null value.
     ///

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -112,6 +112,7 @@ pub use crate::raw::{to_raw_value, RawValue};
 ///
 /// See the [`serde_json::value` module documentation](self) for usage examples.
 #[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Value {
     /// Represents a JSON null value.
     ///

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2385,3 +2385,10 @@ fn hash_positive_and_negative_zero() {
         assert_eq!(hash(k1), hash(k2));
     }
 }
+
+#[cfg(feature = "arbitrary_value")]
+#[test]
+fn arbitrary_value() {
+    let mut u = arbitrary::Unstructured::new(&[1, 2, 3, 4]);
+    let _value: Value = u.arbitrary().expect("Could not generate arbitrary Value");
+}


### PR DESCRIPTION
This adds the option to derive the Arbitrary trait (defined in the [arbitrary crate](https://github.com/rust-fuzz/arbitrary/)) for `serde_json::Value`, gated behind the `arbitrary_value` feature.