### PR TITLE
Format f64 in error messages using ryu

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -466,10 +466,14 @@ struct JsonUnexpected<'a>(de::Unexpected<'a>);
 
 impl<'a> Display for JsonUnexpected<'a> {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        if let de::Unexpected::Unit = self.0 {
-            formatter.write_str("null")
-        } else {
-            Display::fmt(&self.0, formatter)
+        match self.0 {
+            de::Unexpected::Unit => formatter.write_str("null"),
+            de::Unexpected::Float(value) => write!(
+                formatter,
+                "floating point `{}`",
+                ryu::Buffer::new().format(value),
+            ),
+            unexp => Display::fmt(&unexp, formatter),
         }
     }
 }


### PR DESCRIPTION
This produces a more readable representation using exponential notation for values that might be hundreds of digits when formatted by std::fmt.

It also includes trailing `.0` on integer values (https://github.com/serde-rs/serde/pull/2679).