### PR TITLE
Enhance operation on untyped json through operator overload based on json pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,40 @@ unrecognized fields in the input data. The compiler is powerless to help you
 when you make a mistake, for example imagine typoing `v["name"]` as `v["nmae"]`
 in one of the dozens of places it is used in your code.
 
+### JSON pointer for untyped JSON values and operator overload
+
+Json pointer is an usefull tool to refer to and operate on individual json
+node. There is a method `.pointer()` for `serde_json::Value` to create json
+pointer, and beside that, `/` is overloaded as path operator to yield pointer
+more conveniently and visually，and it can be chained to point to furthur
+deeper node along the json tree, then there is other operator to read from or
+write to the node it pointed.
+
+```rust
+let data = r#"
+    {
+        "name": "John Doe",
+        "age": 43,
+        "phones": [
+            "+44 1234567",
+            "+44 2345678"
+        ]
+    }"#;
+let v: Value = serde_json::from_str(data)?;
+
+let age_ptr = &v / "age";
+let age_val = age_ptr | 0; // got 43, or default 0 if something wrong.
+let first_phone = &v / "phones" / 0 | "";
+assert_eq!(first_phone, "+44 1234567");
+
+// modify some node
+let _ = &mut v / "age" << 44;
+let _ = &mut v / "phones" << ["+44 3456789"];
+let _ = &mut v << ("sex": "male");
+```
+
+Please refer to the operator documentation for detail meaning and usage.
+
 ## Parsing JSON as strongly typed data structures
 
 Serde provides a powerful way of mapping JSON data into Rust data structures

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -421,5 +421,7 @@ mod read;
 #[cfg(feature = "raw_value")]
 mod raw;
 
+#[cfg(feature = "std")]
 pub mod operator;
+#[cfg(feature = "std")]
 pub use crate::operator::PathOperator;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,3 +420,6 @@ mod read;
 
 #[cfg(feature = "raw_value")]
 mod raw;
+
+pub mod operator;
+pub use crate::operator::PathOperator;

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -163,7 +163,7 @@ impl PathOperator for Value {
 /// The rust type for scalar json node, which can used after operator `|` to read,
 /// or/and operator `<<` to write. Only support `i64` for integer, to make use literal
 /// number more convenient.
-trait JsonScalar {}
+pub trait JsonScalar {}
 impl JsonScalar for String {}
 impl JsonScalar for &str {}
 impl JsonScalar for i64 {}

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -1,0 +1,570 @@
+//! An alternative and may convenient way to operate on untyped json is provided
+//! through operator overloading based on json pointer. 
+//! The core start point is path operator `/` to create json pointer struct,
+//! which is no more than `Option<&Value>` that point to a node in json tree.
+//!
+//! ```rust
+//! use serde_json::json;
+//! use serde_json::PathOperator;
+//!
+//! let v = json!({"root": true, "usr": {
+//!     "include": ["a.h", "b.h"],
+//!     "lib": ["a.so", "b.so", {"name": "c.so", "version": "0.0.1"}],
+//!     "lib64": null,
+//!     "local": {"include": [], "lib": null}}
+//! });
+//!
+//! let p1 = v.path() / "usr" / "lib" / 2 / "name";
+//! let p2 = v.path() / "usr/lib/2/name";
+//! let p3 = v.path() / "/usr/lib/2/name";
+//! let p4 = v.pointer("/usr/lib/2/name");
+//! assert!(p1 == p2 && p2 == p3 && p3.unwrap() == p4.unwrap());
+//! assert!(v.path().unwrap() == &v);
+//!
+//! let usr = v.path() / "usr";
+//! let local = v.path() / "usr" / "local";
+//! let lib = "lib64";
+//! let p1 = usr / lib;
+//! let p2 = local / lib;
+//!
+//! assert!(p1.is_some());
+//! assert!(p1.unwrap().is_null());
+//! assert!(p2.is_none());
+//! assert!(v["usr"]["local"]["lib64 or any absent"].is_null());
+//! ```
+//!
+//! The `path()` method call can also replace with reference to `Value`, as `&v`,
+//! And there is the other struct for mutable json pointer as well.
+//!
+//! The difference between `/` operator and `pointer()` method:
+//!
+//! * operator `/` can be chained and manually split path token in compile time.
+//! * each path token can be use variable and modify seperately.
+//! * joined path can optional omit the leading `/` required by json syntax.
+//! * split path no need to escpace special char when key contins `/` or `~`.
+//! * easy to save middle node pointer as variable and reuse later.
+//!
+//! The difference between `/` operator and `[]` index:
+//!
+//! * a bit more consistent and compact.
+//! * can distinguish json null node and non-exist node.
+//! * mutable pointer won't auto insert key to json object as index does. 
+//! * mutable pointer won't panic when beyond range of json array as index does. 
+//!
+//! The pointer struct (and reference to `Value`) can further use 
+//! operator `|` to read the primitive value hold in node with default fallback, and
+//! operator `<<` to overwrite leaf node or push new item to array or object node.
+//!
+//! ```rust
+//! use serde_json::json;
+//! use serde_json::PathOperator;
+//!
+//! let mut v = json!({"int":10, "float":3.14, "array":["pi", null, true]});
+//!
+//! let node = v.path() / "int";
+//! let val = node | 0;
+//! assert_eq!(val, 10);
+//! assert_eq!(v.path() / "float" | 0.0, 3.14);
+//!
+//! let _ode = v.path_mut() / "float" << 31.4;
+//! let node = v.path_mut() / "array" / 2 << "true";
+//! assert!(node.is_string()); // changed node type
+//!
+//! let _ode = v.path_mut() << ("key", "val");
+//! let _ode = v.path_mut() / "array" << ("val",) << ["more"] << [100];
+//! let _ode = v.path_mut() / "int" << ();
+//! assert!(v["int"].is_null());
+//!
+//! assert_eq!(v, json!({"int":null, "float":31.4, "key":"val", "array":["pi",null,"true","val","more",100]}));
+//! ```
+//!
+//! The `path_mut()` method above can replace with `&mut v` to create mutable pointer.
+//!
+//! And more, using `|`, the `&mut v` can also chained pipe to some function
+//! or custom closure that modify the json tree continuously, which is much
+//! different from operation on leaf node with `get_or` meaning and so would
+//! finalize the operator chains.
+//! 
+
+use crate::Value;
+use crate::value::Index;
+use crate::json;
+use std::ops::{Div, BitOr, BitAnd, Shl, Deref, DerefMut};
+
+/// Wrap `Option<&Value>` as pointer to json node for operator overload.
+///
+/// It can used as `Option` implicitly at most time, as overload `*` Deref trait,
+/// where `None` means refer to non-exist node, and `'tr` lifetime refers to 
+/// the overall json tree.
+/// Most method is hidden behind at the operator overload interface, except those
+/// `is_*` methods that check the data type of pointed json node.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct JsonPtr<'tr> {
+    ptr: Option<&'tr Value>,
+}
+
+/// Mutable josn pointer wrapper of `Optione<&mut Value>` for operator overload.
+///
+/// It can used as `Option` implicitly at most time, as overload `*` Deref trait,
+/// where `None` means refer to non-exist node, and `'tr` lifetime refers to 
+/// the overall json tree.
+/// Most method is hidden behind at the operator overload interface, except those
+/// `is_*` methods that check the data type of pointed json node.
+///
+/// Note that mutable reference don't support copy, only use it when you really 
+/// need to modify the pointed json node, otherwise use the immutable pointer.
+#[derive(Eq, PartialEq, Debug)]
+pub struct JsonPtrMut<'tr> {
+    ptr: Option<&'tr mut Value>,
+}
+
+/// Provide json pointer to supported operator overload.
+pub trait PathOperator {
+    /// Construct immutable json pointer to some initial node.
+    fn path<'tr>(&'tr self) -> JsonPtr<'tr>;
+
+    /// Construct immutable json pointer and move it follwoing sub path.
+    fn pathto<'tr>(&'tr self, p: &str) -> JsonPtr<'tr>;
+
+    /// Construct mutable json pointer to some initial node.
+    fn path_mut<'tr>(&'tr mut self) -> JsonPtrMut<'tr>;
+
+    /// Construct mutable json pointer and move it follwoing sub path.
+    fn pathto_mut<'tr>(&'tr mut self, p: &str) -> JsonPtrMut<'tr>;
+}
+
+/// Create json pointer directely from `json::Value`.
+impl PathOperator for Value {
+    /// Create a `JsonPtr` instance which point to self node.
+    /// Similar to `pointer()` method with empty str arguemnt, except raw `Option`.
+    fn path<'tr>(&'tr self) -> JsonPtr<'tr> {
+        JsonPtr::new(Some(self))
+    }
+
+    /// Create a `JsonPtr` instance which point to some subpath under self node.
+    /// Similar to `pointer()` method except leading `/` is optionally.
+    fn pathto<'tr>(&'tr self, p: &str) -> JsonPtr<'tr> {
+        self.path().pathto(p)
+    }
+
+    /// Create a `JsonPtrMut` instance which point to self node.
+    /// Similar to `pointer_mut()` method with empty str arguemnt.
+    fn path_mut<'tr>(&'tr mut self) -> JsonPtrMut<'tr> {
+        JsonPtrMut::new(Some(self))
+    }
+
+    /// Create a `JsonPtrMut` instance which point to some subpath under self node.
+    /// Similar to `pointer_mut()` method except leading `/` is optionally.
+    fn pathto_mut<'tr>(&'tr mut self, p: &str) -> JsonPtrMut<'tr> {
+        self.path_mut().pathto(p)
+    }
+}
+
+/// The rust type for scalar json node, which can used after operator `|` to read,
+/// or/and operator `<<` to write. Only support `i64` for integer, to make use literal
+/// number more convenient.
+trait JsonScalar {}
+impl JsonScalar for String {}
+impl JsonScalar for &str {}
+impl JsonScalar for i64 {}
+impl JsonScalar for f64 {}
+impl JsonScalar for bool {}
+impl JsonScalar for () {}
+
+/// extend method to read Value.
+trait JsonReader {
+    fn get_type(&self) -> &'static str;
+    fn get_str<'tr>(&'tr self, rhs: &'tr str) -> &'tr str;
+    fn get_string(&self, rhs: String) -> String;
+    fn get_i64(&self, rhs: i64) -> i64;
+    fn get_f64(&self, rhs: f64) -> f64;
+    fn get_bool(&self, rhs: bool) -> bool;
+}
+
+impl JsonReader for Value {
+    /// return the node type in string representation.
+    fn get_type(&self) -> &'static str {
+        match self {
+            Value::Null => "null",
+            Value::Bool(_) => "bool",
+            Value::Number(_) => "number",
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Object(_) => "object",
+        }
+    }
+
+    /// operator `| &str`
+    fn get_str<'tr>(&'tr self, rhs: &'tr str) -> &'tr str {
+        match self.as_str() {
+            Some(val) => val,
+            None => rhs,
+        }
+    }
+
+    /// operator `| String`.
+    fn get_string(&self, rhs: String) -> String {
+        match self {
+            Value::String(s) => s.to_string(),
+            Value::Number(i) if rhs == "0" && i.is_i64() => i.to_string(),
+            Value::Number(u) if rhs == "0" && u.is_u64() => u.to_string(),
+            Value::Number(f) if rhs == "0.0" && f.is_f64() => f.to_string(),
+            Value::Bool(tf) if rhs == "bool" => tf.to_string(),
+            Value::Array(_) if rhs == "[]" => self.to_string(),
+            Value::Object(_) if rhs == "{}" => self.to_string(),
+            _ if rhs.is_empty() => self.to_string(),
+            _ => rhs
+        }
+    }
+
+    /// operator `| i64`.
+    fn get_i64(&self, rhs: i64) -> i64 {
+        match self {
+            Value::Number(n) if n.is_i64() => n.as_i64().unwrap_or(rhs),
+            Value::String(s) => s.parse().unwrap_or(rhs),
+            Value::Bool(tf) => if *tf { 1 } else { 0 },
+            _ => rhs
+        }
+    }
+
+    /// operator `| f64`.
+    fn get_f64(&self, rhs: f64) -> f64 {
+        match self {
+            Value::Number(n) if n.is_f64() => n.as_f64().unwrap_or(rhs),
+            Value::String(s) => s.parse().unwrap_or(rhs),
+            _ => rhs
+        }
+    }
+
+    /// operator `| bool`.
+    fn get_bool(&self, rhs: bool) -> bool {
+        match self {
+            Value::Bool(tf) => *tf,
+            Value::Number(n) if n.is_i64() => n.as_i64().unwrap_or(0) != 0,
+            Value::Number(n) if n.is_u64() => true,
+            Value::String(s) => s.parse().unwrap_or(rhs),
+            _ => rhs
+        }
+    }
+}
+
+/// extend method to read Value.
+trait JsonWriter {
+    // put scalar or push item to one onde using `<<`
+    fn put_value<T>(&mut self, rhs: T) -> &mut Self where Value: From<T>, T: JsonScalar;
+    fn push_object<K: ToString, T>(&mut self, key: K, val: T) -> &mut Self where Value: From<T>;
+    fn push_array<T>(&mut self, val: T) -> &mut Self where Value: From<T>;
+
+    // pipe the whole json tree to function with `|`
+    fn pipe_fn<F>(&mut self, f: F) -> &mut Self where F: FnOnce(&mut Self);
+    fn merge_move(&mut self, other: &mut Self) -> &mut Self;
+    fn merge_copy(&mut self, other: &Self) -> &mut Self;
+    fn filter_shape(&mut self, other: &Self) -> &mut Self;
+    fn remove_null(&mut self) -> &mut Self;
+}
+
+impl JsonWriter for Value {
+    /// For operator `<<` with scalar string, integer, float, bool and unit.
+    fn put_value<T>(&mut self, rhs: T) -> &mut Self where Value: From<T> , T: JsonScalar {
+        *self = Value::from(rhs);
+        self
+    }
+
+    /// For operator `<<` to jsob objecet.
+    fn push_object<K: ToString, T>(&mut self, key: K, val: T) -> &mut Self where Value: From<T> {
+        if !self.is_object() {
+            *self = json!({});
+        }
+        if let Some(v) = self.as_object_mut() {
+            v.insert(key.to_string(), Value::from(val));
+        }
+        self
+    }
+
+    /// For operator `<<` to jsob array.
+    fn push_array<T>(&mut self, val: T) -> &mut Self where Value: From<T> {
+        if !self.is_array() {
+            *self = json!([]);
+        }
+        if let Some(v) = self.as_array_mut() {
+            v.push(Value::from(val));
+        }
+        self
+    }
+
+    /// Forward `JsonPtrMut | FnOnce`
+    fn pipe_fn<F>(&mut self, f: F) -> &mut Self where F: FnOnce(&mut Self) {
+        pipe::apply(self, f);
+        self
+    }
+
+    /// Forward `JsonPtrMut | JsonPtrMut`
+    fn merge_move(&mut self, other: &mut Self) -> &mut Self {
+        pipe::merge_move(self, other);
+        self
+    }
+
+    /// Forward `JsonPtrMut | JsonPtr`
+    fn merge_copy(&mut self, other: &Self) -> &mut Self {
+        pipe::merge_copy(self, other);
+        self
+    }
+
+    /// Forward `JsonPtrMut & JsonPtr`
+    fn filter_shape(&mut self, other: &Self) -> &mut Self {
+        pipe::filter_shape(self, other);
+        self
+    }
+
+    /// Forward `JsonPtrMut | ()`
+    fn remove_null(&mut self) -> &mut Self {
+        pipe::remove_null(self);
+        self
+    }
+}
+
+/// Proxy `is_*` methods of `Value` for json pointer.
+macro_rules! type_checker {
+    ($func_name:ident) => {
+        /// Check pointer is valid and the node match the type;
+        pub fn $func_name(&self) -> bool {
+            self.is_some() && self.as_ref().unwrap().$func_name()
+        }
+    };
+}
+
+/// Proxy `get_*` methods of `Value` for json pointer.
+macro_rules! scalar_getter {
+    ($func_name:ident | $ret:ty) => {
+        /// Forward the getter method to pointed node, or return `rhs` by default.
+        fn $func_name(&self, rhs: $ret) -> $ret {
+            match self.ptr {
+                Some(v) => v.$func_name(rhs),
+                None => rhs,
+            }
+        }
+    };
+}
+
+impl<'tr> JsonPtr<'tr> {
+    /// Trivial new constructor.
+    /// Usually there is no need to create `JsonPtr` instance directly, but yield one
+    /// from existed json `Value`, except `None`.
+    pub fn new(ptr: Option<&'tr Value>) -> Self {
+        Self { ptr }
+    }
+
+    /// Resolve to sub path, by single index or joined path.
+    /// Used in operator `/`.
+    fn path<B>(&self, p: B) -> Self where B: Index + Copy + ToString {
+        if self.is_none() {
+            return Self::new(None);
+        }
+
+        let v = self.unwrap();
+        let target = v.get(p);
+        if target.is_some() {
+            Self::new(target)
+        }
+        else {
+            self.pathto(&p.to_string())
+        }
+    }
+
+    /// Resolve to sub path, by joined path, auto prefix '/' for json pointer syntax.
+    fn pathto(&self, p: &str) -> Self {
+        if self.is_none() {
+            return Self::new(None);
+        }
+
+        let v = self.unwrap();
+        if !p.is_empty() && p.chars().nth(0) == Some('/') {
+            return Self::new(v.pointer(p));
+        }
+
+        let mut fixp = String::from("/");
+        fixp.push_str(p);
+        return Self::new(v.pointer(&fixp));
+    }
+
+    /// Get a str ref if the value type matches, or defalut `rhs`.
+    /// Used in operator `| ""` or `| &str`.
+    fn get_str(&self, rhs: &'tr str) -> &'tr str {
+        match self.ptr {
+            Some(v) => v.get_str(rhs),
+            None => rhs,
+        }
+    }
+
+    scalar_getter!(get_string | String);
+    scalar_getter!(get_i64 | i64);
+    scalar_getter!(get_f64 | f64);
+    scalar_getter!(get_bool | bool);
+
+    // Check if the pointer is valid and refer to node of specific type.
+    type_checker!(is_string);
+    type_checker!(is_i64);
+    type_checker!(is_u64);
+    type_checker!(is_f64);
+    type_checker!(is_boolean);
+    type_checker!(is_null);
+    type_checker!(is_array);
+    type_checker!(is_object);
+}
+
+impl<'tr> JsonPtrMut<'tr> {
+    /// Trivial new constructor.
+    /// Usually there is no need to create `JsonPtr` instance directly, but yield one
+    /// from existed json `Value`, except `None`.
+    pub fn new(ptr: Option<&'tr mut Value>) -> Self {
+        Self { ptr }
+    }
+
+    /// Convert to immutable pointer, leave self None.
+    pub fn immut(&mut self) -> JsonPtr<'tr> {
+        if self.ptr.is_none() {
+            return JsonPtr::new(None);
+        }
+        let v = self.ptr.take().unwrap();
+        JsonPtr::new(Some(v))
+    }
+
+    /// Resolve to sub path, by single index or joined path.
+    /// Used in operator `/`.
+    fn path<B>(&mut self, p: B) -> Self where B: Index + Copy + ToString {
+        if self.is_none() {
+            return Self::new(None);
+        }
+
+        // use immutable get to check first, avoid mutable refer twice
+        let v = self.take().unwrap();
+        let target = v.get(p);
+        if target.is_some() {
+            Self::new(v.get_mut(p))
+        }
+        else {
+            self.ptr = Some(v); // restore reference had took out to `v`
+            self.pathto(&p.to_string())
+        }
+    }
+
+    /// Resolve to sub path, by joined path, auto prefix '/' for json pointer syntax.
+    fn pathto(&mut self, p: &str) -> Self {
+        if self.is_none() {
+            return Self::new(None);
+        }
+
+        let v = self.take().unwrap();
+        if !p.is_empty() && p.chars().nth(0) == Some('/') {
+            return Self::new(v.pointer_mut(p));
+        }
+
+        let mut fixp = String::from("/");
+        fixp.push_str(p);
+        return Self::new(v.pointer_mut(&fixp));
+    }
+
+    /// Put a value to json and return pointer to it, which may change the node type.
+    /// Implement for `<< (val)` , usually in scarlar node.
+    fn put_value<T>(&mut self, rhs: T) -> Self where Value: From<T>, T: JsonScalar {
+        match self.take() {
+            Some(v) => { v.put_value(rhs); Self::new(Some(v)) },
+            None => Self::new(None)
+        }
+    }
+
+    /// Push a pair to object node, would invalidate the pointer if type mismatch.
+    /// Implment for `<< (key, val)`.
+    fn push_object<K: ToString, T>(&mut self, key: K, val: T) -> Self where Value: From<T> {
+        match self.take() {
+            Some(v) => { v.push_object(key, val); Self::new(Some(v)) },
+            None => Self::new(None)
+        }
+    }
+
+    /// Push a item to array node, would invalidate the pointer if type mismatch.
+    /// Implment for `<< (val, )` or  `<< [item]` .
+    fn push_array<T>(&mut self, val: T) -> Self where Value: From<T> {
+        match self.take() {
+            Some(v) => { v.push_array(val); Self::new(Some(v)) },
+            None => Self::new(None)
+        }
+    }
+
+    // Check if the pointer is valid and refer to node of specific type.
+    type_checker!(is_string);
+    type_checker!(is_i64);
+    type_checker!(is_u64);
+    type_checker!(is_f64);
+    type_checker!(is_boolean);
+    type_checker!(is_null);
+    type_checker!(is_array);
+    type_checker!(is_object);
+
+    /// Forward `JsonPtrMut | FnOnce`
+    fn pipe_fn<F>(mut self, f: F) -> Self where F: FnOnce(&mut Value) {
+        match self.take() {
+            Some(v) => {
+                v.pipe_fn(f);
+                Self::new(Some(v))
+            },
+            None => Self::new(None)
+        }
+    }
+
+    /// Forward `JsonPtrMut | JsonPtrMut`
+    fn merge_move(mut self, mut other: Self) -> Self {
+        match self.take() {
+            Some(v) => {
+                if !other.is_null() {
+                    v.merge_move(other.take().unwrap());
+                }
+                Self::new(Some(v))
+            },
+            None => Self::new(None)
+        }
+    }
+
+    /// Forward `JsonPtrMut | JsonPtrMut`
+    fn merge_copy(mut self, other: JsonPtr) -> Self {
+        match self.take() {
+            Some(v) => {
+                if !other.is_null() {
+                    v.merge_copy(other.unwrap());
+                }
+                Self::new(Some(v))
+            },
+            None => Self::new(None)
+        }
+    }
+
+    /// Forward `JsonPtrMut & JsonPtr`
+    fn filter_shape(mut self, other: JsonPtr) -> Self {
+        match self.take() {
+            Some(v) => {
+                v.filter_shape(other.unwrap());
+                Self::new(Some(v))
+            },
+            None => Self::new(None)
+        }
+    }
+
+    /// Forward `JsonPtrMut | ()`
+    fn remove_null(mut self) -> Self {
+        match self.take() {
+            Some(v) => {
+                v.remove_null();
+                Self::new(Some(v))
+            },
+            None => Self::new(None)
+        }
+    }
+}
+
+/// Extend functionily for pipe operator `|`.
+mod pipe;
+
+// Split operator overload implemntation to seperate files but not sub mod.
+include!("overload_ptr.rs");
+include!("overload_val.rs");
+

--- a/src/operator/overload_ptr.rs
+++ b/src/operator/overload_ptr.rs
@@ -1,0 +1,508 @@
+// Not sub mod but seperate file for operator overload interface.
+// Used by include! macro in operator mod.
+
+/* ------------------------------------------------------------ */
+
+/// Overload `*` deref operator to treate pointer as `Option<&json::Value>`.
+impl<'tr> Deref for JsonPtr<'tr>
+{
+    type Target = Option<&'tr Value>;
+    fn deref(&self) -> &Self::Target {
+        &self.ptr
+    }
+}
+
+/// Path operator `/`, visit sub-node by string key for object or index for array.
+/// 
+/// First try directly json index, then try json pointer syntax, otherwise
+/// return `None` if both fail.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let v = json!({"i":1,"f":3.14,"a":["pi",null,true]});
+/// let p = v.path() / "i";
+/// assert_eq!(p.unwrap(), &v["i"]);
+/// let p = v.path() / "a" / 0;
+/// assert_eq!(p.unwrap(), &v["a"][0]);
+/// let p = v.path() / "a/0";
+/// assert_eq!(p.unwrap(), &v["a"][0]);
+/// ```
+impl<'tr, Rhs> Div<Rhs> for JsonPtr<'tr> where Rhs: Index + Copy + ToString
+{
+    type Output = Self;
+    fn div(self, rhs: Rhs) -> Self::Output {
+        self.path(rhs)
+    }
+}
+
+/// Pipe operator `|` to get string refer or default `rhs`
+/// when invalid pointer or the json type is not string.
+/// Usually used with literal `|"default"` or just simple `|""`.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let v = json!({"sub":{"key":"val"}});
+/// assert_eq!(v.path()/"sub" | "", "");
+/// assert_eq!(v.path()/"sub"/"key" | "", "val");
+/// assert_eq!(v.path()/"sub"/"any" | "xxx", "xxx");
+/// ```
+impl<'tr> BitOr<&'tr str> for JsonPtr<'tr> {
+    type Output = &'tr str;
+    fn bitor(self, rhs: &'tr str) -> Self::Output {
+        self.get_str(rhs)
+    }
+}
+
+/// Pipe operator `|` try to get string from a json node or default `rhs`.
+///
+/// * if `lhs` is really string node, return the string content.
+/// * if `rhs` is empty, stringfy the json for any other type.
+/// * if `rhs` is "0", only stringfy node for i64 or u64 type.
+/// * if `rhs` is "0.0", only stringfy node for float type.
+/// * if `rhs` is "bool", only stringfy node for bool type.
+/// * if `rhs` is "[]", only stringfy node for array type.
+/// * if `rhs` is "{}", only stringfy node for object type.
+/// * otherwise, return `rhs` as default.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let v = json!({"int":3, "float":3.14, "str":"null", "array":[1,null,"null"]});
+/// 
+/// assert_eq!(v.path()/"str" | "".to_string(), "null");
+/// assert_eq!(v.path()/"int" | "".to_string(), "3");
+/// assert_eq!(v.path()/"int" | "0".to_string(), "3");
+/// assert_eq!(v.path()/"int" | "0.0".to_string(), "0.0");
+/// assert_eq!(v.path()/"array" | "".to_string(), "[1,null,\"null\"]");
+/// assert_eq!(v.path()/"array" | "[]".to_string(), "[1,null,\"null\"]");
+/// ```
+///
+/// Note that the `rhs` string would be moved.
+/// If want to only get content from string node, use `| &str` version instead.
+impl<'tr> BitOr<String> for JsonPtr<'tr> {
+    type Output = String;
+    fn bitor(self, rhs: String) -> Self::Output {
+        self.get_string(rhs)
+    }
+}
+
+/// Pipe operator `|` to get integer value if the json node don't hold a integer
+/// or string which can parse to integer, or bool which conver to 1 or 0,
+/// otherwise return default `rhs`. 
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let v = json!({"a":1, "b":"2", "c":"nan", "e":true});
+/// assert_eq!(v.path()/"a" | 0, 1);
+/// assert_eq!(v.path()/"b" | 0, 2);
+/// assert_eq!(v.path()/"c" | 0, 0);
+/// assert_eq!(v.path()/"d" | -1, -1);
+/// assert_eq!(v.path()/"e" | -1, 1);
+/// ```
+///
+/// Not support `| u64` overload, only support `| i64`
+/// to make `| 0` as simple as possible in most use case.
+impl<'tr> BitOr<i64> for JsonPtr<'tr> {
+    type Output = i64;
+    fn bitor(self, rhs: i64) -> Self::Output {
+        self.get_i64(rhs)
+    }
+}
+
+/// Pipe operator `|` to get float value if the json node hold a float
+/// or string which can parse to float, otherwise default `rhs`. 
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let v = json!({"a":1.0, "b":"2.0", "c":"not"});
+/// assert_eq!(v.path()/"a" | 0.0, 1.0);
+/// assert_eq!(v.path()/"b" | 0.0, 2.0);
+/// assert_eq!(v.path()/"c" | 0.0, 0.0);
+/// assert_eq!(v.path()/"d" | -1.0, -1.0);
+/// ```
+impl<'tr> BitOr<f64> for JsonPtr<'tr> {
+    type Output = f64;
+    fn bitor(self, rhs: f64) -> Self::Output {
+        self.get_f64(rhs)
+    }
+}
+
+/// Pipe operator `|` to get bool value if the json node hold a bool
+/// or string which can parse to bool, otherwise default `rhs`. 
+/// And for integer node, non-zero value is treated as true, zero is false.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let v = json!({"a":1, "b":"2", "c":"nan", "e":true});
+/// assert_eq!(v.path()/"a" | false, true);
+/// assert_eq!(v.path()/"b" | false, false);
+/// assert_eq!(v.path()/"c" | false, false);
+/// assert_eq!(v.path()/"e" | false, true);
+/// ```
+impl<'tr> BitOr<bool> for JsonPtr<'tr> {
+    type Output = bool;
+    fn bitor(self, rhs: bool) -> Self::Output {
+        self.get_bool(rhs)
+    }
+}
+
+/* ------------------------------------------------------------ */
+
+/// Overload `*` deref operator to treate pointer as `Option<&mut json::Value>`.
+impl<'tr> Deref for JsonPtrMut<'tr> {
+    type Target = Option<&'tr mut Value>;
+    fn deref(&self) -> &Self::Target {
+        &self.ptr
+    }
+}
+
+/// Overload `*` deref operator to treate pointer as `Option<&mut json::Value>`.
+impl<'tr> DerefMut for JsonPtrMut<'tr> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.ptr
+    }
+}
+
+/// Path operator `/`, visit sub-node by string key for object or index for array.
+/// Can chained as `jsonptr / "path" / "to" / "node"` or `jsonptr / "path/to/node"`.
+/// First try directly json index, then try json pointer syntax, then
+/// return `None` if both fail.
+/// Hope to change the node it point to, otherwise better to use immutable `JsonPtr`.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!({"i":1,"f":3.14,"a":["pi",null,true]});
+/// let p = v.path_mut() / "i";
+/// assert_eq!(p | 0, 1);
+/// let p = v.path_mut() / "a" / 0;
+/// assert_eq!(p | "", "pi");
+/// let p = v.path_mut() / "a/0";
+/// assert_eq!(p | "", "pi");
+/// ```
+impl<'tr, Rhs> Div<Rhs> for JsonPtrMut<'tr> where Rhs: Index + Copy + ToString
+{
+    type Output = Self;
+    fn div(mut self, rhs: Rhs) -> Self::Output {
+        self.path(rhs)
+    }
+}
+
+/// Pipe operator `|` to get string refer or default `rhs`.
+/// 
+/// Behaves the same as `JsonPtr | &str`, except that
+/// the `JsonPtrMut` in `lhs` would be moved and cannot used any more.
+impl<'tr> BitOr<&'tr str> for JsonPtrMut<'tr> {
+    type Output = &'tr str;
+    fn bitor(mut self, rhs: &'tr str) -> Self::Output {
+        self.immut().bitor(rhs)
+    }
+}
+
+/// Proxy of `|` operator overload for mutable json pointer.
+/// Would expand for String, i64, f64, bool.
+macro_rules! bitor_mut {
+    ($rhs:ty) => {
+        impl<'tr> BitOr<$rhs> for JsonPtrMut<'tr> {
+            type Output = $rhs;
+            fn bitor(mut self, rhs: $rhs) -> Self::Output {
+                self.immut().bitor(rhs)
+            }
+        }
+    };
+}
+
+bitor_mut!(String);
+bitor_mut!(i64);
+bitor_mut!(f64);
+bitor_mut!(bool);
+
+/// Operator `<<` to put a scalar value into json node, what supported type inclde:
+/// &str, String, i64, f64, bool, and unit() for json null.
+/// It will consume the `lhs` pointer and return a new one point to the same node
+/// after modify it's content and may type.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!({});
+/// 
+/// let _ = v.path_mut() << "pi";
+/// assert!(v.is_string());
+/// let _ = v.path_mut() << 1;
+/// assert!(v.is_i64());
+/// let _ = v.path_mut() << 3.14;
+/// assert!(v.is_f64());
+/// let _ = v.path_mut() << true;
+/// assert!(v.is_boolean());
+/// let _ = v.path_mut() << ();
+/// assert!(v.is_null());
+///
+/// let pi = String::from("PI");
+/// let _ = v.path_mut() << "pi" << 3.14 << pi;
+/// assert_eq!(v, "PI");
+/// ```
+///
+/// Though put operator `<<` can be chained, the later one overwrite the previous value.
+impl<'tr, Rhs> Shl<Rhs> for JsonPtrMut<'tr> where Rhs: JsonScalar, Value: From<Rhs> {
+    type Output = Self;
+    fn shl(mut self, rhs: Rhs) -> Self::Output {
+        self.put_value(rhs)
+    }
+}
+
+/// Operator `<<` to push key-value pair (tuple) into json object.
+///
+/// It will consume the `lhs` pointer and return a new one point to the same node
+/// after modify it's content and type.
+/// If the node is object, the new pair is insert to it,
+/// otherwise change the node to object with only one new pair.
+/// The key and value will be moved into json node, and key require String conversion.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!("init string node");
+/// 
+/// let _ = v.path_mut() << ("i", 1) << ("f", 3.14);
+/// assert_eq!(v, json!({"i":1,"f":3.14}));
+/// ```
+///
+/// It can chain `<<` to object with several pairs, while it may be not good enough
+/// to use in large loop.
+impl<'tr, K: ToString, T> Shl<(K, T)> for JsonPtrMut<'tr> where Value: From<T> {
+    type Output = Self;
+    fn shl(mut self, rhs: (K, T)) -> Self::Output {
+        self.push_object(rhs.0, rhs.1)
+    }
+}
+
+/// Operator `<<` to push one value tuple into json array.
+///
+/// It will consume the `lhs` pointer and return a new one point to the same node
+/// after modify it's content and type, and so is chainable.
+/// If the node is array, the new item is push back to it,
+/// otherwise change the node to array with only one new item.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!("init string node");
+/// 
+/// let _ = v.path_mut() << ("i",) << (1,) << ("f",) << (3.14,);
+/// assert_eq!(v, json!(["i", 1,"f", 3.14]));
+/// ```
+///
+/// Note that use single tuple to distinguish with pushing one value to node.
+/// Can also use the other overload `<< ["val"]` instead of `("val",)` which may be
+/// more clear to express the meanning for one item in array.
+impl<'tr, T> Shl<(T,)> for JsonPtrMut<'tr> where Value: From<T> {
+    type Output = Self;
+    fn shl(mut self, rhs: (T,)) -> Self::Output {
+        self.push_array(rhs.0)
+    }
+}
+
+/// Operator `<<` to push one item to json array.
+///
+/// It will consume the `lhs` pointer and return a new one point to the same node
+/// after modify it's content and type, and so is chainable.
+/// If the node is array, the new item is push back to it,
+/// otherwise change the node to array with only one new item.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!("init string node");
+/// 
+/// let _ = v.path_mut() << ["i"] << [1] << ["f"] << [3.14];
+/// assert_eq!(v, json!(["i", 1,"f", 3.14]));
+/// ```
+impl<'tr, T: Copy> Shl<[T;1]> for JsonPtrMut<'tr> where Value: From<T> {
+    type Output = Self;
+    fn shl(mut self, rhs: [T;1]) -> Self::Output {
+        self.push_array(rhs[0])
+    }
+}
+
+/// Operator `<<` to push a slice to json array.
+///
+/// It will consume the `lhs` pointer and return a new one point to the same node
+/// after modify it's content and type, and so can chain further.
+/// If the node is array, the new items is append back,
+/// otherwise change the node to array with only the new items.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!("init string node");
+/// 
+/// let vi = vec![1, 2, 3, 4];
+/// let _ = v.path_mut() << &vi[..] << [5] << (6,);
+/// assert_eq!(v, json!([1,2,3,4,5,6]));
+/// ```
+impl<'tr, T: Copy> Shl<&[T]> for JsonPtrMut<'tr> where Value: From<T> {
+    type Output = Self;
+    fn shl(mut self, rhs: &[T]) -> Self::Output {
+        for item in rhs {
+            self = self.push_array(*item);
+        }
+        self
+    }
+}
+
+/* ------------------------------------------------------------ */
+
+/// Operator `JsonPtrMut | FnOnce`, perform some action to json tree.
+///
+/// Return a new mutable pointer that points to the same modified tree,
+/// and then can chain with other operator.
+///
+/// ```rust
+/// # use serde_json::{json, Value};
+/// # use serde_json::PathOperator;
+/// let remove_null = |v: &mut Value| {
+///     if let Value::Array(array) = v {
+///         array.retain(|x| !x.is_null())
+///     }
+/// };
+///
+/// let mut v = json!(["pi", null, 3.14]);
+/// let second = (v.path_mut() | remove_null) / 1 | 0.0;
+/// assert_eq!(second, 3.14);
+/// assert_eq!(v, json!(["pi", 3.14]));
+/// ```
+///
+/// Note in above that, the first `|` pipe json tree to function, 
+/// while the last one pipe leaf node to scalar to read the value in it,
+/// and the operator `/` has higher priority than `|` so () is required.
+///
+/// See also operator `JsonPtrMut | ()` to remove null recursively.
+impl<'tr, F> BitOr<F> for JsonPtrMut<'tr> where F: FnOnce(&mut Value) {
+    type Output = Self;
+    fn bitor(self, rhs: F) -> Self::Output {
+        self.pipe_fn(rhs)
+    }
+}
+
+/// Operator `JsonPtrMut | JsonPtrMut`, merge rhs to lhs recursively.
+///
+/// Each leaf node in `rhs` would move to `lhs` if the corresponding node in `lhs`
+/// is null or absent.
+/// When the array in `rhs` has only one item then it reeatedly compare 
+/// with each array item in `lhs` and switch to copy to `lhs` as needed,
+/// otherwise compare one by one and the extra items in `rhs` move to 
+/// the end of `rhs` array.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut va = json!({"name": "pi"});
+/// let mut vb = json!({"name": "PI", "value": "3.14"});
+/// let _ = va.path_mut() | vb.path_mut();
+/// assert_eq!(va, json!({"name":"pi", "value":"3.14"}));
+/// assert_eq!(vb, json!({"name": "PI", "value":null}));
+/// 
+/// va = json!(["pi", null, null, 2.72]);
+/// vb = json!(["PI", 3.14, "e", 2.71, false, null, 6.18]);
+/// let _ = va.path_mut() | vb.path_mut();
+/// assert_eq!(va, json!(["pi", 3.14, "e", 2.72, false, null, 6.18]));
+/// assert_eq!(vb, json!(["PI", null, null, 2.71, null, null, null]));
+/// ```
+impl<'tr> BitOr<JsonPtrMut<'tr>> for JsonPtrMut<'tr> {
+    type Output = Self;
+    fn bitor(self, rhs: JsonPtrMut<'tr>) -> Self::Output {
+        self.merge_move(rhs)
+    }
+}
+
+/// Operator `JsonPtrMut | JsonPtr`, merge rhs to lhs recursively.
+///
+/// Each leaf node in `rhs` would copy to `lhs` if the corresponding node in `lhs`
+/// is null or absent.
+/// When the array in `rhs` has only one item then it reeatedly compare 
+/// with each array item in `lhs`, otherwise compare one by one and the
+/// extra items in `rhs` copy to the end of `rhs` array.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut va = json!({"name": "pi"});
+/// let mut vb = json!({"name": "PI", "value": "3.14"});
+/// let _ = va.path_mut() | vb.path();
+/// assert_eq!(va, json!({"name":"pi", "value":"3.14"}));
+/// assert_eq!(vb, json!({"name": "PI", "value":"3.14"}));
+/// 
+/// va = json!(["pi", null, null, 2.72]);
+/// vb = json!(["PI", 3.14, "e", 2.71, false, null, 6.18]);
+/// let _ = va.path_mut() | vb.path();
+/// assert_eq!(va, json!(["pi", 3.14, "e", 2.72, false, null, 6.18]));
+/// assert_eq!(vb, json!(["PI", 3.14, "e", 2.71, false, null, 6.18]));
+/// ```
+impl<'tr> BitOr<JsonPtr<'tr>> for JsonPtrMut<'tr> {
+    type Output = Self;
+    fn bitor(self, rhs: JsonPtr<'tr>) -> Self::Output {
+        self.merge_copy(rhs)
+    }
+}
+
+/// Operator `JsonPtrMut & JsonPtr`, filter `lhs` recursively by `rhs`
+/// as template or sample structure.
+///
+/// Each leaf node in `lhs` would set to null if the corresponding node in `rhs`
+/// has different type or absent. The null node only marked while not actually remove
+/// from it's parent node, may chain to `| ()` to achieve that purpose.
+/// When the array in `rhs` has only one item then it reeatedly compare 
+/// with each array item in `lhs`, otherwise compare one by one.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut va = json!({"name": "pi", "VALUE": 3.14});
+/// let mut vb = json!({"name": "PI", "value": "3.14"});
+/// let _ = va.path_mut() & vb.path();
+/// assert_eq!(va, json!({"name":"pi", "VALUE": null}));
+/// 
+/// va = json!(["pi", "314", null, 2.72, true, "xx", 6.18]);
+/// vb = json!(["PI", 3.14, "e", 2.71, false, null]);
+/// let _ = va.path_mut() & vb.path();
+/// assert_eq!(va, json!(["pi", null, null, 2.72, true, null, null]));
+/// 
+/// va = json!(["pi", "314", null, 2.72, true, "xx", 6.18]);
+/// let _ = va.path_mut() & vb.path() | ();
+/// assert_eq!(va, json!(["pi", 2.72, true]));
+/// ```
+///
+/// Note that the bitand `&` operator is selected after `|` to perform
+/// different operation on two json tree, and they both are special case
+/// for pipe to function `JsonPtrMut | FnOnce`.
+impl<'tr> BitAnd<JsonPtr<'tr>> for JsonPtrMut<'tr> {
+    type Output = Self;
+    fn bitand(self, rhs: JsonPtr<'tr>) -> Self::Output {
+        self.filter_shape(rhs)
+    }
+}
+
+/// Operator `JsonPtrMut | ()`, remove null node recursively.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!({"null": "null", "Null": null,
+///     "array": ["null", null, {"i": 10, "n": null, "s": "null"}],
+///     "object": {"1":null, "a":[,{}, {}], "3":{}}
+/// });
+/// let _ = v.path_mut() | ();
+/// assert_eq!(v, json!({"null":"null","array":["null", {"i":10,"s":"null"}]}))
+/// ```
+impl<'tr> BitOr<()> for JsonPtrMut<'tr> {
+    type Output = Self;
+    fn bitor(self, _rhs: ()) -> Self::Output {
+        self.remove_null()
+    }
+}

--- a/src/operator/overload_val.rs
+++ b/src/operator/overload_val.rs
@@ -1,0 +1,429 @@
+// Not sub mod but seperate file for operator overload interface.
+// Used by include! macro in operator mod.
+
+/* ------------------------------------------------------------ */
+
+/// Path operator `/` create a json pointer to sub-node.
+/// 
+/// First try directly json index, then try json pointer syntax,
+/// return pointer in `JsonPtr` struct, may `None` if both fail.
+/// Use `path()` method to return pointer to self node.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let v = json!({"i":1,"f":3.14,"a":["pi",null,true]});
+/// let p = &v / "i";
+/// assert_eq!(p.unwrap(), &v["i"]);
+/// let p = &v / "a" / 0;
+/// assert_eq!(p.unwrap(), &v["a"][0]);
+/// let p = &v / "a/0";
+/// assert_eq!(p.unwrap(), &v["a"][0]);
+/// ```
+impl<'tr, Rhs> Div<Rhs> for &'tr Value where Rhs: Index + Copy + ToString {
+    type Output = JsonPtr<'tr>;
+    fn div(self, rhs: Rhs) -> Self::Output {
+        self.path().path(rhs)
+    }
+}
+
+/// Pipe operator `|` try to get string from a json node or default `rhs`.
+///
+/// * if `lhs` is really string node, return the string content.
+/// * if `rhs` is empty, stringfy the json for any other type.
+/// * if `rhs` is "0", only stringfy node for i64 or u64 type.
+/// * if `rhs` is "0.0", only stringfy node for float type.
+/// * if `rhs` is "bool", only stringfy node for bool type.
+/// * if `rhs` is "[]", only stringfy node for array type.
+/// * if `rhs` is "{}", only stringfy node for object type.
+/// * otherwise, return `rhs` as default.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let v = json!({"int":3, "float":3.14, "str":"null", "array":[1,null,"null"]});
+/// 
+/// assert_eq!(&v/"str" | "".to_string(), "null");
+/// assert_eq!(&v/"int" | "".to_string(), "3");
+/// assert_eq!(&v/"int" | "0".to_string(), "3");
+/// assert_eq!(&v/"int" | "0.0".to_string(), "0.0");
+/// assert_eq!(&v/"array" | "".to_string(), "[1,null,\"null\"]");
+/// assert_eq!(&v/"array" | "[]".to_string(), "[1,null,\"null\"]");
+/// ```
+///
+/// Note that the `rhs` string would be moved.
+/// If want to only get content from string node, use `| &str` version instead.
+impl<'tr> BitOr<String> for &'tr Value {
+    type Output = String;
+    fn bitor(self, rhs: String) -> Self::Output {
+        self.get_string(rhs)
+    }
+}
+
+/// Pipe operator `|` to get string reference or default `rhs`
+/// if the json node type is not string.
+/// Usually used with literal `|"default"` or just simple `|""`.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let v = json!({"sub":{"key":"val"}});
+/// assert_eq!(&v/"sub" | "", "");
+/// assert_eq!(&v/"sub"/"key" | "", "val");
+/// assert_eq!(&v/"sub"/"any" | "xxx", "xxx");
+/// ```
+impl<'tr> BitOr<&'tr str> for &'tr Value {
+    type Output = &'tr str;
+    fn bitor(self, rhs: &'tr str) -> Self::Output {
+        self.get_str(rhs)
+    }
+}
+
+/// Pipe operator `|` to get integer value if the json node hold a integer
+/// or string which can parse to integer, or bool which conver to 1 or 0,
+/// otherwise return default `rhs`. 
+///
+/// ```rust
+/// # use serde_json::json;
+/// let v = json!({"a":1, "b":"2", "c":"nan", "e":true});
+/// assert_eq!(&v/"a" | 0, 1);
+/// assert_eq!(&v/"b" | 0, 2);
+/// assert_eq!(&v/"c" | 0, 0);
+/// assert_eq!(&v/"d" | -1, -1);
+/// assert_eq!(&v/"e" | -1, 1);
+/// ```
+///
+/// Not support `| u64` overload, only support `| i64`
+/// to make `| 0` as simple as possible in most use case.
+impl BitOr<i64> for &Value {
+    type Output = i64;
+    fn bitor(self, rhs: i64) -> Self::Output {
+        self.get_i64(rhs)
+    }
+}
+
+/// Pipe operator `|` to get float value if the json node hold a float
+/// or string which can parse to float, otherwise default `rhs`. 
+///
+/// ```rust
+/// # use serde_json::json;
+/// let v = json!({"a":1.0, "b":"2.0", "c":"not"});
+/// assert_eq!(&v/"a" | 0.0, 1.0);
+/// assert_eq!(&v/"b" | 0.0, 2.0);
+/// assert_eq!(&v/"c" | 0.0, 0.0);
+/// assert_eq!(&v/"d" | -1.0, -1.0);
+/// ```
+impl BitOr<f64> for &Value {
+    type Output = f64;
+    fn bitor(self, rhs: f64) -> Self::Output {
+        self.get_f64(rhs)
+    }
+}
+
+/// Pipe operator `|` to get bool value if the json node hold a bool
+/// or string which can parse to bool, otherwise default `rhs`. 
+/// And for integer node, non-zero value is treated as true, zero is false.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let v = json!({"a":1, "b":"2", "c":"nan", "e":true});
+/// assert_eq!(&v/"a" | false, true);
+/// assert_eq!(&v/"b" | false, false);
+/// assert_eq!(&v/"c" | false, false);
+/// assert_eq!(&v/"e" | false, true);
+/// ```
+impl BitOr<bool> for &Value {
+    type Output = bool;
+    fn bitor(self, rhs: bool) -> Self::Output {
+        self.get_bool(rhs)
+    }
+}
+
+/* ------------------------------------------------------------ */
+
+/// Path operator `/` create a json pointer to sub-node.
+/// 
+/// First try directly json index, then try json pointer syntax,
+/// return mutable pointer in `JsonPtrMut` struct, may `None` if both fail.
+/// Use `path_mut()` method to return pointer to self node.
+/// Hope to change the node it point to, otherwise better to use immutable version.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut v = json!({"i":1,"f":3.14,"a":["pi",null,true]});
+/// let p = &mut v / "i";
+/// assert_eq!(p | 0, 1);
+/// let p = &mut v / "a" / 0;
+/// assert_eq!(p | "", "pi");
+/// let p = &mut v / "a/0";
+/// assert_eq!(p | "", "pi");
+/// ```
+impl<'tr, Rhs> Div<Rhs> for &'tr mut Value where Rhs: Index + Copy + ToString {
+    type Output = JsonPtrMut<'tr>;
+    fn div(self, rhs: Rhs) -> Self::Output {
+        self.path_mut().path(rhs)
+    }
+}
+
+/// Operator `<<` to put a scalar value into json node, what supported type inclde:
+/// &str, String, i64, f64, bool, and unit`()` for json null.
+///
+/// ```rust
+/// # use serde_json::json;
+/// # use serde_json::PathOperator;
+/// let mut v = json!({});
+/// 
+/// let _ = v.path_mut() << "pi";
+/// assert!(v.is_string());
+/// let _ = v.path_mut() << 1;
+/// assert!(v.is_i64());
+/// let _ = v.path_mut() << 3.14;
+/// assert!(v.is_f64());
+/// let _ = v.path_mut() << true;
+/// assert!(v.is_boolean());
+/// let _ = v.path_mut() << ();
+/// assert!(v.is_null());
+///
+/// let pi = String::from("PI");
+/// let _ = v.path_mut() << "pi" << 3.14 << pi;
+/// assert_eq!(v, "PI");
+/// ```
+///
+/// Though put operator `<<` can be chained, the later one overwrite the previous value.
+impl<Rhs> Shl<Rhs> for &mut Value where Rhs: JsonScalar, Value: From<Rhs> {
+    type Output = Self;
+    fn shl(self, rhs: Rhs) -> Self::Output {
+        self.put_value(rhs)
+    }
+}
+
+/// Operator `<<` to push key-value pair (tuple) into json object.
+///
+/// If the node is object, the new pair is insert to it,
+/// otherwise change the node to object with only one new pair.
+/// The key and value will be moved into json node, and key require String conversion.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut v = json!("init string node");
+/// 
+/// let _ = &mut v << ("i", 1) << ("f", 3.14);
+/// assert_eq!(v, json!({"i":1,"f":3.14}));
+/// ```
+///
+/// It can chain `<<` to object with several pairs, while it may be not good enough
+/// to use in large loop.
+impl<K: ToString, T> Shl<(K, T)> for &mut Value where Value: From<T> {
+    type Output = Self;
+    fn shl(self, rhs: (K, T)) -> Self::Output {
+        self.push_object(rhs.0, rhs.1)
+    }
+}
+
+/// Operator `<<` to push one value tuple into json array.
+///
+/// If the node is array, the new item is push back to it,
+/// otherwise change the node to array with only one new item.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut v = json!("init string node");
+/// 
+/// let _ = &mut v << ("i",) << (1,) << ("f",) << (3.14,);
+/// assert_eq!(v, json!(["i", 1,"f", 3.14]));
+/// ```
+///
+/// Note that use single tuple to distinguish with pushing one value to node.
+/// Can also use the other overload `<< ["val"]` instead of `("val",)` which may be
+/// more clear to express the meanning for one item in array.
+impl<T> Shl<(T,)> for &mut Value where Value: From<T> {
+    type Output = Self;
+    fn shl(self, rhs: (T,)) -> Self::Output {
+        self.push_array(rhs.0)
+    }
+}
+
+/// Operator `<<` to push one item to json array.
+///
+/// If the node is array, the new item is push back to it,
+/// otherwise change the node to array with only one new item.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut v = json!("init string node");
+/// 
+/// let _ = &mut v << ["i"] << [1] << ["f"] << [3.14];
+/// assert_eq!(v, json!(["i", 1,"f", 3.14]));
+/// ```
+impl<T: Copy> Shl<[T;1]> for &mut Value where Value: From<T> {
+    type Output = Self;
+    fn shl(self, rhs: [T;1]) -> Self::Output {
+        self.push_array(rhs[0])
+    }
+}
+
+/// Operator `<<` to push a slice to json array.
+///
+/// If the node is array, the new items is append back,
+/// otherwise change the node to array with only the new items.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut v = json!("init string node");
+/// 
+/// let vi = vec![1, 2, 3, 4];
+/// let _ = &mut v << &vi[..] << [5] << (6,);
+/// assert_eq!(v, json!([1,2,3,4,5,6]));
+/// ```
+impl<T: Copy> Shl<&[T]> for &mut Value where Value: From<T> {
+    type Output = Self;
+    fn shl(self, rhs: &[T]) -> Self::Output {
+        for item in rhs {
+            self.push_array(*item);
+        }
+        self
+    }
+}
+
+/* ------------------------------------------------------------ */
+
+/// Operator `&mut Value | FnOnce`, perform some action to json tree.
+///
+/// Return mutable reference to the same modified json tree,
+/// and then can chain with other operator.
+///
+/// ```rust
+/// # use serde_json::{json, Value};
+/// let remove_null = |v: &mut Value| {
+///     if let Value::Array(array) = v {
+///         array.retain(|x| !x.is_null())
+///     }
+/// };
+///
+/// let mut v = json!(["pi", null, 3.14]);
+/// let second = (&mut v | remove_null) / 1 | 0.0;
+/// assert_eq!(second, 3.14);
+/// assert_eq!(v, json!(["pi", 3.14]));
+/// ```
+///
+/// Note in above that, the first `|` pipe json tree to function, 
+/// while the last one pipe leaf node to scalar to read the value in it,
+/// and the operator `/` has higher priority than `|` so () is required.
+///
+/// See also operator `&mut Value | ()` to remove null recursively.
+impl<F> BitOr<F> for &mut Value where F: FnOnce(&mut Value) {
+    type Output = Self;
+    fn bitor(self, rhs: F) -> Self::Output {
+        self.pipe_fn(rhs)
+    }
+}
+
+/// Operator `&mut Value | &mut Value`, merge rhs to lhs recursively.
+///
+/// Each leaf node in `rhs` would move to `lhs` if the corresponding node in `lhs`
+/// is null or absent.
+/// When the array in `rhs` has only one item then it reeatedly compare 
+/// with each array item in `lhs` and switch to copy to `lhs` as needed,
+/// otherwise compare one by one and the extra items in `rhs` move to 
+/// the end of `rhs` array.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut va = json!({"name": "pi"});
+/// let mut vb = json!({"name": "PI", "value": "3.14"});
+/// let _ = &mut va | &mut vb;
+/// assert_eq!(va, json!({"name":"pi", "value":"3.14"}));
+/// assert_eq!(vb, json!({"name": "PI", "value":null}));
+/// 
+/// va = json!(["pi", null, null, 2.72]);
+/// vb = json!(["PI", 3.14, "e", 2.71, false, null, 6.18]);
+/// let _ = &mut va | &mut vb;
+/// assert_eq!(va, json!(["pi", 3.14, "e", 2.72, false, null, 6.18]));
+/// assert_eq!(vb, json!(["PI", null, null, 2.71, null, null, null]));
+/// ```
+impl BitOr<&mut Value> for &mut Value {
+    type Output = Self;
+    fn bitor(self, rhs: &mut Value) -> Self::Output {
+        self.merge_move(rhs)
+    }
+}
+
+/// Operator `&mut Value | &Value`, merge rhs to lhs recursively.
+///
+/// Each leaf node in `rhs` would copy to `lhs` if the corresponding node in `lhs`
+/// is null or absent.
+/// When the array in `rhs` has only one item then it reeatedly compare 
+/// with each array item in `lhs`, otherwise compare one by one and the
+/// extra items in `rhs` copy to the end of `rhs` array.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut va = json!({"name": "pi"});
+/// let mut vb = json!({"name": "PI", "value": "3.14"});
+/// let _ = &mut va | &vb;
+/// assert_eq!(va, json!({"name":"pi", "value":"3.14"}));
+/// 
+/// va = json!(["pi", null, null, 2.72]);
+/// vb = json!(["PI", 3.14, "e", 2.71, false, null, 6.18]);
+/// let _ = &mut va | &vb;
+/// assert_eq!(va, json!(["pi", 3.14, "e", 2.72, false, null, 6.18]));
+/// ```
+impl BitOr<&Value> for &mut Value {
+    type Output = Self;
+    fn bitor(self, rhs: &Value) -> Self::Output {
+        self.merge_copy(rhs)
+    }
+}
+
+/// Operator `&mut Value & &Value`, filter `lhs` recursively by `rhs`
+/// as template or sample structure.
+///
+/// Each leaf node in `lhs` would set to null if the corresponding node in `rhs`
+/// has different type or absent. The null node only marked while not actually remove
+/// from it's parent node, may chain to `| ()` to achieve that purpose.
+/// When the array in `rhs` has only one item then it reeatedly compare 
+/// with each array item in `lhs`, otherwise compare one by one.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut va = json!({"name": "pi", "VALUE": 3.14});
+/// let mut vb = json!({"name": "PI", "value": "3.14"});
+/// let _ = &mut va & &vb;
+/// assert_eq!(va, json!({"name":"pi", "VALUE": null}));
+/// 
+/// va = json!(["pi", "314", null, 2.72, true, "xx", 6.18]);
+/// vb = json!(["PI", 3.14, "e", 2.71, false, null]);
+/// let _ = &mut va & &vb;
+/// assert_eq!(va, json!(["pi", null, null, 2.72, true, null, null]));
+/// 
+/// va = json!(["pi", "314", null, 2.72, true, "xx", 6.18]);
+/// let _ = &mut va & &vb | ();
+/// assert_eq!(va, json!(["pi", 2.72, true]));
+/// ```
+///
+/// Note that the bitand `&` operator is selected after `|` to perform
+/// different operation on two json tree, and they both are special case
+/// for pipe to function `&mut Value | FnOnce`.
+/// Since `&` is also used for reference type, this bitand operator may be
+/// more clear when used with `JsonPtrMut` type.
+impl BitAnd<&Value> for &mut Value {
+    type Output = Self;
+    fn bitand(self, rhs: &Value) -> Self::Output {
+        self.filter_shape(rhs)
+    }
+}
+
+/// Operator `&mut Value | ()`, remove null node recursively.
+///
+/// ```rust
+/// # use serde_json::json;
+/// let mut v = json!({"null": "null", "Null": null,
+///     "array": ["null", null, {"i": 10, "n": null, "s": "null"}],
+///     "object": {"1":null, "a":[,{}, {}], "3":{}}
+/// });
+/// let _ = &mut v | ();
+/// assert_eq!(v, json!({"null":"null","array":["null", {"i":10,"s":"null"}]}))
+/// ```
+impl BitOr<()> for &mut Value {
+    type Output = Self;
+    fn bitor(self, _rhs: ()) -> Self::Output {
+        self.remove_null()
+    }
+}

--- a/src/operator/pipe.rs
+++ b/src/operator/pipe.rs
@@ -1,0 +1,175 @@
+use crate::Value;
+use super::JsonReader;
+
+/// Implement `JsonPtrMut | FnOnce` simply.
+pub fn apply<F>(v: &mut Value, f: F) where F: FnOnce(&mut Value) {
+    f(v);
+}
+
+/// Implement `JsonPtrMut | JsonPtrMut` to merge `rhs` json to `lhs`.
+/// The `rhs` json serve as default value in each node.
+pub fn merge_move(lhs: &mut Value, rhs: &mut Value) {
+    match lhs {
+        Value::Null => { *lhs = rhs.take(); }
+        Value::Array(array_lhs) => {
+            if let Value::Array(array_rhs) = rhs {
+                let len_lhs = array_lhs.len();
+                let len_rhs = array_rhs.len();
+                if len_rhs == 0 {
+                    return;
+                }
+                if len_rhs == 1 {
+                    for i in 0 .. len_lhs {
+                        merge_copy(&mut array_lhs[i], &array_rhs[0]);
+                    }
+                }
+                else {
+                    let len_min = std::cmp::min(len_lhs, len_rhs);
+                    for i in 0 .. len_min {
+                        merge_move(&mut array_lhs[i], &mut array_rhs[i]);
+                    }
+                    if len_min < len_rhs {
+                        for i in len_min .. len_rhs {
+                            array_lhs.push(array_rhs[i].take());
+                        }
+                    }
+                }
+            }
+        }
+        Value::Object(object_lhs) => {
+            if let Value::Object(object_rhs) = rhs {
+                for (key, val) in object_rhs {
+                    if !object_lhs.contains_key(key) || object_lhs[key].is_null() {
+                        object_lhs.insert(key.to_string(), val.take());
+                    }
+                    else {
+                        merge_move(&mut object_lhs[key], val);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Implement `JsonPtrMut | JsonPtr` to merge immutable `rhs` json to `lhs`.
+pub fn merge_copy(lhs: &mut Value, rhs: &Value) {
+    match lhs {
+        Value::Null => { *lhs = rhs.clone(); }
+        Value::Array(array_lhs) => {
+            if let Value::Array(array_rhs) = rhs {
+                let len_lhs = array_lhs.len();
+                let len_rhs = array_rhs.len();
+                if len_rhs == 0 {
+                    return;
+                }
+                if len_rhs == 1 {
+                    for i in 0 .. len_lhs {
+                        merge_copy(&mut array_lhs[i], &array_rhs[0]);
+                    }
+                }
+                else {
+                    let len_min = std::cmp::min(len_lhs, len_rhs);
+                    for i in 0 .. len_min {
+                        merge_copy(&mut array_lhs[i], &array_rhs[i]);
+                    }
+                    if len_min < len_rhs {
+                        for i in len_min .. len_rhs {
+                            array_lhs.push(array_rhs[i].clone());
+                        }
+                    }
+                }
+            }
+        }
+        Value::Object(object_lhs) => {
+            if let Value::Object(object_rhs) = rhs {
+                for (key, val) in object_rhs {
+                    if !object_lhs.contains_key(key) || object_lhs[key].is_null() {
+                        object_lhs.insert(key.to_string(), val.clone());
+                    }
+                    else {
+                        merge_copy(&mut object_lhs[key], val);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Implement `JsonPtrMut & JsonPtr` to filter `lhs` by `rhs` as sample structure.
+pub fn filter_shape(lhs: &mut Value, rhs: &Value) {
+    if lhs.get_type() != rhs.get_type() {
+        *lhs = Value::Null;
+    }
+    match lhs {
+        Value::Array(array_lhs) => {
+            if let Value::Array(array_rhs) = rhs {
+                let len_lhs = array_lhs.len();
+                let len_rhs = array_rhs.len();
+                if len_rhs == 0 {
+                    array_lhs.clear();
+                    return;
+                }
+                if len_rhs == 1 {
+                    for i in 0 .. len_lhs {
+                        filter_shape(&mut array_lhs[i], &array_rhs[0]);
+                    }
+                }
+                else {
+                    let len_min = std::cmp::min(len_lhs, len_rhs);
+                    for i in 0 .. len_min {
+                        filter_shape(&mut array_lhs[i], &array_rhs[i]);
+                    }
+                    if len_min < len_lhs {
+                        for i in len_min .. len_lhs {
+                            array_lhs[i] = Value::Null;
+                        }
+                    }
+                }
+            }
+        }
+        Value::Object(object_lhs) => {
+            if let Value::Object(object_rhs) = rhs {
+                for (key, val) in &mut *object_lhs {
+                    if !object_rhs.contains_key(key) || object_rhs[key].is_null() {
+                        *val = Value::Null;
+                    }
+                    else {
+                        filter_shape(val, &object_rhs[key]);
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Check json node is empty, include null and empty array or object.
+fn is_empty_node(v: &Value) -> bool {
+    match v {
+        Value::Null => true,
+        Value::Array(array) => array.is_empty(),
+        Value::Object(object) => object.is_empty(),
+        _ => false
+    }
+}
+
+/// Implement `JsonPtrMut | ()` to remove null node recursively in array or object.
+pub fn remove_null (lhs: &mut Value) {
+    match lhs {
+        Value::Array(array) => {
+            for v in &mut *array {
+                remove_null(v);
+            }
+            array.retain(|v| !is_empty_node(v));
+        }
+        Value::Object(object) => {
+            for (_, v) in &mut *object {
+                remove_null(v);
+            }
+            object.retain(|_, v| !is_empty_node(v));
+        }
+        _ => {}
+    }
+}

--- a/tests/operator_ptr.rs
+++ b/tests/operator_ptr.rs
@@ -1,0 +1,585 @@
+use serde_json::PathOperator;
+use serde_json::operator::{JsonPtr, JsonPtrMut};
+use serde_json::{json, Value};
+
+#[test]
+fn pointer_test() {
+    //! review the usage of pointer method.
+    let v = json!({"x": {"y": ["z", "zz"]}});
+    assert_eq!(v.pointer("").unwrap(), &v);
+    //assert_eq!(v.pointer("/").unwrap(), &v);
+    assert_eq!(v.pointer("/"), None);
+    assert_eq!(v.pointer("/x").unwrap(), &json!({"y": ["z", "zz"]}));
+    assert_eq!(v.pointer("/x/y").unwrap(), &json!(["z", "zz"]));
+    assert_eq!(v.pointer("/x/y/0").unwrap(), &json!("z"));
+    assert_eq!(v.pointer("/x/y/1").unwrap(), &json!("zz"));
+
+    assert_eq!(v.pointer("/x/y/2"), None);
+    assert_eq!(v.pointer("x/y/0"), None);
+
+    let v = json!([0, 1, 2, 3]);
+    assert_eq!(v.pointer("/0").unwrap(), &json!(0));
+    assert_eq!(v.pointer("/1").unwrap(), &json!(1));
+    assert_eq!(v.pointer("1"), None);
+}
+
+#[test]
+fn path_test() {
+    //! test path method behaves similar to ponter, with explicit token.
+    let v = json!({"x": {"y": ["z", "zz"]}});
+
+    let node = v.path() / "x";
+    assert_eq!(node.is_none(), false);
+    assert_eq!(node.unwrap(), &json!({"y": ["z", "zz"]}));
+    let node = v.path() / "x" / "y";
+    assert_eq!(node.unwrap(), &json!(["z", "zz"]));
+    let first = node / 0;
+    assert_eq!(first.unwrap(), &json!("z"));
+    let second = node / 1;
+    assert_eq!(second.unwrap(), &json!("zz"));
+    let third = node / 2;
+    assert_eq!(third.is_none(), true);
+    assert_eq!(*third, None);
+
+    let s = 1.to_string();
+    assert_eq!(s, "1");
+
+    // use variable for path token, String not implemnt Copy, need reference
+    let x = String::from("x");
+    let y = String::from("y");
+    let i = 1; // as usize;
+    let node = v.path() / &x / &y / i;
+    assert_eq!(node.unwrap(), &json!("zz"));
+}
+
+#[test]
+fn pathto_test() {
+    //! test path method behaves similar to ponter, with joined token.
+    let v = json!({"x": {"y": ["z", "zz"]}});
+
+    // joined path would auto prefix '/' according json pointer standard
+    let node = v.path() / "/x/y";
+    assert_eq!(node.unwrap(), &json!(["z", "zz"]));
+    let node = v.path() / "/x / y";
+    assert_eq!(node.is_none(), true);
+    let node = v.path() / "x/y";
+    assert_eq!(node.is_none(), false);
+    assert_eq!(node.unwrap(), &json!(["z", "zz"]));
+    let node = v.pathto("/x/y");
+    assert_eq!(node.unwrap(), &json!(["z", "zz"]));
+}
+
+#[test]
+fn path_empty_test() {
+    //! test empty path token.
+    let v = json!({"x": {"y": ["z", "zz"]}});
+    let root = v.path();
+    let empty = v.path() / "";
+    assert_eq!(empty.is_none(), true);
+    assert_eq!(root.unwrap(), &v);
+
+    let p = v.get("");
+    assert_eq!(p.is_none(), true);
+
+    let v = json!({"x": {"y": ["z", "zz"]}, "": "abc"});
+    let p = v.get("");
+    assert_eq!(p.is_none(), false);
+    assert_eq!(p.unwrap(), &json!("abc"));
+
+    let node = v.path() / "";
+    assert_eq!(node.unwrap(), &json!("abc"));
+
+    let node = v.pathto("");
+    assert_eq!(node.unwrap(), &json!("abc"));
+}
+
+#[test]
+fn path_number_test() {
+    //! test numberic path token.
+    let v = json!({"1": "a", "2": "b", "array": [1, 2], "3": [3, 4]});
+
+    let p = v.pointer("/1");
+    assert_eq!(p.is_none(), false);
+    assert_eq!(p.unwrap(), &json!("a"));
+    let p = v.pointer("/array/1");
+    assert_eq!(p.is_none(), false);
+    assert_eq!(p.unwrap(), &json!(2));
+    let p = v.pointer("/3/1");
+    assert_eq!(p.is_none(), false);
+    assert_eq!(p.unwrap(), &json!(4));
+
+    let node = v.path() / "1";
+    assert_eq!(node.is_none(), false);
+    assert_eq!(node.unwrap(), &json!("a"));
+    assert_eq!(node.unwrap().as_str().unwrap(), "a");
+
+    // backforward to pathto() using converted string path
+    let node = v.path() / 1;
+    assert_eq!(node.is_none(), false);
+    assert_eq!(node.unwrap(), &json!("a"));
+
+    let node = v.path() / "3" / 1;
+    assert_eq!(node.is_none(), false);
+    assert_eq!(node.unwrap(), &json!(4));
+
+    let node = v.pathto("/3/1");
+    assert_eq!(node.unwrap(), &json!(4));
+}
+
+#[test]
+fn pipe_test() {
+    //! test basic pipe operator usage.
+    let v = json!({"x": {"y": ["z", "zz"]}});
+
+    let val = v.path() / "x" / "y" / 1 | "";
+    assert_eq!(val, "zz");
+    let val = v.pathto("/x/y/1") | "";
+    assert_eq!(val, "zz");
+
+    let v = json!({"misc": {"int": 10, "float": 3.14, "str": "pi", "bool": true}});
+    let misc = v.path() / "misc";
+    let val = misc / "int" | 0;
+    assert_eq!(val, 10);
+    let val = misc / "float" | 0.0;
+    assert_eq!(val, 3.14);
+    let val = misc / "str" | "";
+    assert_eq!(val, "pi");
+    let val = misc / "bool" | false;
+    assert_eq!(val, true);
+    let val = misc / "bool" | 0;
+    assert_eq!(val, 1); // true cast to 1
+
+    let def = 0;
+    let val = misc / "int" | def;
+    assert_eq!(val, 10);
+}
+
+#[test]
+fn pipe_cast_test() {
+    //! test |number can fallback to parse from string node.
+    let v = json!({"a": 10, "b": 3.14, "c": true, "A": "10", "B": "3.14", "C": "true", "x": "text"});
+    let root = v.path();
+
+    assert_eq!(root/"a" | 0, 10);
+    assert_eq!(root/"A" | 0, 10);
+    assert_eq!(root/"b" | 0.0, 3.14);
+    assert_eq!(root/"B" | 0.0, 3.14);
+    assert_eq!(root/"x" | 0, 0);
+    assert_eq!(root/"x" | 0.0, 0.0);
+
+    let tf: bool = "true".parse().unwrap();
+    assert!(tf);
+    let tf: bool = "false".parse().unwrap();
+    assert!(!tf);
+
+    assert_eq!(root/"c" | false, true);
+    assert_eq!(root/"C" | false, true);
+    assert_eq!(root/"a" | false, true);
+    assert_eq!(root/"A" | false, false);
+}
+
+#[test]
+fn pipe_string_test() {
+    //! test |string to get selectively stringfy for json node.
+    let v = json!({"int":3, "float":3.14, "str":"text", "array":[1,null,true]});
+    let root = v.path();
+
+    assert_eq!(root/"int" | "", "");
+    assert_eq!(root/"int" | "".to_string(), "3");
+    assert_eq!(root/"int" | "0".to_string(), "3");
+    assert_eq!(root/"int" | "0.0".to_string(), "0.0");
+
+    assert_eq!(root/"float" | "", "");
+    assert_eq!(root/"float" | "".to_string(), "3.14");
+    assert_eq!(root/"float" | "0".to_string(), "0");
+    assert_eq!(root/"float" | "0.0".to_string(), "3.14");
+
+    let vs = (root/"str").unwrap();
+    assert_eq!(root/"str" | "", "text");
+    assert_eq!(root/"str" | "".to_string(), "text");
+    assert_ne!(root/"str" | "".to_string(), vs.to_string());
+    assert_eq!(vs.to_string(), "\"text\"");
+
+    assert_eq!(root/"array" | "", "");
+    assert_eq!(root/"array" | "".to_string(), "[1,null,true]");
+    assert_eq!(root/"array" | "[]".to_string(), "[1,null,true]");
+    assert_eq!(root/"array" | "0".to_string(), "0");
+    assert_eq!(root/"array" | "any default".to_string(), "any default");
+    assert_eq!(root/"array" | "any default", "any default");
+
+    assert_eq!(root | "any default", "any default");
+    assert_eq!(root | "".to_string(), root.unwrap().to_string());
+    assert_eq!(root | "{}".to_string(), v.to_string());
+    assert_eq!(root | "any default".to_string(), "any default");
+}
+
+#[test]
+fn pipe_str_test() {
+    //! test |&str lifetime
+    let mut v = json!({"int":10, "float":3.14, "str":"pi", "bool":true});
+
+    let node = v.path() / "str";
+    assert_eq!(node | "", "pi");
+
+    let s = String::from("xx");
+    let mut val = node | s.as_str();
+    assert_eq!(val, "pi");
+
+    {
+        let ss = String::from("xx");
+        val = node | ss.as_str();
+        assert_eq!(val, "pi");
+        assert_eq!(v.path() / "int" | ss.as_str(), "xx");
+    }
+
+    let node = v.path_mut() / "str";
+    {
+        let ss = String::from("xx");
+        val = node | ss.as_str();
+        assert_eq!(val, "pi");
+        assert_eq!(v.path_mut() / "int" | ss.as_str(), "xx");
+    }
+
+    assert_eq!(s, "xx");
+    let val = v.path() / "str" | s;
+    assert_eq!(val, "pi");
+    // assert_eq!(s, "xx"); //< complie error, s moved by | operator.
+}
+
+#[test]
+fn path_mut_test() {
+    //! test basic mutable path operator.
+    let mut v = json!({"x": {"y": ["z", "zz"]}});
+    let node = v.path_mut() / "x";
+    assert_eq!(node.as_ref().unwrap(), &&json!({"y": ["z", "zz"]}));
+
+    let val = v.path_mut() / "x" / "y" / 1 | "";
+    assert_eq!(val, "zz");
+    let val = v.pathto_mut("/x/y/1") | "";
+    assert_eq!(val, "zz");
+    let val = v.path_mut() / "x/y/1" | "";
+    assert_eq!(val, "zz");
+
+    let mut v = json!({"misc": {"int":10, "float":3.14, "str":"pi", "bool":true}});
+    let misc = v.path_mut() / "misc";
+    let val = misc / "int" | 0;
+    assert_eq!(val, 10);
+
+    // mutable ptr moved after | operator
+    let val = v.path_mut() / "misc" / "float" | 0.0;
+    assert_eq!(val, 3.14);
+    let val = v.path_mut() / "misc" / "str" | "";
+    assert_eq!(val, "pi");
+    let val = v.path_mut() / "misc" / "bool" | false;
+    assert_eq!(val, true);
+    let val = v.path_mut() / "misc" / "bool" | 0;
+    assert_eq!(val, 1);
+
+    let def = 0;
+    let val = v.path_mut() / "misc" / "int" | def;
+    assert_eq!(val, 10);
+}
+
+#[test]
+fn put_test() {
+    //! test operator << to put new value to scalar node, or overwrite any node.
+    let mut v = json!({"x": {"y": ["z", "zz"]}});
+
+    // overwrite leaf node data
+    let node = v.path_mut() / "x" / "y" / 1;
+    let node = node << "AA";
+    assert_eq!(node | "", "AA");
+    let val = v.pathto("/x/y/1") | "";
+    assert_eq!(val, "AA");
+
+    // may also change node type
+    let node = v.pathto_mut("/x/y/1") << 12;
+    assert_eq!(node.is_none(), false);
+    assert_eq!(v.pathto("/x/y/1") | "", "");
+    assert_eq!(v.pathto("/x/y/1") | 0, 12);
+    let node = v.pathto_mut("x/y") << "array";
+    assert_eq!(node | "", "array");
+
+    let mut v = json!({"int":10, "float":3.14, "str":"pi", "bool":true});
+    let node = v.path_mut() / "int" << 11;
+    assert_eq!(node | 0, 11);
+    let node = v.path_mut() / "float" << 31.4;
+    assert_eq!(node | 0.0, 31.4);
+    let node = v.path_mut() / "str" << "PI";
+    assert_eq!(node | "", "PI");
+    let node = v.path_mut() / "bool" << false;
+    assert_eq!(node | true, false);
+
+    let node = v.path_mut() / "bool" << ();
+    assert_eq!(node.is_none(), false);
+    assert_eq!(node.is_null(), true);
+}
+
+#[test]
+fn push_test() {
+    //! test operator << to push new item to object or array.
+    let mut v = json!({});
+
+    let node = v.path_mut() << ("int", 10) << ("float", 3.14);
+    let _ =  node << ("str", "pi") << ("bool", true);
+
+    assert_eq!(v.path()/"int" | 0, 10);
+    assert_eq!(v.path()/"float" | 0.0, 3.14);
+    assert_eq!(v.path()/"str" | "", "pi");
+    assert_eq!(v.path()/"bool" | false, true);
+
+    let node = v.path_mut() << ("array", json!([]));
+    let node = node / "array" << [11] << [11.22] << ("PI",) << (true,);
+    assert_eq!(node.is_none(), false);
+
+    let array = v.path() / "array";
+    assert_eq!(array/0 | 0, 11);
+    assert_eq!(array/1 | 0.1, 11.22);
+    assert_eq!(array/2 | "", "PI");
+    assert_eq!(array/3 | false, true);
+
+    // change int node to array of int
+    let node = v.path_mut() / "int";
+    let _ode = node << [10] << [20] << [()];
+    assert_eq!((v.path()/"int").unwrap(), &json!([10, 20, null]));
+    assert_eq!(v["int"], json!([10, 20, null]));
+
+    println!("{}", v);
+    assert_eq!(v.pathto("int/2").is_null(), true);
+
+    // Value not implement Copy, need refer with &
+    let dint = &v["int"];
+    assert_eq!(dint[0], 10);
+    assert_eq!(dint.path()/0 | 0, 10);
+    assert_eq!(v.path()/"int"/0 | 0, 10);
+}
+
+#[test]
+fn path_index_test() {
+    //! compare path and index syntax.
+    let v = json!({"int":10, "float":3.14, "str":"pi", "array":[1,null,true]});
+    let root = v.path();
+
+    assert_eq!(root/"array"/0 | 0, 1);
+    assert_eq!(v["array"][0], 1);
+
+    let val: i64 = root/"array"/0 | 0;
+    assert_eq!(val, 1);
+    // let val: i64 = &v["array"][0];
+    //^^ compile error, index return Value node, which overload ==
+    let val: i64 = v["array"][0].as_i64().unwrap_or(0);
+    assert_eq!(val, 1);
+
+    // None pointer for non-existed node.
+    let nokey = &v["nokey"]; //< & required
+    let nokey_ptr = root/"nokey";
+    assert_eq!(nokey.is_null(), true);
+    assert_eq!(nokey_ptr.is_none(), true);
+    assert_eq!(nokey_ptr.is_null(), false);
+
+    let outrange = &v["array"][3];
+    assert_eq!(outrange.is_null(), true);
+    let outrange = root/"array"/3;
+    assert_eq!(outrange.is_null(), false);
+    assert_eq!(outrange.is_none(), true);
+
+    // auto insert for index object, but not path
+    let mut v = json!({"array":[1,null,true]});
+    let node = v.path_mut() / "new";
+    assert_eq!(node.is_none(), true);
+    v["new"] = "auto insert".into();
+    assert_eq!(v["new"], "auto insert");
+    let node = v.path() / "new";
+    assert_eq!(node.is_none(), false);
+    assert_eq!(node | "", "auto insert");
+
+    // panic when outof range with mutable index
+    let outrange = v.path()/"array"/3;
+    assert_eq!(outrange.is_none(), true);
+    let outrange = &v["array"][3];
+    assert_eq!(outrange.is_null(), true);
+    // v["array"][3] = "panic".into();
+    // ^^ panic at runtime
+
+    let _p = v.path_mut() / "array" << ["new item"];
+    assert_eq!(_p/3|"", "new item");
+    assert_eq!(v["array"][3], "new item");
+}
+
+#[test]
+fn check_type_test() {
+    //! check type before operator.
+    let mut v = json!({"x": {"y": ["z", "zz"]}});
+
+    let node = v.path() / "x" / "y" / 1;
+    if node.unwrap().is_string() {
+        let val = node | "";
+        assert_eq!(val, "zz");
+    }
+
+    let node = v.path_mut() / "x" / "y" / 1;
+    if node.as_ref().unwrap().is_string() {
+        let val = node | "";
+        assert_eq!(val, "zz");
+    }
+
+    let node = v.path_mut() / "x" / "y" / 1;
+    if node.as_ref().unwrap().is_string() {
+        let node = node << "AA";
+        let val = node | "";
+        assert_eq!(val, "AA");
+    }
+
+    let node = v.path_mut() / "x" / "y" / 1;
+    if node.is_string() {
+        let node = node << "BB";
+        let val = node | "";
+        assert_eq!(val, "BB");
+    }
+}
+
+#[test]
+fn type_test() {
+    //! check type method, not overload operator.
+    let mut v = json!({"int":10, "float":3.14, "str":"pi", "bool":true});
+
+    assert_eq!(v.pathto("int").is_i64(), true);
+    assert_eq!(v.pathto("int").is_u64(), true);
+    assert_eq!(v.pathto("float").is_f64(), true);
+    assert_eq!(v.pathto("str").is_string(), true);
+    assert_eq!(v.pathto("bool").is_boolean(), true);
+
+    assert_eq!(v.pathto_mut("int").is_i64(), true);
+    assert_eq!(v.pathto_mut("int").is_u64(), true);
+    assert_eq!(v.pathto_mut("float").is_f64(), true);
+    assert_eq!(v.pathto_mut("str").is_string(), true);
+    assert_eq!(v.pathto_mut("bool").is_boolean(), true);
+
+    assert_eq!(v.pathto("int").is_string(), false);
+    assert_eq!(v.pathto("float").is_string(), false);
+    assert_eq!(v.pathto("bool").is_string(), false);
+    assert_eq!(v.pathto("str").is_i64(), false);
+    assert_eq!(v.pathto("float").is_i64(), false);
+    assert_eq!(v.pathto("bool").is_i64(), false);
+
+    assert_eq!(v.path().is_object(), true);
+    assert_eq!(v.path().is_array(), false);
+    assert_eq!(v.path().is_null(), false);
+    assert_eq!(v.path_mut().is_object(), true);
+    assert_eq!(v.path_mut().is_array(), false);
+    assert_eq!(v.path_mut().is_null(), false);
+}
+
+#[test]
+fn ptr_eq_test() {
+    //! test the derived `==` operator trait. compare the value they point to.
+    let mut v = json!({"int":10, "float":3.14, "array":["pi", 10, true]});
+    let mut v2 = json!({"int":10, "float":3.14, "array":["pi", 10, true]});
+
+    let p1 = v.path() / "int";
+    let p2 = v.path() / "float";
+    let p3 = v.pathto("int");
+    let p4 = v.path() / "array" / 1;
+    assert_ne!(p1, p2);
+    assert_eq!(p1, p3);
+    assert!(p1 == p3);
+    assert_eq!(p1, p4);
+
+    let p4 = v2.path() / "int";
+    assert_eq!(p1, p4);
+
+    let pn = JsonPtr::new(None);
+    let pm = JsonPtr::new(None);
+    assert_ne!(p1, pn);
+    assert_eq!(pm, pn);
+
+    assert_eq!(&v, &v2);
+
+    let p1 = v.path_mut() / "int";
+    let p2 = v2.path_mut() / "int";
+    assert_eq!(p1, p2);
+
+    let pn = JsonPtrMut::new(None);
+    let pm = JsonPtrMut::new(None);
+    assert_ne!(p1, pn);
+    assert_eq!(pm, pn);
+}
+
+#[test]
+fn pipe_json_test() {
+    //! test pipe two json operation.
+    let mut va = json!([
+        {"name":"PI", "value":3.14},
+        {"name":"e", "value":null},
+        {"name":null, "value":1.0},
+        {"name":618, "value":"618"},
+        {"name":false, "value":false},
+    ]);
+    let vb = json!([{"name":"const", "value":1.0}]);
+
+    let pa = va.path_mut() & vb.path() | () | vb.path();
+    assert_eq!(pa/1/"value"|0.0, 1.0);
+    assert_eq!(va, json!([
+            {"name":"PI", "value":3.14},
+            {"name":"e", "value":1.0},
+            {"name":"const", "value":1.0},
+    ]));
+}
+
+#[test]
+fn pipe_func_test() {
+    //! test pipe to closure.
+    // double value for int json node.
+    let double = |v: &mut Value| {
+        if let Some(i) = v.as_i64() {
+            *v = (i*2).into();
+        }
+    };
+
+    let mut v = json!([1, 2, 3.0, "3", false]);
+    let i = v.path_mut()/0 | double | 0;
+    assert_eq!(i, 2);
+    assert_eq!(v, json!([2, 2, 3.0, "3", false]));
+
+    let i = v.path_mut()/1 | double | 0;
+    assert_eq!(i, 4);
+    assert_eq!(v, json!([2, 4, 3.0, "3", false]));
+
+    // no effect for later items.
+    let i = v.path_mut()/2 | double | 0;
+    assert_eq!(i, 0);
+    assert_eq!(v, json!([2, 4, 3.0, "3", false]));
+}
+
+#[test]
+fn pipe_simulate_test() {
+    //! simulate some other json operator use pipe closure.
+
+    // set int node only when node is int type.
+    // similar json << i64
+    let set_int = |node: &mut Value, val: i64| {
+        if node.is_i64() {
+            *node = val.into();
+        }
+    };
+
+    let mut json = json!(100);
+    let ival = -100;
+    let mptr = json.path_mut() | |node: &mut Value| {set_int(node, ival);};
+    assert_eq!(mptr | 0, -100);
+    assert_eq!(json, json!(-100));
+
+    json = json!("100");
+    let mptr = json.path_mut() | |node: &mut Value| {set_int(node, ival);};
+    assert_eq!(mptr | 0, 100);
+    assert_eq!(json, json!("100"));
+
+    // similar json | i64
+    let mut oint = 0;
+    json = json!(100);
+    let _ptr = json.path_mut() | |node: &mut Value| {
+        oint = node.as_i64().unwrap_or(1);
+    };
+    assert_eq!(oint, 100);
+    assert_eq!(json, json!(100));
+}

--- a/tests/operator_val.rs
+++ b/tests/operator_val.rs
@@ -1,0 +1,103 @@
+use serde_json::{json, Value};
+
+#[test]
+fn value_ops_test() {
+    //! test use operator directly from &Value without call leading path() method.
+    let mut v = json!({"x": {"y": ["z", "zz"]}});
+
+    let node = &v / "x";
+    assert_eq!(node.unwrap(), &json!({"y": ["z", "zz"]}));
+    let node = &v / "x" / "y";
+    assert_eq!(node.unwrap(), &json!(["z", "zz"]));
+
+    let val = &v / "x/y/0" | "";
+    assert_eq!(val, "z");
+    let val = &v / "x/y" / 1 | "";
+    assert_eq!(val, "zz");
+
+    let _ = &mut v / "x/y/1" << "AA";
+    assert_eq!(&v/"x/y/1" | "", "AA");
+
+    let _ = &mut v / "x" / "y" << [10] << [3.14] << [true] << ["END"];
+    assert_eq!((&v/"x/y").unwrap(), &json!(["z", "AA", 10, 3.14, true, "END"]));
+    assert_eq!(&v /"x/y/2" | 0, 10);
+    assert_eq!(&v /"x/y/3" | 0.0, 3.14);
+    assert_eq!(&v /"x" / "y" / "4" | false, true);
+
+    let _ = &mut v / "x" << ("int", 20) << ("float", 3.14) << ("key", "val");
+    assert_eq!(v, json!({
+        "x": {
+            "y": ["z", "AA", 10, 3.14, true, "END"],
+            "int": 20,
+            "float": 3.14,
+            "key": "val"
+        }
+    }));
+
+    assert_eq!((&v/"x"/"y").is_array(), true);
+    let _ = &mut v / "x" / "y" << "array";
+    assert_eq!((&v/"x"/"y").is_array(), false);
+    assert_eq!(v, json!({
+        "x": {
+            "y": "array",
+            "int": 20,
+            "float": 3.14,
+            "key": "val"
+        }
+    }));
+
+    let _ = &mut v << "object";
+    assert_eq!(v, json!("object"));
+}
+
+#[test]
+fn pipe_json_test() {
+    //! test pipe two json operation.
+    let mut va = json!([
+        {"name":"PI", "value":3.14},
+        {"name":"e", "value":null},
+        {"name":null, "value":1.0},
+        {"name":618, "value":"618"},
+        {"name":false, "value":false},
+    ]);
+    let vb = json!([{"name":"const", "value":1.0}]);
+
+    let ra = &mut va & &vb | () | &vb;
+    assert_eq!(ra/1/"value"|0.0, 1.0);
+    assert_eq!(va, json!([
+            {"name":"PI", "value":3.14},
+            {"name":"e", "value":1.0},
+            {"name":"const", "value":1.0},
+    ]));
+}
+
+#[test]
+fn pipe_simulate_test() {
+    //! simulate some other json operator use pipe closure.
+
+    // set int node only when node is int type.
+    // similar json << i64
+    let set_int = |node: &mut Value, val: i64| {
+        if node.is_i64() {
+            *node = val.into();
+        }
+    };
+
+    let mut json = json!(100);
+    let ival = -100;
+    let _ref = &mut json | |node: &mut Value| {set_int(node, ival);};
+    assert_eq!(json, json!(-100));
+
+    json = json!("100");
+    let _ref = &mut json | |node: &mut Value| {set_int(node, ival);};
+    assert_eq!(json, json!("100"));
+
+    // similar json | i64
+    let mut oint = 0;
+    json = json!(100);
+    let _ref = &mut json | |node: &mut Value| {
+        oint = node.as_i64().unwrap_or(1);
+    };
+    assert_eq!(oint, 100);
+    assert_eq!(json, json!(100));
+}


### PR DESCRIPTION
Although it is wonderfull to deserilize json to strong type struct, sometimes it has to deal with untyped json, especially when the input json is too loose or too freely to fit a struct hierarchy. So I devolop a solution for such case.

I summarize the following basic operation on untyped json tree:

1. Locate and refer to some node in the tree by json pointer syntax, using operator `/` overload.
2. Read value from leaf node with default fallback, using operator `|`, image as `get_or` method.
3. Write value to json node as container of common data type, using operator `<<`, image as push item to array or object, or overwrite put value to scalar node.
4. Some advanced modification on json tree as a whole, using operator `|`, pipe to function or closure. 

All the operators above can be chained as return json pointer, except case 2 which only return primitive scalar value.

Example from that added to `README.md`:

```rust
let v: Value = json( {
        "name": "John Doe",
        "age": 43,
        "phones": [
            "+44 1234567",
            "+44 2345678"
        ]
    });

let age_ptr = &v / "age";
let age_val = age_ptr | 0; // got 43, or default 0 if something wrong.
let first_phone = &v / "phones" / 0 | ""; // got &str
assert_eq!(first_phone, "+44 1234567");

// modify some node
let _ = &mut v / "age" << 44;
let _ = &mut v / "phones" << ["+44 3456789"];
let _ = &mut v << ("sex": "male");
```

And there is also fully documantation example and tests.

Because it is impossible to overload operator for `serde_json::Value` outside the crate, but at most can only to overload operator for new struct for json pointer. So I create this pull request to support json operator natively as well.