### PR TITLE
Standardize on "I/O" instead of "IO"

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -2408,9 +2408,9 @@ where
     Ok(value)
 }
 
-/// Deserialize an instance of type `T` from an IO stream of JSON.
+/// Deserialize an instance of type `T` from an I/O stream of JSON.
 ///
-/// The content of the IO stream is deserialized directly from the stream
+/// The content of the I/O stream is deserialized directly from the stream
 /// without being buffered in memory by serde_json.
 ///
 /// When reading from a source against which short reads are not efficient, such

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,15 +36,16 @@ impl Error {
     /// The first character in the input and any characters immediately
     /// following a newline character are in column 1.
     ///
-    /// Note that errors may occur in column 0, for example if a read from an IO
-    /// stream fails immediately following a previously read newline character.
+    /// Note that errors may occur in column 0, for example if a read from an
+    /// I/O stream fails immediately following a previously read newline
+    /// character.
     pub fn column(&self) -> usize {
         self.err.column
     }
 
     /// Categorizes the cause of this error.
     ///
-    /// - `Category::Io` - failure to read or write bytes on an IO stream
+    /// - `Category::Io` - failure to read or write bytes on an I/O stream
     /// - `Category::Syntax` - input that is not syntactically valid JSON
     /// - `Category::Data` - input data that is semantically incorrect
     /// - `Category::Eof` - unexpected end of the input data
@@ -76,7 +77,7 @@ impl Error {
     }
 
     /// Returns true if this error was caused by a failure to read or write
-    /// bytes on an IO stream.
+    /// bytes on an I/O stream.
     pub fn is_io(&self) -> bool {
         self.classify() == Category::Io
     }
@@ -109,7 +110,7 @@ impl Error {
 /// Categorizes the cause of a `serde_json::Error`.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Category {
-    /// The error was caused by a failure to read or write bytes on an IO
+    /// The error was caused by a failure to read or write bytes on an I/O
     /// stream.
     Io,
 
@@ -134,8 +135,8 @@ pub enum Category {
 impl From<Error> for io::Error {
     /// Convert a `serde_json::Error` into an `io::Error`.
     ///
-    /// JSON syntax and data errors are turned into `InvalidData` IO errors.
-    /// EOF errors are turned into `UnexpectedEof` IO errors.
+    /// JSON syntax and data errors are turned into `InvalidData` I/O errors.
+    /// EOF errors are turned into `UnexpectedEof` I/O errors.
     ///
     /// ```
     /// use std::io;
@@ -182,7 +183,7 @@ pub(crate) enum ErrorCode {
     /// Catchall for syntax error messages
     Message(Box<str>),
 
-    /// Some IO error occurred while serializing or deserializing.
+    /// Some I/O error occurred while serializing or deserializing.
     Io(io::Error),
 
     /// EOF while parsing a list.

--- a/src/io/core.rs
+++ b/src/io/core.rs
@@ -9,7 +9,7 @@ pub enum ErrorKind {
     Other,
 }
 
-// IO errors can never occur in no-std mode. All our no-std IO implementations
+// I/O errors can never occur in no-std mode. All our no-std I/O implementations
 // are infallible.
 pub struct Error;
 

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2062,7 +2062,7 @@ static ESCAPE: [u8; 256] = [
     __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
 ];
 
-/// Serialize the given data structure as JSON into the IO stream.
+/// Serialize the given data structure as JSON into the I/O stream.
 ///
 /// Serialization guarantees it only feeds valid UTF-8 sequences to the writer.
 ///
@@ -2081,7 +2081,7 @@ where
     value.serialize(&mut ser)
 }
 
-/// Serialize the given data structure as pretty-printed JSON into the IO
+/// Serialize the given data structure as pretty-printed JSON into the I/O
 /// stream.
 ///
 /// Serialization guarantees it only feeds valid UTF-8 sequences to the writer.


### PR DESCRIPTION
Previously the documentation used an inconsistent mix of "I/O" and "IO".

"I/O" is the spelling used by the std::io module documentation: https://doc.rust-lang.org/1.70.0/std/io/index.html.

Wikipedia also prefers "I/O", with "IO" listed only as an informal spelling. <https://en.wikipedia.org/wiki/Input/output> _"input/output (I/O, i/o, or informally io or IO)"_