### PR TITLE
Fix message duplication between error Display and source()

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -319,7 +319,7 @@ impl serde::de::StdError for Error {
     #[cfg(feature = "std")]
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match &self.err.code {
-            ErrorCode::Io(err) => Some(err),
+            ErrorCode::Io(err) => err.source(),
             _ => None,
         }
     }


### PR DESCRIPTION
Fixes #991.

The same code in the issue now produces:

```console
Error: bad read

Caused by:
    timed out waiting on channel
```