### PR TITLE
impl `Hash` for `Value`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -8,6 +8,8 @@
 
 use crate::value::Value;
 use alloc::string::String;
+#[cfg(feature = "preserve_order")]
+use alloc::vec::Vec;
 use core::borrow::Borrow;
 use core::fmt::{self, Debug};
 use core::hash::Hash;
@@ -367,6 +369,23 @@ impl PartialEq for Map<String, Value> {
 }
 
 impl Eq for Map<String, Value> {}
+
+#[cfg(not(feature = "preserve_order"))]
+impl Hash for Map<String, Value> {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.map.hash(state)
+    }
+}
+#[cfg(feature = "preserve_order")]
+impl Hash for Map<String, Value> {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        let mut kv = self.map.iter().collect::<Vec<_>>();
+        kv.sort_unstable_by(|a, b| a.0.cmp(b.0));
+        kv.hash(state);
+    }
+}
 
 /// Access an element of this map. Panics if the given key is not present in the
 /// map.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -112,7 +112,7 @@ pub use crate::raw::{to_raw_value, RawValue};
 /// Represents any valid JSON value.
 ///
 /// See the [`serde_json::value` module documentation](self) for usage examples.
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub enum Value {
     /// Represents a JSON null value.
     ///


### PR DESCRIPTION
`IndexMap` is the only type that is used within `Value` that does not implement `Hash`, and it is by design: https://github.com/indexmap-rs/indexmap/issues/288#issuecomment-1804735361

If "preserve_order" feature is not set, `Value::Object` uses `BTreeMap` instead of `IndexMap` so it is possible to auto-impl `Hash` for `Value`.