### PR TITLE
Resolve manual_hash_one lint in test

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2492,15 +2492,14 @@ fn test_value_into_deserializer() {
 #[test]
 fn hash_positive_and_negative_zero() {
     let rand = std::hash::RandomState::new();
-    let hash = |obj| rand.hash_one(obj);
 
     let k1 = serde_json::from_str::<Number>("0.0").unwrap();
     let k2 = serde_json::from_str::<Number>("-0.0").unwrap();
     if cfg!(feature = "arbitrary_precision") {
         assert_ne!(k1, k2);
-        assert_ne!(hash(k1), hash(k2));
+        assert_ne!(rand.hash_one(k1), rand.hash_one(k2));
     } else {
         assert_eq!(k1, k2);
-        assert_eq!(hash(k1), hash(k2));
+        assert_eq!(rand.hash_one(k1), rand.hash_one(k2));
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -30,12 +30,11 @@ use serde_json::{
     from_reader, from_slice, from_str, from_value, json, to_string, to_string_pretty, to_value,
     to_vec, Deserializer, Number, Value,
 };
-use std::collections::hash_map::DefaultHasher;
 use std::collections::BTreeMap;
 #[cfg(feature = "raw_value")]
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
-use std::hash::{Hash, Hasher};
+use std::hash::{BuildHasher, Hash, Hasher};
 use std::io;
 use std::iter;
 use std::marker::PhantomData;
@@ -2490,11 +2489,12 @@ fn test_value_into_deserializer() {
 
 #[test]
 fn hash_positive_and_negative_zero() {
-    fn hash(obj: impl Hash) -> u64 {
-        let mut hasher = DefaultHasher::new();
+    let rand = std::hash::RandomState::new();
+    let hash = |obj: Number| -> u64 {
+        let mut hasher = rand.build_hasher();
         obj.hash(&mut hasher);
         hasher.finish()
-    }
+    };
 
     let k1 = serde_json::from_str::<Number>("0.0").unwrap();
     let k2 = serde_json::from_str::<Number>("-0.0").unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -34,7 +34,9 @@ use std::collections::BTreeMap;
 #[cfg(feature = "raw_value")]
 use std::collections::HashMap;
 use std::fmt::{self, Debug};
-use std::hash::{BuildHasher, Hash, Hasher};
+use std::hash::BuildHasher;
+#[cfg(feature = "raw_value")]
+use std::hash::{Hash, Hasher};
 use std::io;
 use std::iter;
 use std::marker::PhantomData;
@@ -2490,11 +2492,7 @@ fn test_value_into_deserializer() {
 #[test]
 fn hash_positive_and_negative_zero() {
     let rand = std::hash::RandomState::new();
-    let hash = |obj: Number| -> u64 {
-        let mut hasher = rand.build_hasher();
-        obj.hash(&mut hasher);
-        hasher.finish()
-    };
+    let hash = |obj| rand.hash_one(obj);
 
     let k1 = serde_json::from_str::<Number>("0.0").unwrap();
     let k2 = serde_json::from_str::<Number>("-0.0").unwrap();


### PR DESCRIPTION
New clippy lint from Rust 1.75: https://rust-lang.github.io/rust-clippy/rust-1.75.0/index.html#/manual_hash_one