### PR TITLE
Do not discard byte that is not `\`

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -888,7 +888,6 @@ fn parse_escape<'de, R: Read<'de>>(
                         read.discard();
                     } else {
                         return if validate {
-                            read.discard();
                             error(read, ErrorCode::UnexpectedEndOfHexEscape)
                         } else {
                             encode_surrogate(scratch, n1);


### PR DESCRIPTION
When parsing escaped utf-16 surrogates, they must be in the form `\uHHHH\uLLLL` for high and low surrogates, respectively. If the character following the last `H` is not `\`, then the parse is invalid.

In that case, do not consume the character that is not `\`. In this implementation, this bug is of no consequence because the invalid parse results in an error that is returned to the caller. However, `serde_json_lenient` can optionally replace the invalid character with REPLACEMENT CHARACTER, in which case it is important to account for consumed and unconsumed bytes correctly.

This mirrors the fix in
https://github.com/google/serde_json_lenient/pull/12.

This continues to pass all tests. I have not added any new tests since the incorrect behavior has no external effect.