### PR TITLE
Remove pre-NLL borrow checker workarounds

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -177,11 +177,9 @@ impl RawValue {
     /// - the input has no leading or trailing whitespace, and
     /// - the input has capacity equal to its length.
     pub fn from_string(json: String) -> Result<Box<Self>, Error> {
-        {
-            let borrowed = tri!(crate::from_str::<&Self>(&json));
-            if borrowed.json.len() < json.len() {
-                return Ok(borrowed.to_owned());
-            }
+        let borrowed = tri!(crate::from_str::<&Self>(&json));
+        if borrowed.json.len() < json.len() {
+            return Ok(borrowed.to_owned());
         }
         Ok(Self::from_owned(json.into_boxed_str()))
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -439,17 +439,15 @@ where
             .formatter
             .begin_string(&mut self.writer)
             .map_err(Error::io));
-        {
-            let mut adapter = Adapter {
-                writer: &mut self.writer,
-                formatter: &mut self.formatter,
-                error: None,
-            };
-            match write!(adapter, "{}", value) {
-                Ok(()) => debug_assert!(adapter.error.is_none()),
-                Err(fmt::Error) => {
-                    return Err(Error::io(adapter.error.expect("there should be an error")));
-                }
+        let mut adapter = Adapter {
+            writer: &mut self.writer,
+            formatter: &mut self.formatter,
+            error: None,
+        };
+        match write!(adapter, "{}", value) {
+            Ok(()) => debug_assert!(adapter.error.is_none()),
+            Err(fmt::Error) => {
+                return Err(Error::io(adapter.error.expect("there should be an error")));
             }
         }
         self.formatter


### PR DESCRIPTION
NLL has been in use since Rust 1.31 (for edition 2018+) or Rust 1.36 (for edition 2015).

```console
error[E0505]: cannot move out of `json` because it is borrowed
   --> src/raw.rs:184:29
    |
180 |             let borrowed = ::from_str::<&Self>(&json)?;
    |                                                 ---- borrow of `json` occurs here
...
184 |         Ok(Self::from_owned(json.into_boxed_str()))
    |                             ^^^^ move out of `json` occurs here

error[E0499]: cannot borrow `self.formatter` as mutable more than once at a time
   --> src/ser.rs:453:13
    |
444 |                 formatter: &mut self.formatter,
    |                                 -------------- first mutable borrow occurs here
...
453 |             self.formatter
    |             ^^^^^^^^^^^^^^ second mutable borrow occurs here
...
456 |     }
    |     - first borrow ends here

error[E0499]: cannot borrow `self.writer` as mutable more than once at a time
   --> src/ser.rs:454:34
    |
443 |                 writer: &mut self.writer,
    |                              ----------- first mutable borrow occurs here
...
454 |                 .end_string(&mut self.writer)
    |                                  ^^^^^^^^^^^ second mutable borrow occurs here
...
456 |     }
    |     - 
```