### PR TITLE
[Deserialize] Split out peek logic from seed generic

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1192,8 +1192,8 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                     Some(_) => {
                         if accept_comma {
                             return Err(self.peek_error(match frame {
-                                b'[' => ErrorCode::ExpectedNextOrEnd { end: b'[' },
-                                b'{' => ErrorCode::ExpectedNextOrEnd { end: b'{' },
+                                b'[' => ErrorCode::ExpectedNextOrEnd { end: b']' },
+                                b'{' => ErrorCode::ExpectedNextOrEnd { end: b'}' },
                                 _ => unreachable!(),
                             }));
                         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,8 +60,7 @@ impl Error {
             | ErrorCode::EofWhileParsingString
             | ErrorCode::EofWhileParsingValue => Category::Eof,
             ErrorCode::ExpectedColon
-            | ErrorCode::ExpectedListCommaOrEnd
-            | ErrorCode::ExpectedObjectCommaOrEnd
+            | ErrorCode::ExpectedNextOrEnd { .. }
             | ErrorCode::ExpectedSomeIdent
             | ErrorCode::ExpectedSomeValue
             | ErrorCode::ExpectedDoubleQuote
@@ -255,11 +254,8 @@ pub(crate) enum ErrorCode {
     /// Expected this character to be a `':'`.
     ExpectedColon,
 
-    /// Expected this character to be either a `','` or a `']'`.
-    ExpectedListCommaOrEnd,
-
-    /// Expected this character to be either a `','` or a `'}'`.
-    ExpectedObjectCommaOrEnd,
+    /// Expected this character to be either ',' or end.
+    ExpectedNextOrEnd { end: u8 },
 
     /// Expected to parse either a `true`, `false`, or a `null`.
     ExpectedSomeIdent,
@@ -356,8 +352,9 @@ impl Display for ErrorCode {
             ErrorCode::EofWhileParsingString => f.write_str("EOF while parsing a string"),
             ErrorCode::EofWhileParsingValue => f.write_str("EOF while parsing a value"),
             ErrorCode::ExpectedColon => f.write_str("expected `:`"),
-            ErrorCode::ExpectedListCommaOrEnd => f.write_str("expected `,` or `]`"),
-            ErrorCode::ExpectedObjectCommaOrEnd => f.write_str("expected `,` or `}`"),
+            ErrorCode::ExpectedNextOrEnd { end } => {
+                write!(f, "expected `,` or `{}`", *end as char)
+            }
             ErrorCode::ExpectedSomeIdent => f.write_str("expected ident"),
             ErrorCode::ExpectedSomeValue => f.write_str("expected value"),
             ErrorCode::ExpectedDoubleQuote => f.write_str("expected `\"`"),


### PR DESCRIPTION
Splits duplicated and somewhat complex logic depending on two generics (`Read` and `seed`) into only depending on one generic (`Read`) cutting debug mode llvm-lines output on my program by:
- `SeqAccess::next_element_seed`: 34232 -> 21752
- `MapAccess::next_key_seed`: 11225 -> 6722