### PR TITLE
push_to_string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ pub use crate::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]
 pub use crate::error::{Error, Result};
 #[doc(inline)]
-pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty};
+pub use crate::ser::{push_to_string, to_string, to_string_pretty, to_vec, to_vec_pretty};
 #[cfg(feature = "std")]
 #[doc(inline)]
 pub use crate::ser::{to_writer, to_writer_pretty, Serializer};

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2148,6 +2148,24 @@ where
     Ok(string)
 }
 
+/// Serialize the given data structure as JSON, appending it to the given `String`.
+///
+/// # Errors
+///
+/// Serialization can fail if `T`'s implementation of `Serialize` decides to
+/// fail, or if `T` contains a map with non-string keys.
+pub fn push_to_string<T>(value: &T, string: &mut String) -> Result<()>
+where
+    T: ?Sized + Serialize,
+{
+    let mut writer = unsafe {
+        // We do not emit invalid UTF-8.
+        string.as_mut_vec()
+    };
+    tri!(to_writer(&mut writer, value));
+    Ok(())
+}
+
 /// Serialize the given data structure as a pretty-printed String of JSON.
 ///
 /// # Errors

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -30,8 +30,8 @@ use serde_bytes::{ByteBuf, Bytes};
 #[cfg(feature = "raw_value")]
 use serde_json::value::RawValue;
 use serde_json::{
-    from_reader, from_slice, from_str, from_value, json, to_string, to_string_pretty, to_value,
-    to_vec, Deserializer, Number, Value,
+    from_reader, from_slice, from_str, from_value, json, push_to_string, to_string,
+    to_string_pretty, to_value, to_vec, Deserializer, Number, Value,
 };
 use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
@@ -2406,4 +2406,12 @@ fn hash_positive_and_negative_zero() {
         assert_eq!(k1, k2);
         assert_eq!(hash(k1), hash(k2));
     }
+}
+
+#[test]
+fn test_push_to_string() {
+    let mut s = String::new();
+    push_to_string(&1, &mut s).unwrap();
+    push_to_string(&["a"], &mut s).unwrap();
+    assert_eq!("1[\"a\"]", s);
 }


### PR DESCRIPTION
Safe API to use when serde-json is used to serialze values semi-automatically, i.e. half of JSON is written by appending strings to `String`, and and half of serialization is done with `serde-json`.