### PR TITLE
Feature: JSONC Deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,7 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+# Enable the deserializer to treat comments in JSONC as whitespace. Comments are
+# not tokenized or serialized.
+jsonc-deserializer = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -245,6 +245,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
 
     /// Returns the first non-comment byte without consuming it, or `None` if
     /// EOF is encountered.
+    #[cfg(feature = "jsonc-deserializer")]
     fn parse_comment(&mut self) -> Result<Option<u8>> {
         // Move the cursor after the first slash.
         self.eat_char();
@@ -260,6 +261,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    #[cfg(feature = "jsonc-deserializer")]
     fn parse_line_comment(&mut self) -> Result<Option<u8>> {
         // Eat the second character of the prefix.
         self.eat_char();
@@ -275,6 +277,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
     }
 
+    #[cfg(feature = "jsonc-deserializer")]
     fn parse_block_comment(&mut self) -> Result<Option<u8>> {
         // Eat the second character of the prefix.
         self.eat_char();
@@ -308,6 +311,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                     self.eat_char();
                 }
                 // Treat comments as whitespace.
+                #[cfg(feature = "jsonc-deserializer")]
                 Some(b'/') => {
                     return self.parse_comment();
                 }

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -52,6 +52,42 @@ fn test_json_stream_newlines() {
 }
 
 #[test]
+fn test_json_stream_inline_comment() {
+    let data = "{//\n\"x\":42}";
+
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 42);
+        assert_eq!(stream.byte_offset(), 11);
+
+        assert!(stream.next().is_none());
+        assert_eq!(stream.byte_offset(), 11);
+    });
+}
+
+#[test]
+fn test_json_stream_inline_comment_prefix() {
+    let data = "//\n{\"x\":42}";
+
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 42);
+        assert_eq!(stream.byte_offset(), 11);
+
+        assert!(stream.next().is_none());
+        assert_eq!(stream.byte_offset(), 11);
+    });
+}
+
+#[test]
+fn test_json_stream_invalid_inline_comment_prefix() {
+    let data = "{/\n\"x\":42}";
+
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().is_err(), true);
+        assert_eq!(stream.byte_offset(), 0);
+    });
+}
+
+#[test]
 fn test_json_stream_trailing_whitespaces() {
     let data = "{\"x\":42} \t\n";
 

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -53,33 +53,43 @@ fn test_json_stream_newlines() {
 
 #[test]
 fn test_json_stream_inline_comment() {
-    let data = "{//\n\"x\":42}";
+    let data = "//\n{//\n\"x\"//\n://\n42//\n}//\n//";
 
     test_stream!(data, Value, |stream| {
         assert_eq!(stream.next().unwrap().unwrap()["x"], 42);
-        assert_eq!(stream.byte_offset(), 11);
+        assert_eq!(stream.byte_offset(), 23);
 
         assert!(stream.next().is_none());
-        assert_eq!(stream.byte_offset(), 11);
+        assert_eq!(stream.byte_offset(), 28);
     });
 }
 
 #[test]
-fn test_json_stream_inline_comment_prefix() {
-    let data = "//\n{\"x\":42}";
-
-    test_stream!(data, Value, |stream| {
-        assert_eq!(stream.next().unwrap().unwrap()["x"], 42);
-        assert_eq!(stream.byte_offset(), 11);
-
-        assert!(stream.next().is_none());
-        assert_eq!(stream.byte_offset(), 11);
-    });
-}
-
-#[test]
-fn test_json_stream_invalid_inline_comment_prefix() {
+fn test_json_stream_invalid_inline_comment() {
     let data = "{/\n\"x\":42}";
+
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().is_err(), true);
+        assert_eq!(stream.byte_offset(), 0);
+    });
+}
+
+#[test]
+fn test_json_stream_block_comment() {
+    let data = "/**/{/**/\"x\"/**/:/**/42/**/}/**/";
+
+    test_stream!(data, Value, |stream| {
+        assert_eq!(stream.next().unwrap().unwrap()["x"], 42);
+        assert_eq!(stream.byte_offset(), 28);
+
+        assert!(stream.next().is_none());
+        assert_eq!(stream.byte_offset(), 32);
+    });
+}
+
+#[test]
+fn test_json_stream_invalid_block_comment() {
+    let data = "{/*\"x\":42}";
 
     test_stream!(data, Value, |stream| {
         assert_eq!(stream.next().unwrap().is_err(), true);

--- a/tests/stream.rs
+++ b/tests/stream.rs
@@ -51,6 +51,7 @@ fn test_json_stream_newlines() {
     });
 }
 
+#[cfg(feature = "jsonc-deserializer")]
 #[test]
 fn test_json_stream_inline_comment() {
     let data = "//\n{//\n\"x\"//\n://\n42//\n}//\n//";
@@ -64,6 +65,7 @@ fn test_json_stream_inline_comment() {
     });
 }
 
+#[cfg(feature = "jsonc-deserializer")]
 #[test]
 fn test_json_stream_invalid_inline_comment() {
     let data = "{/\n\"x\":42}";
@@ -74,6 +76,7 @@ fn test_json_stream_invalid_inline_comment() {
     });
 }
 
+#[cfg(feature = "jsonc-deserializer")]
 #[test]
 fn test_json_stream_block_comment() {
     let data = "/**/{/**/\"x\"/**/:/**/42/**/}/**/";
@@ -87,6 +90,7 @@ fn test_json_stream_block_comment() {
     });
 }
 
+#[cfg(feature = "jsonc-deserializer")]
 #[test]
 fn test_json_stream_invalid_block_comment() {
     let data = "{/*\"x\":42}";


### PR DESCRIPTION
I propose that `serde_json` support _reading_ (but not tokenizing or serializing) JSONC documents when opting in to a feature.

This is a feature request, but I've included a sample working implementation as a straw proposal. My reason for doing it this way is to demonstrate the minimal scope of the change and how it can have zero impact on those _not_ using the feature.

Why not use, say, https://crates.io/crates/jsonc-parser? Guaranteed consistency with the Rust community's reference implementation and its performance and security guarantees is extremely valuable.

Notes:
- The entire integration point to existing code is addition of a single new match arm.
- The feature name is bikesheddable, I just chose something close.
- There's one "advances the reader index too far" problem noted, but if `serde_json` actually wants to consider this feature I'll go back and adjust the implementation to solve it.

Related: #168