### PR TITLE
Fix missing backtick in doc comments letting markdown think &[u8] is a link to u8

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ enum Value {
 
 A string of JSON data can be parsed into a `serde_json::Value` by the
 [`serde_json::from_str`][from_str] function. There is also
-[`from_slice`][from_slice] for parsing from a byte slice &\[u8\] and
+[`from_slice`][from_slice] for parsing from a byte slice `&[u8]` and
 [`from_reader`][from_reader] for parsing from any `io::Read` like a File or a
 TCP stream.
 

--- a/src/lexical/large_powers32.rs
+++ b/src/lexical/large_powers32.rs
@@ -2,7 +2,7 @@
 
 //! Precalculated large powers for 32-bit limbs.
 
-/// Large powers (&[u32]) for base5 operations.
+/// Large powers (`&[u32]`) for base5 operations.
 const POW5_1: [u32; 1] = [5];
 const POW5_2: [u32; 1] = [25];
 const POW5_3: [u32; 1] = [625];

--- a/src/lexical/large_powers64.rs
+++ b/src/lexical/large_powers64.rs
@@ -2,7 +2,7 @@
 
 //! Precalculated large powers for 64-bit limbs.
 
-/// Large powers (&[u64]) for base5 operations.
+/// Large powers (`&[u64]`) for base5 operations.
 const POW5_1: [u64; 1] = [5];
 const POW5_2: [u64; 1] = [25];
 const POW5_3: [u64; 1] = [625];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //!
 //! A string of JSON data can be parsed into a `serde_json::Value` by the
 //! [`serde_json::from_str`][from_str] function. There is also [`from_slice`]
-//! for parsing from a byte slice &\[u8\] and [`from_reader`] for parsing from
+//! for parsing from a byte slice `&[u8]` and [`from_reader`] for parsing from
 //! any `io::Read` like a File or a TCP stream.
 //!
 //! ```

--- a/src/read.rs
+++ b/src/read.rs
@@ -20,7 +20,7 @@ use alloc::string::String;
 use serde::de::Visitor;
 
 /// Trait used by the deserializer for iterating over input. This is manually
-/// "specialized" for iterating over &[u8]. Once feature(specialization) is
+/// "specialized" for iterating over `&[u8]`. Once feature(specialization) is
 /// stable we can use actual specialization.
 ///
 /// This trait is sealed and cannot be implemented for types outside of


### PR DESCRIPTION
While reading the documentation/the source code (for the purpose of creating my own `Deserializer` for a different format) I found that in [`serde_json::de::Read`](https://docs.rs/serde_json/latest/serde_json/de/trait.Read.html) `&[u8]` was rendered incorrectly.

So I did a quick `grep` and fixed all I could find by adding backticks.

I also switching the `&[u8]` in the `README.md`/`src/lib.rs` from escapes to backticks for consistency sake. \
(I assume the `README.md` was generated from the `src/lib.rs` with some tool, but if both are changed the same way, it should still be consistent with the output.)