### PR TITLE
Allow `f32` and `f64` map keys

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -2118,7 +2118,7 @@ struct MapKey<'a, R: 'a> {
     de: &'a mut Deserializer<R>,
 }
 
-macro_rules! deserialize_numeric_key {
+macro_rules! deserialize_integer_key {
     ($method:ident => $visit:ident) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value>
         where
@@ -2132,6 +2132,25 @@ macro_rules! deserialize_numeric_key {
                 (Err(_), Reference::Borrowed(s)) => visitor.visit_borrowed_str(s),
                 (Err(_), Reference::Copied(s)) => visitor.visit_str(s),
             }
+        }
+    };
+}
+
+macro_rules! deserialize_float_key {
+    ($method:ident) => {
+        fn $method<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: de::Visitor<'de>,
+        {
+            self.de.eat_char();
+            let value = self.de.$method(visitor)?;
+
+            match self.de.peek()? {
+                Some(b'"') => self.de.eat_char(),
+                _ => return Err(self.de.peek_error(ErrorCode::ExpectedDoubleQuote)),
+            }
+
+            Ok(value)
         }
     };
 }
@@ -2155,18 +2174,19 @@ where
         }
     }
 
-    deserialize_numeric_key!(deserialize_i8 => visit_i8);
-    deserialize_numeric_key!(deserialize_i16 => visit_i16);
-    deserialize_numeric_key!(deserialize_i32 => visit_i32);
-    deserialize_numeric_key!(deserialize_i64 => visit_i64);
-    deserialize_numeric_key!(deserialize_i128 => visit_i128);
-    deserialize_numeric_key!(deserialize_u8 => visit_u8);
-    deserialize_numeric_key!(deserialize_u16 => visit_u16);
-    deserialize_numeric_key!(deserialize_u32 => visit_u32);
-    deserialize_numeric_key!(deserialize_u64 => visit_u64);
-    deserialize_numeric_key!(deserialize_u128 => visit_u128);
-    deserialize_numeric_key!(deserialize_f32 => visit_f32);
-    deserialize_numeric_key!(deserialize_f64 => visit_f64);
+    deserialize_integer_key!(deserialize_i8 => visit_i8);
+    deserialize_integer_key!(deserialize_i16 => visit_i16);
+    deserialize_integer_key!(deserialize_i32 => visit_i32);
+    deserialize_integer_key!(deserialize_i64 => visit_i64);
+    deserialize_integer_key!(deserialize_i128 => visit_i128);
+    deserialize_integer_key!(deserialize_u8 => visit_u8);
+    deserialize_integer_key!(deserialize_u16 => visit_u16);
+    deserialize_integer_key!(deserialize_u32 => visit_u32);
+    deserialize_integer_key!(deserialize_u64 => visit_u64);
+    deserialize_integer_key!(deserialize_u128 => visit_u128);
+
+    deserialize_float_key!(deserialize_f32);
+    deserialize_float_key!(deserialize_f64);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de.rs
+++ b/src/de.rs
@@ -2118,25 +2118,7 @@ struct MapKey<'a, R: 'a> {
     de: &'a mut Deserializer<R>,
 }
 
-macro_rules! deserialize_integer_key {
-    ($method:ident => $visit:ident) => {
-        fn $method<V>(self, visitor: V) -> Result<V::Value>
-        where
-            V: de::Visitor<'de>,
-        {
-            self.de.eat_char();
-            self.de.scratch.clear();
-            let string = tri!(self.de.read.parse_str(&mut self.de.scratch));
-            match (string.parse(), string) {
-                (Ok(integer), _) => visitor.$visit(integer),
-                (Err(_), Reference::Borrowed(s)) => visitor.visit_borrowed_str(s),
-                (Err(_), Reference::Copied(s)) => visitor.visit_str(s),
-            }
-        }
-    };
-}
-
-macro_rules! deserialize_float_key {
+macro_rules! deserialize_numeric_key {
     ($method:ident) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value>
         where
@@ -2174,19 +2156,18 @@ where
         }
     }
 
-    deserialize_integer_key!(deserialize_i8 => visit_i8);
-    deserialize_integer_key!(deserialize_i16 => visit_i16);
-    deserialize_integer_key!(deserialize_i32 => visit_i32);
-    deserialize_integer_key!(deserialize_i64 => visit_i64);
-    deserialize_integer_key!(deserialize_i128 => visit_i128);
-    deserialize_integer_key!(deserialize_u8 => visit_u8);
-    deserialize_integer_key!(deserialize_u16 => visit_u16);
-    deserialize_integer_key!(deserialize_u32 => visit_u32);
-    deserialize_integer_key!(deserialize_u64 => visit_u64);
-    deserialize_integer_key!(deserialize_u128 => visit_u128);
-
-    deserialize_float_key!(deserialize_f32);
-    deserialize_float_key!(deserialize_f64);
+    deserialize_numeric_key!(deserialize_i8);
+    deserialize_numeric_key!(deserialize_i16);
+    deserialize_numeric_key!(deserialize_i32);
+    deserialize_numeric_key!(deserialize_i64);
+    deserialize_numeric_key!(deserialize_i128);
+    deserialize_numeric_key!(deserialize_u8);
+    deserialize_numeric_key!(deserialize_u16);
+    deserialize_numeric_key!(deserialize_u32);
+    deserialize_numeric_key!(deserialize_u64);
+    deserialize_numeric_key!(deserialize_u128);
+    deserialize_numeric_key!(deserialize_f32);
+    deserialize_numeric_key!(deserialize_f64);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>

--- a/src/de.rs
+++ b/src/de.rs
@@ -2118,7 +2118,7 @@ struct MapKey<'a, R: 'a> {
     de: &'a mut Deserializer<R>,
 }
 
-macro_rules! deserialize_integer_key {
+macro_rules! deserialize_numeric_key {
     ($method:ident => $visit:ident) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value>
         where
@@ -2155,16 +2155,18 @@ where
         }
     }
 
-    deserialize_integer_key!(deserialize_i8 => visit_i8);
-    deserialize_integer_key!(deserialize_i16 => visit_i16);
-    deserialize_integer_key!(deserialize_i32 => visit_i32);
-    deserialize_integer_key!(deserialize_i64 => visit_i64);
-    deserialize_integer_key!(deserialize_i128 => visit_i128);
-    deserialize_integer_key!(deserialize_u8 => visit_u8);
-    deserialize_integer_key!(deserialize_u16 => visit_u16);
-    deserialize_integer_key!(deserialize_u32 => visit_u32);
-    deserialize_integer_key!(deserialize_u64 => visit_u64);
-    deserialize_integer_key!(deserialize_u128 => visit_u128);
+    deserialize_numeric_key!(deserialize_i8 => visit_i8);
+    deserialize_numeric_key!(deserialize_i16 => visit_i16);
+    deserialize_numeric_key!(deserialize_i32 => visit_i32);
+    deserialize_numeric_key!(deserialize_i64 => visit_i64);
+    deserialize_numeric_key!(deserialize_i128 => visit_i128);
+    deserialize_numeric_key!(deserialize_u8 => visit_u8);
+    deserialize_numeric_key!(deserialize_u16 => visit_u16);
+    deserialize_numeric_key!(deserialize_u32 => visit_u32);
+    deserialize_numeric_key!(deserialize_u64 => visit_u64);
+    deserialize_numeric_key!(deserialize_u128 => visit_u128);
+    deserialize_numeric_key!(deserialize_f32 => visit_f32);
+    deserialize_numeric_key!(deserialize_f64 => visit_f64);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
@@ -2221,8 +2223,8 @@ where
     }
 
     forward_to_deserialize_any! {
-        bool f32 f64 char str string unit unit_struct seq tuple tuple_struct map
-        struct identifier ignored_any
+        bool char str string unit unit_struct seq tuple tuple_struct map struct
+        identifier ignored_any
     }
 }
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -2125,7 +2125,12 @@ macro_rules! deserialize_numeric_key {
             V: de::Visitor<'de>,
         {
             self.de.eat_char();
-            let value = self.de.$method(visitor)?;
+
+            if let Some(b' ') | Some(b'\n') | Some(b'\r') | Some(b'\t') = tri!(self.de.peek()) {
+                return Err(self.de.peek_error(ErrorCode::UnexpectedWhitespaceInKey));
+            }
+
+            let value = tri!(self.de.$method(visitor));
 
             match self.de.peek()? {
                 Some(b'"') => self.de.eat_char(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,7 @@ impl Error {
             | ErrorCode::ExpectedObjectCommaOrEnd
             | ErrorCode::ExpectedSomeIdent
             | ErrorCode::ExpectedSomeValue
+            | ErrorCode::ExpectedDoubleQuote
             | ErrorCode::InvalidEscape
             | ErrorCode::InvalidNumber
             | ErrorCode::NumberOutOfRange
@@ -265,6 +266,9 @@ pub(crate) enum ErrorCode {
     /// Expected this character to start a JSON value.
     ExpectedSomeValue,
 
+    /// Expected this character to be a `"`.
+    ExpectedDoubleQuote,
+
     /// Invalid hex escape code.
     InvalidEscape,
 
@@ -352,6 +356,7 @@ impl Display for ErrorCode {
             ErrorCode::ExpectedObjectCommaOrEnd => f.write_str("expected `,` or `}`"),
             ErrorCode::ExpectedSomeIdent => f.write_str("expected ident"),
             ErrorCode::ExpectedSomeValue => f.write_str("expected value"),
+            ErrorCode::ExpectedDoubleQuote => f.write_str("expected `\"`"),
             ErrorCode::InvalidEscape => f.write_str("invalid escape"),
             ErrorCode::InvalidNumber => f.write_str("invalid number"),
             ErrorCode::NumberOutOfRange => f.write_str("number out of range"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,7 @@ impl Error {
             | ErrorCode::InvalidUnicodeCodePoint
             | ErrorCode::ControlCharacterWhileParsingString
             | ErrorCode::KeyMustBeAString
+            | ErrorCode::FloatKeyMustBeFinite
             | ErrorCode::LoneLeadingSurrogateInHexEscape
             | ErrorCode::TrailingComma
             | ErrorCode::TrailingCharacters
@@ -282,6 +283,9 @@ pub(crate) enum ErrorCode {
     /// Object key is not a string.
     KeyMustBeAString,
 
+    /// Object key is a non-finite float value.
+    FloatKeyMustBeFinite,
+
     /// Lone leading surrogate in hex escape.
     LoneLeadingSurrogateInHexEscape,
 
@@ -356,6 +360,9 @@ impl Display for ErrorCode {
                 f.write_str("control character (\\u0000-\\u001F) found while parsing a string")
             }
             ErrorCode::KeyMustBeAString => f.write_str("key must be a string"),
+            ErrorCode::FloatKeyMustBeFinite => {
+                f.write_str("float key must be finite (got NaN or +/-inf)")
+            }
             ErrorCode::LoneLeadingSurrogateInHexEscape => {
                 f.write_str("lone leading surrogate in hex escape")
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,7 @@ impl Error {
             | ErrorCode::ControlCharacterWhileParsingString
             | ErrorCode::KeyMustBeAString
             | ErrorCode::FloatKeyMustBeFinite
+            | ErrorCode::UnexpectedWhitespaceInKey
             | ErrorCode::LoneLeadingSurrogateInHexEscape
             | ErrorCode::TrailingComma
             | ErrorCode::TrailingCharacters
@@ -290,6 +291,9 @@ pub(crate) enum ErrorCode {
     /// Object key is a non-finite float value.
     FloatKeyMustBeFinite,
 
+    /// Unexpected whitespace in a numeric key.
+    UnexpectedWhitespaceInKey,
+
     /// Lone leading surrogate in hex escape.
     LoneLeadingSurrogateInHexEscape,
 
@@ -367,6 +371,9 @@ impl Display for ErrorCode {
             ErrorCode::KeyMustBeAString => f.write_str("key must be a string"),
             ErrorCode::FloatKeyMustBeFinite => {
                 f.write_str("float key must be finite (got NaN or +/-inf)")
+            }
+            ErrorCode::UnexpectedWhitespaceInKey => {
+                f.write_str("unexpected whitespace in object key")
             }
             ErrorCode::LoneLeadingSurrogateInHexEscape => {
                 f.write_str("lone leading surrogate in hex escape")

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -789,6 +789,10 @@ fn key_must_be_a_string() -> Error {
     Error::syntax(ErrorCode::KeyMustBeAString, 0, 0)
 }
 
+fn float_key_must_be_finite() -> Error {
+    Error::syntax(ErrorCode::FloatKeyMustBeFinite, 0, 0)
+}
+
 impl<'a, W, F> ser::Serializer for MapKeySerializer<'a, W, F>
 where
     W: io::Write,
@@ -1003,6 +1007,10 @@ where
     }
 
     fn serialize_f32(self, value: f32) -> Result<()> {
+        if !value.is_finite() {
+            return Err(float_key_must_be_finite());
+        }
+
         tri!(self
             .ser
             .formatter
@@ -1020,6 +1028,10 @@ where
     }
 
     fn serialize_f64(self, value: f64) -> Result<()> {
+        if !value.is_finite() {
+            return Err(float_key_must_be_finite());
+        }
+
         tri!(self
             .ser
             .formatter

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1002,12 +1002,38 @@ where
             .map_err(Error::io)
     }
 
-    fn serialize_f32(self, _value: f32) -> Result<()> {
-        Err(key_must_be_a_string())
+    fn serialize_f32(self, value: f32) -> Result<()> {
+        tri!(self
+            .ser
+            .formatter
+            .begin_string(&mut self.ser.writer)
+            .map_err(Error::io));
+        tri!(self
+            .ser
+            .formatter
+            .write_f32(&mut self.ser.writer, value)
+            .map_err(Error::io));
+        self.ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io)
     }
 
-    fn serialize_f64(self, _value: f64) -> Result<()> {
-        Err(key_must_be_a_string())
+    fn serialize_f64(self, value: f64) -> Result<()> {
+        tri!(self
+            .ser
+            .formatter
+            .begin_string(&mut self.ser.writer)
+            .map_err(Error::io));
+        tri!(self
+            .ser
+            .formatter
+            .write_f64(&mut self.ser.writer, value)
+            .map_err(Error::io));
+        self.ser
+            .formatter
+            .end_string(&mut self.ser.writer)
+            .map_err(Error::io)
     }
 
     fn serialize_char(self, value: char) -> Result<()> {

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1120,7 +1120,7 @@ struct MapKeyDeserializer<'de> {
     key: Cow<'de, str>,
 }
 
-macro_rules! deserialize_integer_key {
+macro_rules! deserialize_numeric_key {
     ($method:ident => $visit:ident) => {
         fn $method<V>(self, visitor: V) -> Result<V::Value, Error>
         where
@@ -1146,16 +1146,18 @@ impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
         BorrowedCowStrDeserializer::new(self.key).deserialize_any(visitor)
     }
 
-    deserialize_integer_key!(deserialize_i8 => visit_i8);
-    deserialize_integer_key!(deserialize_i16 => visit_i16);
-    deserialize_integer_key!(deserialize_i32 => visit_i32);
-    deserialize_integer_key!(deserialize_i64 => visit_i64);
-    deserialize_integer_key!(deserialize_i128 => visit_i128);
-    deserialize_integer_key!(deserialize_u8 => visit_u8);
-    deserialize_integer_key!(deserialize_u16 => visit_u16);
-    deserialize_integer_key!(deserialize_u32 => visit_u32);
-    deserialize_integer_key!(deserialize_u64 => visit_u64);
-    deserialize_integer_key!(deserialize_u128 => visit_u128);
+    deserialize_numeric_key!(deserialize_i8 => visit_i8);
+    deserialize_numeric_key!(deserialize_i16 => visit_i16);
+    deserialize_numeric_key!(deserialize_i32 => visit_i32);
+    deserialize_numeric_key!(deserialize_i64 => visit_i64);
+    deserialize_numeric_key!(deserialize_i128 => visit_i128);
+    deserialize_numeric_key!(deserialize_u8 => visit_u8);
+    deserialize_numeric_key!(deserialize_u16 => visit_u16);
+    deserialize_numeric_key!(deserialize_u32 => visit_u32);
+    deserialize_numeric_key!(deserialize_u64 => visit_u64);
+    deserialize_numeric_key!(deserialize_u128 => visit_u128);
+    deserialize_numeric_key!(deserialize_f32 => visit_f32);
+    deserialize_numeric_key!(deserialize_f64 => visit_f64);
 
     #[inline]
     fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Error>
@@ -1193,7 +1195,7 @@ impl<'de> serde::Deserializer<'de> for MapKeyDeserializer<'de> {
     }
 
     forward_to_deserialize_any! {
-        bool f32 f64 char str string bytes byte_buf unit unit_struct seq tuple
+        bool char str string bytes byte_buf unit unit_struct seq tuple
         tuple_struct map struct identifier ignored_any
     }
 }

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -1126,7 +1126,8 @@ macro_rules! deserialize_numeric_key {
         where
             V: Visitor<'de>,
         {
-            match (self.key.parse(), self.key) {
+            let parsed = crate::from_str(&self.key);
+            match (parsed, self.key) {
                 (Ok(integer), _) => visitor.$visit(integer),
                 (Err(_), Cow::Borrowed(s)) => visitor.visit_borrowed_str(s),
                 #[cfg(any(feature = "std", feature = "alloc"))]

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -523,8 +523,7 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f32(self, value: f32) -> Result<String> {
         if value.is_finite() {
-            let mut buffer = ryu::Buffer::new();
-            Ok(buffer.format_finite(value).to_owned())
+            Ok(ryu::Buffer::new().format_finite(value).to_owned())
         } else {
             Err(float_key_must_be_finite())
         }
@@ -532,8 +531,7 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f64(self, value: f64) -> Result<String> {
         if value.is_finite() {
-            let mut buffer = ryu::Buffer::new();
-            Ok(buffer.format_finite(value).to_owned())
+            Ok(ryu::Buffer::new().format_finite(value).to_owned())
         } else {
             Err(float_key_must_be_finite())
         }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -517,12 +517,12 @@ impl serde::Serializer for MapKeySerializer {
         Ok(value.to_string())
     }
 
-    fn serialize_f32(self, _value: f32) -> Result<String> {
-        Err(key_must_be_a_string())
+    fn serialize_f32(self, value: f32) -> Result<String> {
+        Ok(value.to_string())
     }
 
-    fn serialize_f64(self, _value: f64) -> Result<String> {
-        Err(key_must_be_a_string())
+    fn serialize_f64(self, value: f64) -> Result<String> {
+        Ok(value.to_string())
     }
 
     #[inline]

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -529,7 +529,7 @@ impl serde::Serializer for MapKeySerializer {
             let mut formatter = CompactFormatter;
 
             // `Vec`'s `Write` implementation never returns an error.
-            formatter.write_f32(&mut buf, value).unwrap();
+            let _ = formatter.write_f32(&mut buf, value);
 
             // `CompactFormatter` does not emit invalid UTF-8.
             Ok(String::from_utf8(buf).unwrap())
@@ -545,7 +545,7 @@ impl serde::Serializer for MapKeySerializer {
             let mut formatter = CompactFormatter;
 
             // `Vec`'s `Write` implementation never returns an error.
-            formatter.write_f64(&mut buf, value).unwrap();
+            let _ = formatter.write_f64(&mut buf, value);
 
             // `CompactFormatter` does not emit invalid UTF-8.
             Ok(String::from_utf8(buf).unwrap())

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,6 +1,5 @@
 use crate::error::{Error, ErrorCode, Result};
 use crate::map::Map;
-use crate::ser::{CompactFormatter, Formatter};
 use crate::value::{to_value, Value};
 use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
@@ -524,15 +523,8 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f32(self, value: f32) -> Result<String> {
         if value.is_finite() {
-            // We initialize our output buffer with a heuristic capacity.
-            let mut buf = Vec::with_capacity(8);
-            let mut formatter = CompactFormatter;
-
-            // `Vec`'s `Write` implementation never returns an error.
-            let _ = formatter.write_f32(&mut buf, value);
-
-            // `CompactFormatter` does not emit invalid UTF-8.
-            Ok(String::from_utf8(buf).unwrap())
+            let mut buffer = ryu::Buffer::new();
+            Ok(buffer.format_finite(value).to_owned())
         } else {
             Err(float_key_must_be_finite())
         }
@@ -540,15 +532,8 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f64(self, value: f64) -> Result<String> {
         if value.is_finite() {
-            // We initialize our output buffer with a heuristic capacity.
-            let mut buf = Vec::with_capacity(8);
-            let mut formatter = CompactFormatter;
-
-            // `Vec`'s `Write` implementation never returns an error.
-            let _ = formatter.write_f64(&mut buf, value);
-
-            // `CompactFormatter` does not emit invalid UTF-8.
-            Ok(String::from_utf8(buf).unwrap())
+            let mut buffer = ryu::Buffer::new();
+            Ok(buffer.format_finite(value).to_owned())
         } else {
             Err(float_key_must_be_finite())
         }

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -451,6 +451,10 @@ fn key_must_be_a_string() -> Error {
     Error::syntax(ErrorCode::KeyMustBeAString, 0, 0)
 }
 
+fn float_key_must_be_finite() -> Error {
+    Error::syntax(ErrorCode::FloatKeyMustBeFinite, 0, 0)
+}
+
 impl serde::Serializer for MapKeySerializer {
     type Ok = String;
     type Error = Error;
@@ -518,11 +522,19 @@ impl serde::Serializer for MapKeySerializer {
     }
 
     fn serialize_f32(self, value: f32) -> Result<String> {
-        Ok(value.to_string())
+        if value.is_finite() {
+            Ok(value.to_string())
+        } else {
+            Err(float_key_must_be_finite())
+        }
     }
 
     fn serialize_f64(self, value: f64) -> Result<String> {
-        Ok(value.to_string())
+        if value.is_finite() {
+            Ok(value.to_string())
+        } else {
+            Err(float_key_must_be_finite())
+        }
     }
 
     #[inline]

--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, ErrorCode, Result};
 use crate::map::Map;
+use crate::ser::{CompactFormatter, Formatter};
 use crate::value::{to_value, Value};
 use alloc::borrow::ToOwned;
 use alloc::string::{String, ToString};
@@ -523,7 +524,15 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f32(self, value: f32) -> Result<String> {
         if value.is_finite() {
-            Ok(value.to_string())
+            // We initialize our output buffer with a heuristic capacity.
+            let mut buf = Vec::with_capacity(8);
+            let mut formatter = CompactFormatter;
+
+            // `Vec`'s `Write` implementation never returns an error.
+            formatter.write_f32(&mut buf, value).unwrap();
+
+            // `CompactFormatter` does not emit invalid UTF-8.
+            Ok(String::from_utf8(buf).unwrap())
         } else {
             Err(float_key_must_be_finite())
         }
@@ -531,7 +540,15 @@ impl serde::Serializer for MapKeySerializer {
 
     fn serialize_f64(self, value: f64) -> Result<String> {
         if value.is_finite() {
-            Ok(value.to_string())
+            // We initialize our output buffer with a heuristic capacity.
+            let mut buf = Vec::with_capacity(8);
+            let mut formatter = CompactFormatter;
+
+            // `Vec`'s `Write` implementation never returns an error.
+            formatter.write_f64(&mut buf, value).unwrap();
+
+            // `CompactFormatter` does not emit invalid UTF-8.
+            Ok(String::from_utf8(buf).unwrap())
         } else {
             Err(float_key_must_be_finite())
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1901,6 +1901,15 @@ fn test_integer_key() {
 }
 
 #[test]
+fn test_integer_key_leading_whitespace() {
+    let j = r#"{" 123":null}"#;
+    test_parse_err::<BTreeMap<i32, ()>>(&[(
+        j,
+        "unexpected whitespace in object key at line 1 column 3",
+    )]);
+}
+
+#[test]
 fn test_integer128_key() {
     let map = treemap! {
         100000000000000000000000000000000000000u128 => ()

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1949,6 +1949,64 @@ fn test_float_key() {
 }
 
 #[test]
+fn test_deny_non_finite_f32_key() {
+    // We store float bits so that we can derive `Ord`, and other traits. In a real context, we
+    // would use a crate like `ordered-float` instead.
+
+    #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone)]
+    struct F32Bits(u32);
+    impl Serialize for F32Bits {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_f32(f32::from_bits(self.0))
+        }
+    }
+
+    let map = treemap!(F32Bits(f32::INFINITY.to_bits()) => "x".to_owned());
+    assert!(serde_json::to_string(&map).is_err());
+    assert!(serde_json::to_value(map).is_err());
+
+    let map = treemap!(F32Bits(f32::NEG_INFINITY.to_bits()) => "x".to_owned());
+    assert!(serde_json::to_string(&map).is_err());
+    assert!(serde_json::to_value(map).is_err());
+
+    let map = treemap!(F32Bits(f32::NAN.to_bits()) => "x".to_owned());
+    assert!(serde_json::to_string(&map).is_err());
+    assert!(serde_json::to_value(map).is_err());
+}
+
+#[test]
+fn test_deny_non_finite_f64_key() {
+    // We store float bits so that we can derive `Ord`, and other traits. In a real context, we
+    // would use a crate like `ordered-float` instead.
+
+    #[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone)]
+    struct F64Bits(u64);
+    impl Serialize for F64Bits {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_f64(f64::from_bits(self.0))
+        }
+    }
+
+    let map = treemap!(F64Bits(f64::INFINITY.to_bits()) => "x".to_owned());
+    assert!(serde_json::to_string(&map).is_err());
+    assert!(serde_json::to_value(map).is_err());
+
+    let map = treemap!(F64Bits(f64::NEG_INFINITY.to_bits()) => "x".to_owned());
+    assert!(serde_json::to_string(&map).is_err());
+    assert!(serde_json::to_value(map).is_err());
+
+    let map = treemap!(F64Bits(f64::NAN.to_bits()) => "x".to_owned());
+    assert!(serde_json::to_string(&map).is_err());
+    assert!(serde_json::to_value(map).is_err());
+}
+
+#[test]
 fn test_borrowed_key() {
     let map: BTreeMap<&str, ()> = from_str("{\"borrowed\":null}").unwrap();
     let expected = treemap! { "borrowed" => () };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1944,7 +1944,7 @@ fn test_float_key() {
     let j = r#"{"x": null}"#;
     test_parse_err::<BTreeMap<Float, ()>>(&[(
         j,
-        "invalid type: string \"x\", expected f32 at line 1 column 4",
+        "expected value at line 1 column 3",
     )]);
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1942,10 +1942,7 @@ fn test_float_key() {
     test_parse_ok(vec![(j, map)]);
 
     let j = r#"{"x": null}"#;
-    test_parse_err::<BTreeMap<Float, ()>>(&[(
-        j,
-        "expected value at line 1 column 3",
-    )]);
+    test_parse_err::<BTreeMap<Float, ()>>(&[(j, "expected value at line 1 column 3")]);
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1897,10 +1897,7 @@ fn test_integer_key() {
     test_parse_ok(vec![(j, map)]);
 
     let j = r#"{"x":null}"#;
-    test_parse_err::<BTreeMap<i32, ()>>(&[(
-        j,
-        "invalid type: string \"x\", expected i32 at line 1 column 4",
-    )]);
+    test_parse_err::<BTreeMap<i32, ()>>(&[(j, "expected value at line 1 column 3")]);
 }
 
 #[test]


### PR DESCRIPTION
Now we allow objects with `f32` or `f64` string-serialized keys. For example:

```json
{ "1.123": "foo", "2.0": "bar" }
```

The `test_deny_float_key` test has been inverted, and the `deserialize_integer_key` macros have been renamed to `deserialize_numeric_key` in order to support `f32` and `f64`.