### PR TITLE
error: Implement Serialize

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -382,6 +382,15 @@ impl ser::Error for Error {
     }
 }
 
+impl ser::Serialize for Error {
+    fn serialize<S>(&self, serializer: S) -> result::Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
 // Parse our own error message that looks like "{} at line {} column {}" to work
 // around erased-serde round-tripping the error through de::Error::custom.
 fn make_error(mut msg: String) -> Error {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2385,3 +2385,15 @@ fn hash_positive_and_negative_zero() {
         assert_eq!(hash(k1), hash(k2));
     }
 }
+
+#[test]
+fn error_impl_serialize() {
+    let res = serde_json::from_str::<Number>(";");
+
+    assert!(res.is_err());
+
+    let res = serde_json::to_string(&res.unwrap_err());
+
+    assert!(res.is_ok());
+    assert_eq!(res.unwrap(), "\"expected value at line 1 column 1\"");
+}


### PR DESCRIPTION
This commit implements serialization for the Error struct that simply defers to the Display implementation.

Fixes https://github.com/serde-rs/json/issues/199