### PR TITLE
Support MapKeySerializer::serialize_some

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1043,11 +1043,12 @@ where
         Err(key_must_be_a_string())
     }
 
-    fn serialize_some<T>(self, _value: &T) -> Result<()>
+    #[inline]
+    fn serialize_some<T>(self, value: &T) -> Result<()>
     where
         T: ?Sized + Serialize,
     {
-        Err(key_must_be_a_string())
+        value.serialize(self)
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {


### PR DESCRIPTION
This PR updates `MapKeySerializer::serialize_some` to match `Serializer::serialize_some`.

Currently, all calls to `serialize_some` are rejected with the `key_must_be_a_string` error that many other variants use. Because there is no distinction between `Some(T)` and `T` in JSON, I think that serializing the underlying type directly is a better behavior for this function.

I think this change is useful for serializing types that have internal nullability. In a project I am working on, there is a bitpattern in a type I am serializing that I would like serialize as `null`. To behave correctly with as many serializers as I can, I use `serialize_some` and `serialize_none`. When the type is used as a key, this causes serde_json to panic, even if the value is normally fine as a key.

One argument against this change is that it creates a new footgun. Users may serialize a type like `HashMap<Option<String>, T>` with keys that are all `Some(...)`, and then be surprised when the type fails to serialize with a key that is `None`. Currently, I think that any types that are valid map keys are _always_ valid map keys, which is desirable.

I'm hoping to get feedback by opening this PR to figure out if this is the right direction... or not!