### PR TITLE
adds `as_str` to `Number` if `arbitrary_precision` is enabled

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -283,9 +283,18 @@ impl Number {
     /// Returns the `&str` representation of the `Number`.
     /// ```
     /// # use serde_json::Number;
-    ///
-    /// assert_eq!(Number::from_f64(256.0).unwrap().as_str(), "256.0");
-    /// assert_eq!(Number::from_f64(34.0).unwrap().as_str(), "34.0");
+    /// for value in [
+    ///     "7",
+    ///     "12.34",
+    ///     "34e-56789",
+    ///     "0.0123456789000000012345678900000001234567890000123456789",
+    ///     "343412345678910111213141516171819202122232425262728293034",
+    ///     "-343412345678910111213141516171819202122232425262728293031",
+    /// ] {
+    ///     println!("{value}");
+    ///     let number: Number = serde_json::from_str(value).unwrap();
+    ///     assert_eq!(number.as_str(), value);
+    /// }
     pub fn as_str(&self) -> &str {
         &self.n
     }

--- a/src/number.rs
+++ b/src/number.rs
@@ -291,7 +291,6 @@ impl Number {
     ///     "343412345678910111213141516171819202122232425262728293034",
     ///     "-343412345678910111213141516171819202122232425262728293031",
     /// ] {
-    ///     println!("{value}");
     ///     let number: Number = serde_json::from_str(value).unwrap();
     ///     assert_eq!(number.as_str(), value);
     /// }

--- a/src/number.rs
+++ b/src/number.rs
@@ -279,6 +279,7 @@ impl Number {
         }
     }
 
+    #[cfg(feature = "arbitrary_precision")]
     /// Returns the `&str` representation of the `Number`.
     /// ```
     /// # use serde_json::Number;

--- a/src/number.rs
+++ b/src/number.rs
@@ -279,6 +279,16 @@ impl Number {
         }
     }
 
+    /// Returns the `&str` representation of the `Number`.
+    /// ```
+    /// # use serde_json::Number;
+    ///
+    /// assert_eq!(Number::from_f64(256.0).unwrap().as_str(), "256.0");
+    /// assert_eq!(Number::from_f64(34.0).unwrap().as_str(), "34.0");
+    pub fn as_str(&self) -> &str {
+        &self.n
+    }
+
     pub(crate) fn as_f32(&self) -> Option<f32> {
         #[cfg(not(feature = "arbitrary_precision"))]
         match self.n {


### PR DESCRIPTION
Resolves #1066 by adding `as_str` to `Number` if `arbitrary_precision` is enabled.

I'm sorry this is a silly question but where should I put tests for the method?