### PR TITLE
Hide repr attribute from documentation

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -112,7 +112,7 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 ///     raw_value: Box<RawValue>,
 /// }
 /// ```
-#[repr(transparent)]
+#[cfg_attr(not(doc), repr(transparent))]
 #[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 pub struct RawValue {
     json: str,


### PR DESCRIPTION
Work around this rustdoc issue: https://github.com/rust-lang/rust/issues/90435.