### PR TITLE
Restore doc cfg on re-exports

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -22,6 +22,7 @@ use crate::number::NumberDeserializer;
 pub use crate::read::{Read, SliceRead, StrRead};
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub use crate::read::IoRead;
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,6 +365,7 @@
 extern crate alloc;
 
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[doc(inline)]
 pub use crate::de::from_reader;
 #[doc(inline)]
@@ -374,6 +375,7 @@ pub use crate::error::{Error, Result};
 #[doc(inline)]
 pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty};
 #[cfg(feature = "std")]
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[doc(inline)]
 pub use crate::ser::{to_writer, to_writer_pretty, Serializer};
 #[doc(inline)]

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -106,6 +106,7 @@ pub use crate::map::Map;
 pub use crate::number::Number;
 
 #[cfg(feature = "raw_value")]
+#[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 pub use crate::raw::{to_raw_value, RawValue};
 
 /// Represents any valid JSON value.


### PR DESCRIPTION
This regressed with https://github.com/rust-lang/rust/pull/113091 in nightly-2023-12-16. The doc(cfg()) from the type definition is no longer rendered.