### PR TITLE
fix: Correct spelling error

### DIFF
--- a/src/lexical/num.rs
+++ b/src/lexical/num.rs
@@ -223,7 +223,7 @@ pub trait Float: Number {
     const NEGATIVE_INFINITY_BITS: Self::Unsigned;
     /// Size of the significand (mantissa) without hidden bit.
     const MANTISSA_SIZE: i32;
-    /// Bias of the exponet
+    /// Bias of the exponent
     const EXPONENT_BIAS: i32;
     /// Exponent portion of a denormal float.
     const DENORMAL_EXPONENT: i32;


### PR DESCRIPTION
fix: Correct the only spelling error

After scanning the entire repository, I discovered the only spelling error and fixed it.

- Changed "exponet" to "exponent"
