### PR TITLE
adds `as_number` to `Value`

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -495,6 +495,34 @@ impl Value {
         }
     }
 
+    /// If the `Value` is an Number, returns the associated [`Number`]. Returns None
+    /// otherwise.
+    ///
+    /// ```
+    /// # use serde_json::{json, Number};
+    /// #
+    /// let v = json!({ "a": 1, "b": 2.2, "c": -3, "d": "4" });
+    ///
+    /// // The number `1` is an u64.
+    /// assert_eq!(v["a"].as_number().unwrap(), &Number::from(1u64));
+    ///
+    /// // The number `2.2` is an f64.
+    /// assert_eq!(v["b"].as_number().unwrap(), &Number::from_f64(2.2f64).unwrap());
+    ///
+    /// // The number `-3` is an i64.
+    /// assert_eq!(v["c"].as_number().unwrap(), &Number::from(-3i64));
+    ///
+    /// // The string `"4"` is not a number.
+    /// assert_eq!(v["d"].as_number(), None);
+    ///  
+    /// ```
+    pub fn as_number(&self) -> Option<&Number> {
+        match self {
+            Value::Number(number) => Some(number),
+            _ => None,
+        }
+    }
+
     /// Returns true if the `Value` is a Number. Returns false otherwise.
     ///
     /// ```

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -504,13 +504,13 @@ impl Value {
     /// let v = json!({ "a": 1, "b": 2.2, "c": -3, "d": "4" });
     ///
     /// // The number `1` is an u64.
-    /// assert_eq!(v["a"].as_number().unwrap(), &Number::from(1u64));
+    /// assert_eq!(v["a"].as_number(), Some(&Number::from(1u64)));
     ///
     /// // The number `2.2` is an f64.
-    /// assert_eq!(v["b"].as_number().unwrap(), &Number::from_f64(2.2).unwrap());
+    /// assert_eq!(v["b"].as_number(), Some(&Number::from_f64(2.2).unwrap()));
     ///
     /// // The number `-3` is an i64.
-    /// assert_eq!(v["c"].as_number().unwrap(), &Number::from(-3i64));
+    /// assert_eq!(v["c"].as_number(), Some(&Number::from(-3i64)));
     ///
     /// // The string `"4"` is not a number.
     /// assert_eq!(v["d"].as_number(), None);

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -507,7 +507,7 @@ impl Value {
     /// assert_eq!(v["a"].as_number().unwrap(), &Number::from(1u64));
     ///
     /// // The number `2.2` is an f64.
-    /// assert_eq!(v["b"].as_number().unwrap(), &Number::from_f64(2.2f64).unwrap());
+    /// assert_eq!(v["b"].as_number().unwrap(), &Number::from_f64(2.2).unwrap());
     ///
     /// // The number `-3` is an i64.
     /// assert_eq!(v["c"].as_number().unwrap(), &Number::from(-3i64));


### PR DESCRIPTION
Resolves #1068 by adding `as_number` to `Value`.