### PR TITLE
Feat/allow generic v to be arbitrary struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
 categories = ["encoding", "parser-implementations", "no-std"]
 description = "A JSON serialization file format"

--- a/src/map.rs
+++ b/src/map.rs
@@ -491,7 +491,9 @@ impl<'a, V> Entry<'a, V> {
     /// # Examples
     ///
     /// ```
-    /// let mut map = serde_json::Map::new();
+    /// use serde_json::Value;
+    ///
+    /// let mut map = serde_json::Map::<String, Value>::new();
     /// assert_eq!(map.entry("serde").key(), &"serde");
     /// ```
     pub fn key(&self) -> &String {
@@ -588,8 +590,9 @@ impl<'a, V> VacantEntry<'a, V> {
     ///
     /// ```
     /// use serde_json::map::Entry;
+    /// use serde_json::Value;
     ///
-    /// let mut map = serde_json::Map::new();
+    /// let mut map = serde_json::Map::<String, Value>::new();
     ///
     /// match map.entry("serde") {
     ///     Entry::Vacant(vacant) => {


### PR DESCRIPTION
Hey everyone!

Currently I am finding myself having to deserialize a JSON that might have ***N*** number of arbitrarily  named properties. It is +/- as follows:

```json
{
    "headers": {
        "FirstArbitraryObject": {
            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0",
            "Id": 64
        },
        "SecondAnyGivenObject": {
            "User-Agent": "NULL",
            "Id": 0
        }
    }
}
```

Where in this case I wrote only two objects for brevity's sake. In this scenario I have not a list of objects, but a outer object with unknown size.

And each object follows a specific contract (data structure), though some properties might be optional. Considering this, I wanted to define my data structs as follows:

```rust
#[derive(Serialize, Deserialize, Debug, Default, PartialEq)]
struct ArbitraryContent {
    #[serde(rename = "User-Agent")]
    pub user_agent: String,
    #[serde(rename = "Id")]
    pub id: u64,
}

#[derive(Serialize, Deserialize)]
struct ArbitraryBody {
    pub headers: Map<String, ArbitraryContent>,
}
```

<details> 
  <summary>But this way, in the current `master` branch, pointing to commit `39f5ad1`, I get the errors inside this spoiler dropdown:</summary>

---

```sh
error[E0277]: the trait bound `serde_json::Map<std::string::String, ArbitraryContent>: Serialize` is not satisfied
    --> wks/rest_api/tests/http_requests_tests.rs:92:10
     |
92   | #[derive(Serialize, Deserialize)]
     |          ^^^^^^^^^ the trait `Serialize` is not implemented for `serde_json::Map<std::string::String, ArbitraryContent>`
93   | struct ArbitraryBody {
94   |     pub headers: Map<String, ArbitraryContent>,
     |     --- required by a bound introduced by this call
     |
     = help: the trait `Serialize` is implemented for `serde_json::Map<std::string::String, Value>`
note: required by a bound in `_::_serde::ser::SerializeStruct::serialize_field`
    --> /home/rafaell/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.189/src/ser/mod.rs:1865:12
     |
1859 |     fn serialize_field<T: ?Sized>(
     |        --------------- required by a bound in this associated function
...
1865 |         T: Serialize;
     |            ^^^^^^^^^ required by this bound in `SerializeStruct::serialize_field`
```

```sh
error[E0277]: the trait bound `serde_json::Map<std::string::String, ArbitraryContent>: Deserialize<'_>` is not satisfied
    --> wks/rest_api/tests/http_requests_tests.rs:94:18
     |
94   |     pub headers: Map<String, ArbitraryContent>,
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `serde_json::Map<std::string::String, ArbitraryContent>`
     |
     = help: the trait `Deserialize<'de>` is implemented for `serde_json::Map<std::string::String, Value>`
note: required by a bound in `next_element`
    --> /home/rafaell/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.189/src/de/mod.rs:1724:12
     |
1722 |     fn next_element<T>(&mut self) -> Result<Option<T>, Self::Error>
     |        ------------ required by a bound in this associated function
1723 |     where
1724 |         T: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `SeqAccess::next_element`
```

```sh
error[E0277]: the trait bound `serde_json::Map<std::string::String, ArbitraryContent>: Deserialize<'_>` is not satisfied
    --> wks/rest_api/tests/http_requests_tests.rs:94:18
     |
94   |     pub headers: Map<String, ArbitraryContent>,
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Deserialize<'_>` is not implemented for `serde_json::Map<std::string::String, ArbitraryContent>`
     |
     = help: the trait `Deserialize<'de>` is implemented for `serde_json::Map<std::string::String, Value>`
note: required by a bound in `next_value`
    --> /home/rafaell/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.189/src/de/mod.rs:1863:12
     |
1861 |     fn next_value<V>(&mut self) -> Result<V, Self::Error>
     |        ---------- required by a bound in this associated function
1862 |     where
1863 |         V: Deserialize<'de>,
     |            ^^^^^^^^^^^^^^^^ required by this bound in `MapAccess::next_value`
```

```sh
error[E0277]: the trait bound `serde_json::Map<std::string::String, ArbitraryContent>: Deserialize<'_>` is not satisfied
  --> wks/rest_api/tests/http_requests_tests.rs:94:5
   |
94 |     pub headers: Map<String, ArbitraryContent>,
   |     ^^^ the trait `Deserialize<'_>` is not implemented for `serde_json::Map<std::string::String, ArbitraryContent>`
   |
   = help: the trait `Deserialize<'de>` is implemented for `serde_json::Map<std::string::String, Value>`
note: required by a bound in `_::_serde::__private::de::missing_field`
  --> /home/rafaell/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.189/src/private/de.rs:25:8
   |
23 | pub fn missing_field<'de, V, E>(field: &'static str) -> Result<V, E>
   |        ------------- required by a bound in this function
24 | where
25 |     V: Deserialize<'de>,
   |        ^^^^^^^^^^^^^^^^ required by this bound in `missing_field`
```

---

</details>

By looking at the `Map<K, V>` definition I see that every implementation of this generic struct considers the specific case where `Map<String, Value>`. So it does not care if a given user struct implements the `Deserialize` trait.

On the other hand, I believe every serde user should not [implement a custom map](https://serde.rs/deserialize-map.html) to make it work with a custom object/struct that implements the `Deserialize` trait. For two main reasons:
 - It does not make justice to the good work implementations of `Map<K, V>`;
 - It is relatively simple to make `V` generic;
 - It is responsibility of `Map<K, V>` to accept any given `V` that implements `Serialize` and `Deserialize`.

Considering this I am bringing this PR where I generalized all the `Map<K, V>` implementations. Here are the unit test that I ran with this implementation:

```rust
#[test]
fn test() {
    let body = r#"
    {
        "headers": {
            "FirstArbitraryObject": {
                "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0",
                "Id": 64
            },
            "SecondAnyGivenObject": {
                "User-Agent": "NULL",
                "Id": 0
            }
        }
    }
    "#;

    let arbitrary_body = serde_json::from_str::<ArbitraryBody>(body).unwrap();

    assert_eq!(
        arbitrary_body.headers["FirstArbitraryObject"].type_id(),
        ArbitraryContent::default().type_id()
    );
    assert_eq!(
        arbitrary_body.headers["FirstArbitraryObject"],
        ArbitraryContent {
            user_agent:
                "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/118.0"
                    .parse()
                    .unwrap(),
            id: 64
        }
    );
    assert_eq!(
        arbitrary_body.headers["SecondAnyGivenObject"],
        ArbitraryContent {
            user_agent: "NULL".to_string(),
            id: 0
        }
    );
}
```

For facilitate the reviewers life, here are the dependency pointing to the implementation, or current `master` on my fork:

```toml
[dependencies]
serde_json = { git = "https://github.com/Azgrom/serde_json.git", branch = "master" }#branch = "feat/allow-generic-V-to-be-arbitrary-struct" }
```

---
All tests passed