### PR TITLE
Add Formatter::write_byte_array

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -192,31 +192,22 @@ where
             .formatter
             .begin_array(&mut self.writer)
             .map_err(Error::io));
-        if value.is_empty() {
+        let mut first = true;
+        for byte in value {
             tri!(self
                 .formatter
-                .end_array(&mut self.writer)
+                .begin_array_value(&mut self.writer, first)
                 .map_err(Error::io));
-        } else {
-            let mut state = State::First;
-            for byte in value {
-                tri!(self
-                    .formatter
-                    .begin_array_value(&mut self.writer, state == State::First)
-                    .map_err(Error::io));
-                state = State::Rest;
-                tri!(byte.serialize(&mut *self));
-                tri!(self
-                    .formatter
-                    .end_array_value(&mut self.writer)
-                    .map_err(Error::io));
-            }
+            tri!(byte.serialize(&mut *self));
             tri!(self
                 .formatter
-                .end_array(&mut self.writer)
+                .end_array_value(&mut self.writer)
                 .map_err(Error::io));
+            first = false;
         }
-        Ok(())
+        self.formatter
+            .end_array(&mut self.writer)
+            .map_err(Error::io)
     }
 
     #[inline]

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -198,7 +198,7 @@ where
                 .formatter
                 .begin_array_value(&mut self.writer, first)
                 .map_err(Error::io));
-            tri!(byte.serialize(&mut *self));
+            tri!(self.serialize_u8(*byte));
             tri!(self
                 .formatter
                 .end_array_value(&mut self.writer)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -187,29 +187,10 @@ where
         format_escaped_str(&mut self.writer, &mut self.formatter, value).map_err(Error::io)
     }
 
+    #[inline]
     fn serialize_bytes(self, value: &[u8]) -> Result<()> {
-        tri!(self
-            .formatter
-            .begin_array(&mut self.writer)
-            .map_err(Error::io));
-        let mut first = true;
-        for byte in value {
-            tri!(self
-                .formatter
-                .begin_array_value(&mut self.writer, first)
-                .map_err(Error::io));
-            tri!(self
-                .formatter
-                .write_u8(&mut self.writer, *byte)
-                .map_err(Error::io));
-            tri!(self
-                .formatter
-                .end_array_value(&mut self.writer)
-                .map_err(Error::io));
-            first = false;
-        }
         self.formatter
-            .end_array(&mut self.writer)
+            .write_byte_array(&mut self.writer, value)
             .map_err(Error::io)
     }
 
@@ -1784,6 +1765,24 @@ pub trait Formatter {
         };
 
         writer.write_all(s)
+    }
+
+    /// Writes the representation of a byte array. Formatters can choose whether
+    /// to represent bytes as a JSON array of integers (the default), or some
+    /// JSON string encoding like hex or base64.
+    fn write_byte_array<W>(&mut self, writer: &mut W, value: &[u8]) -> io::Result<()>
+    where
+        W: ?Sized + io::Write,
+    {
+        tri!(self.begin_array(writer));
+        let mut first = true;
+        for byte in value {
+            tri!(self.begin_array_value(writer, first));
+            tri!(self.write_u8(writer, *byte));
+            tri!(self.end_array_value(writer));
+            first = false;
+        }
+        self.end_array(writer)
     }
 
     /// Called before every array.  Writes a `[` to the specified

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -198,7 +198,10 @@ where
                 .formatter
                 .begin_array_value(&mut self.writer, first)
                 .map_err(Error::io));
-            tri!(self.serialize_u8(*byte));
+            tri!(self
+                .formatter
+                .write_u8(&mut self.writer, *byte)
+                .map_err(Error::io));
             tri!(self
                 .formatter
                 .end_array_value(&mut self.writer)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -188,20 +188,15 @@ where
     }
 
     fn serialize_bytes(self, value: &[u8]) -> Result<()> {
-        use serde::ser::SerializeSeq;
         tri!(self
             .formatter
             .begin_array(&mut self.writer)
             .map_err(Error::io));
-        let seq = if value.is_empty() {
+        if value.is_empty() {
             tri!(self
                 .formatter
                 .end_array(&mut self.writer)
                 .map_err(Error::io));
-            Compound::Map {
-                ser: self,
-                state: State::Empty,
-            }
         } else {
             let mut state = State::First;
             for byte in value {
@@ -216,9 +211,12 @@ where
                     .end_array_value(&mut self.writer)
                     .map_err(Error::io));
             }
-            Compound::Map { ser: self, state }
-        };
-        seq.end()
+            tri!(self
+                .formatter
+                .end_array(&mut self.writer)
+                .map_err(Error::io));
+        }
+        Ok(())
     }
 
     #[inline]


### PR DESCRIPTION
Example that writes bytes as base64 JSON strings:

```rust
// [dependencies]
// base64 = "0.21"
// serde = { version = "1", features = ["derive"] }
// serde_bytes = "0.11"
// serde_json = "1"

use serde::Serialize;
use std::io::{self, Write};

#[derive(Serialize)]
struct Struct {
    #[serde(with = "serde_bytes")]
    buf: Vec<u8>,
}

struct Base64Formatter;

impl serde_json::ser::Formatter for Base64Formatter {
    fn write_byte_array<W>(&mut self, writer: &mut W, value: &[u8]) -> io::Result<()>
    where
        W: ?Sized + io::Write,
    {
        writer.write_all(b"\"")?;
        let engine = &base64::engine::general_purpose::STANDARD_NO_PAD;
        let mut encoder = base64::write::EncoderWriter::new(writer, engine);
        encoder.write_all(value)?;
        let writer = encoder.finish()?;
        writer.write_all(b"\"")
    }
}

fn main() -> serde_json::Result<()> {
    let thing = Struct {
        buf: b".....\xed..\x1e\n.".to_vec(),
    };

    let out = io::stdout();
    let mut ser = serde_json::Serializer::with_formatter(out, Base64Formatter);
    thing.serialize(&mut ser)?;
    Ok(())
}
```

```json
{"buf":"Li4uLi7tLi4eCi4"}
```