### PR TITLE
Make all serialization functions available for no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ indexmap = { version = "2.2.1", optional = true }
 itoa = "1.0"
 ryu = "1.0"
 serde = { version = "1.0.194", default-features = false }
+core2 = { version = "0.4", optional = true }
 
 [dev-dependencies]
 automod = "1.0.11"
@@ -39,6 +40,9 @@ rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 [package.metadata.playground]
 features = ["raw_value"]
 
+[[example]]
+name = "test"
+required-features = ["use-core2"]
 
 ### FEATURES #################################################################
 
@@ -86,3 +90,5 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+use-core2 = ["core2"]

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -2,26 +2,29 @@
 //! Run via:
 //!
 //! ```sh
-//! cargo run --example test
-//! cargo run --example test --features alloc --no-default-features
+//! cargo run --example test --features use-core2
+//! cargo run --example test --features alloc,use-core2 --no-default-features
 //! ```
 
 
-use serde_json::io::{Write, Result, Error, ErrorKind};
+use serde_json::alloc_io::{Write, Result, Error, ErrorKind};
 
-struct X {
-}
 
-impl Write for X {
-	fn write(&mut self, _buf: &[u8]) -> Result<usize> {
-		Ok(0)
-	}
+struct Buffer {}
 
+impl Write for Buffer {
+	fn write(&mut self, _bytes: &[u8]) -> Result<usize> { panic!() }
 	fn flush(&mut self) -> Result<()> {
 		Err(Error::new(ErrorKind::Other, "flush not implemented"))
 	}
 }
 
+impl core2::io::Write for Buffer {
+	fn write(&mut self, _bytes: &[u8]) -> core2::io::Result<usize> { panic!() }
+	fn flush(&mut self) -> core2::io::Result<()> { panic!() }
+}
+
 fn main() {
-	let _x = &mut X{} as &mut dyn Write;
+	println!("Hello, world!");
+	let _x = &mut Buffer {} as &mut dyn Write;
 }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,0 +1,27 @@
+//! Tests feature unification
+//! Run via:
+//!
+//! ```sh
+//! cargo run --example test
+//! cargo run --example test --features alloc --no-default-features
+//! ```
+
+
+use serde_json::io::{Write, Result, Error};
+
+struct X {
+}
+
+impl Write for X {
+	fn write(&mut self, _buf: &[u8]) -> Result<usize> {
+		Ok(0)
+	}
+
+	fn flush(&mut self) -> Result<()> {
+		Err(Error {})
+	}
+}
+
+fn main() {
+	let _x = &mut X{} as &mut dyn Write;
+}

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -7,7 +7,7 @@
 //! ```
 
 
-use serde_json::io::{Write, Result, Error};
+use serde_json::io::{Write, Result, Error, ErrorKind};
 
 struct X {
 }
@@ -18,7 +18,7 @@ impl Write for X {
 	}
 
 	fn flush(&mut self) -> Result<()> {
-		Err(Error {})
+		Err(Error::new(ErrorKind::Other, "flush not implemented"))
 	}
 }
 

--- a/src/io/core.rs
+++ b/src/io/core.rs
@@ -5,10 +5,13 @@ use alloc::vec::Vec;
 use core::fmt::{self, Display};
 use core::result;
 
+/// see [`std::io::ErrorKind`]
 pub enum ErrorKind {
+    /// see [`std::io::ErrorKind::Other`]
     Other,
 }
 
+/// see [`std::io::Error`]
 // I/O errors can never occur in no-std mode. All our no-std I/O implementations
 // are infallible.
 pub struct Error;
@@ -25,11 +28,15 @@ impl Error {
     }
 }
 
+/// see [`std::io::Result`]
 pub type Result<T> = result::Result<T, Error>;
 
+/// see [`std::io::Write`]
 pub trait Write {
+    /// see [`std::io::Write::write`]
     fn write(&mut self, buf: &[u8]) -> Result<usize>;
 
+    /// see [`std::io::Write::write_all`]
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         // All our Write impls in no_std mode always write the whole buffer in
         // one call infallibly.
@@ -39,6 +46,7 @@ pub trait Write {
         Ok(())
     }
 
+    /// see [`std::io::Write::flush`]
     fn flush(&mut self) -> Result<()>;
 }
 

--- a/src/io/core.rs
+++ b/src/io/core.rs
@@ -14,7 +14,9 @@ pub enum ErrorKind {
 /// see [`std::io::Error`]
 // I/O errors can never occur in no-std mode. All our no-std I/O implementations
 // are infallible.
-pub struct Error;
+pub struct Error {
+    _priv: (),
+}
 
 impl Display for Error {
     fn fmt(&self, _formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -23,8 +25,9 @@ impl Display for Error {
 }
 
 impl Error {
-    pub(crate) fn new(_kind: ErrorKind, _error: &'static str) -> Error {
-        Error
+    /// see [`std::io::Error::new`]
+    pub fn new(_kind: ErrorKind, _error: &'static str) -> Error {
+        Error(())
     }
 }
 

--- a/src/io/core.rs
+++ b/src/io/core.rs
@@ -27,7 +27,7 @@ impl Display for Error {
 impl Error {
     /// see [`std::io::Error::new`]
     pub fn new(_kind: ErrorKind, _error: &'static str) -> Error {
-        Error(())
+        Error { _priv: () }
     }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -9,9 +9,11 @@
 
 pub use self::imp::{Error, ErrorKind, Result, Write};
 
+// no-std implementation
+pub mod core;
+
 #[cfg(not(feature = "std"))]
-#[path = "core.rs"]
-mod imp;
+use core as imp;
 
 #[cfg(feature = "std")]
 use std::io as imp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,8 @@ pub mod value;
 
 mod features_check;
 
-pub mod io;
+pub use io::core as alloc_io;
+mod io;
 #[cfg(feature = "std")]
 mod iter;
 #[cfg(feature = "float_roundtrip")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,11 +377,7 @@ pub use crate::de::{from_slice, from_str, Deserializer, StreamDeserializer};
 #[doc(inline)]
 pub use crate::error::{Error, Result};
 #[doc(inline)]
-pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty};
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-#[doc(inline)]
-pub use crate::ser::{to_writer, to_writer_pretty, Serializer};
+pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty, to_writer, to_writer_pretty, Serializer};
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Map, Number, Value};
 
@@ -402,16 +398,12 @@ mod macros;
 pub mod de;
 pub mod error;
 pub mod map;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod ser;
-#[cfg(not(feature = "std"))]
-mod ser;
 pub mod value;
 
 mod features_check;
 
-mod io;
+pub mod io;
 #[cfg(feature = "std")]
 mod iter;
 #[cfg(feature = "float_roundtrip")]


### PR DESCRIPTION
We ran into OOMs in a memory constrained no-std environment, when serializing.  We noticed that `to_writer` was not available for no-std, even though there is nothing preventing it from working.

This PR exposes the relevant serialization functions.  It also exposes the crate's no-std io shim, since types from there appears in the `ser` API.

related to #1040 
