### PR TITLE
Change serde_json::from_value to use pass-by-reference

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -987,7 +987,7 @@ where
 ///         "location": "Menlo Park, CA"
 ///     });
 ///
-///     let u: User = serde_json::from_value(&j).unwrap();
+///     let u: User = serde_json::from_value(j).unwrap();
 ///     println!("{:#?}", u);
 /// }
 /// ```
@@ -1001,7 +1001,7 @@ where
 /// is wrong with the data, for example required struct fields are missing from
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
-pub fn from_value<T>(value: &Value) -> Result<T, Error>
+pub fn from_value<T>(value: Value) -> Result<T, Error>
 where
     T: DeserializeOwned,
 {

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -256,6 +256,12 @@ impl Display for Value {
     }
 }
 
+impl AsRef<Value> for Value {
+    fn as_ref(&self) -> &Value {
+        self
+    }
+}
+
 fn parse_index(s: &str) -> Option<usize> {
     if s.starts_with('+') || (s.starts_with('0') && s.len() != 1) {
         return None;
@@ -987,8 +993,13 @@ where
 ///         "location": "Menlo Park, CA"
 ///     });
 ///
-///     let u: User = serde_json::from_value(j).unwrap();
+///     // from_value accepts both reference ...
+///     let u: User = serde_json::from_value(&j).unwrap();
 ///     println!("{:#?}", u);
+///
+///     // ... and moved value
+///     let u2: User = serde_json::from_value(j).unwrap();
+///     println!("{:#?}", u2);
 /// }
 /// ```
 ///
@@ -1001,9 +1012,9 @@ where
 /// is wrong with the data, for example required struct fields are missing from
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
-pub fn from_value<T>(value: Value) -> Result<T, Error>
+pub fn from_value<T, V: AsRef<Value>>(value: V) -> Result<T, Error>
 where
     T: DeserializeOwned,
 {
-    T::deserialize(value)
+    T::deserialize(value.as_ref())
 }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -987,7 +987,7 @@ where
 ///         "location": "Menlo Park, CA"
 ///     });
 ///
-///     let u: User = serde_json::from_value(j).unwrap();
+///     let u: User = serde_json::from_value(&j).unwrap();
 ///     println!("{:#?}", u);
 /// }
 /// ```
@@ -1001,7 +1001,7 @@ where
 /// is wrong with the data, for example required struct fields are missing from
 /// the JSON map or some number is too big to fit in the expected primitive
 /// type.
-pub fn from_value<T>(value: Value) -> Result<T, Error>
+pub fn from_value<T>(value: &Value) -> Result<T, Error>
 where
     T: DeserializeOwned,
 {

--- a/tests/regression/issue520.rs
+++ b/tests/regression/issue520.rs
@@ -12,7 +12,7 @@ enum E {
 fn test() {
     let e = E::Float(159.1);
     let v = serde_json::to_value(e).unwrap();
-    let e = serde_json::from_value::<E>(v).unwrap();
+    let e = serde_json::from_value::<E, serde_json::Value>(v).unwrap();
 
     match e {
         E::Float(f) => assert_eq!(f, 159.1),

--- a/tests/regression/issue520.rs
+++ b/tests/regression/issue520.rs
@@ -12,7 +12,7 @@ enum E {
 fn test() {
     let e = E::Float(159.1);
     let v = serde_json::to_value(e).unwrap();
-    let e = serde_json::from_value::<E>(&v).unwrap();
+    let e = serde_json::from_value::<E>(v).unwrap();
 
     match e {
         E::Float(f) => assert_eq!(f, 159.1),

--- a/tests/regression/issue520.rs
+++ b/tests/regression/issue520.rs
@@ -12,7 +12,7 @@ enum E {
 fn test() {
     let e = E::Float(159.1);
     let v = serde_json::to_value(e).unwrap();
-    let e = serde_json::from_value::<E>(v).unwrap();
+    let e = serde_json::from_value::<E>(&v).unwrap();
 
     match e {
         E::Float(f) => assert_eq!(f, 159.1),

--- a/tests/regression/issue795.rs
+++ b/tests/regression/issue795.rs
@@ -58,5 +58,5 @@ fn test() {
     assert!(serde_json::from_str::<Enum>(s).is_err());
 
     let j = json!({"Variant":{"x":0,"y":0}});
-    assert!(serde_json::from_value::<Enum>(j).is_err());
+    assert!(serde_json::from_value::<Enum, serde_json::Value>(j).is_err());
 }

--- a/tests/regression/issue795.rs
+++ b/tests/regression/issue795.rs
@@ -58,5 +58,5 @@ fn test() {
     assert!(serde_json::from_str::<Enum>(s).is_err());
 
     let j = json!({"Variant":{"x":0,"y":0}});
-    assert!(serde_json::from_value::<Enum>(&j).is_err());
+    assert!(serde_json::from_value::<Enum>(j).is_err());
 }

--- a/tests/regression/issue795.rs
+++ b/tests/regression/issue795.rs
@@ -58,5 +58,5 @@ fn test() {
     assert!(serde_json::from_str::<Enum>(s).is_err());
 
     let j = json!({"Variant":{"x":0,"y":0}});
-    assert!(serde_json::from_value::<Enum>(j).is_err());
+    assert!(serde_json::from_value::<Enum>(&j).is_err());
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2385,7 +2385,7 @@ fn test_boxed_raw_value() {
     assert_eq!(r#"{"foo": 2}"#, wrapper_from_reader.b.get());
 
     let wrapper_from_value: Wrapper =
-        serde_json::from_value(json!({"a": 1, "b": {"foo": 2}, "c": 3})).unwrap();
+        serde_json::from_value(&json!({"a": 1, "b": {"foo": 2}, "c": 3})).unwrap();
     assert_eq!(r#"{"foo":2}"#, wrapper_from_value.b.get());
 
     let wrapper_to_string = serde_json::to_string(&wrapper_from_str).unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -614,11 +614,11 @@ where
         assert_eq!(v, value);
 
         // Make sure we can deserialize from a `Value`.
-        let v: T = from_value(json_value.clone()).unwrap();
+        let v: T = from_value(&json_value).unwrap();
         assert_eq!(v, value);
 
         // Make sure we can round trip back to `Value`.
-        let json_value2: Value = from_value(json_value.clone()).unwrap();
+        let json_value2: Value = from_value(&json_value).unwrap();
         assert_eq!(json_value2, json_value);
 
         // Make sure we can fully ignore.
@@ -1413,10 +1413,10 @@ fn test_missing_option_field() {
     let value: Foo = from_str("{\"x\": 5}").unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 
-    let value: Foo = from_value(json!({})).unwrap();
+    let value: Foo = from_value(&json!({})).unwrap();
     assert_eq!(value, Foo { x: None });
 
-    let value: Foo = from_value(json!({"x": 5})).unwrap();
+    let value: Foo = from_value(&json!({"x": 5})).unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 }
 
@@ -1444,10 +1444,10 @@ fn test_missing_renamed_field() {
     let value: Foo = from_str("{\"y\": 5}").unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 
-    let value: Foo = from_value(json!({})).unwrap();
+    let value: Foo = from_value(&json!({})).unwrap();
     assert_eq!(value, Foo { x: None });
 
-    let value: Foo = from_value(json!({"y": 5})).unwrap();
+    let value: Foo = from_value(&json!({"y": 5})).unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 }
 
@@ -1899,13 +1899,13 @@ fn test_integer_key() {
         (r#"{"123 ":null}"#, "expected `\"` at line 1 column 6"),
     ]);
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({" 123":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(&json!({" 123":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",
     );
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({"123 ":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(&json!({"123 ":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -614,11 +614,11 @@ where
         assert_eq!(v, value);
 
         // Make sure we can deserialize from a `Value`.
-        let v: T = from_value(&json_value).unwrap();
+        let v: T = from_value(json_value.clone()).unwrap();
         assert_eq!(v, value);
 
         // Make sure we can round trip back to `Value`.
-        let json_value2: Value = from_value(&json_value).unwrap();
+        let json_value2: Value = from_value(json_value.clone()).unwrap();
         assert_eq!(json_value2, json_value);
 
         // Make sure we can fully ignore.
@@ -1413,10 +1413,10 @@ fn test_missing_option_field() {
     let value: Foo = from_str("{\"x\": 5}").unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 
-    let value: Foo = from_value(&json!({})).unwrap();
+    let value: Foo = from_value(json!({})).unwrap();
     assert_eq!(value, Foo { x: None });
 
-    let value: Foo = from_value(&json!({"x": 5})).unwrap();
+    let value: Foo = from_value(json!({"x": 5})).unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 }
 
@@ -1444,10 +1444,10 @@ fn test_missing_renamed_field() {
     let value: Foo = from_str("{\"y\": 5}").unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 
-    let value: Foo = from_value(&json!({})).unwrap();
+    let value: Foo = from_value(json!({})).unwrap();
     assert_eq!(value, Foo { x: None });
 
-    let value: Foo = from_value(&json!({"y": 5})).unwrap();
+    let value: Foo = from_value(json!({"y": 5})).unwrap();
     assert_eq!(value, Foo { x: Some(5) });
 }
 
@@ -1899,13 +1899,13 @@ fn test_integer_key() {
         (r#"{"123 ":null}"#, "expected `\"` at line 1 column 6"),
     ]);
 
-    let err = from_value::<BTreeMap<i32, ()>>(&json!({" 123":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(json!({" 123":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",
     );
 
-    let err = from_value::<BTreeMap<i32, ()>>(&json!({"123 ":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>>(json!({"123 ":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2385,7 +2385,7 @@ fn test_boxed_raw_value() {
     assert_eq!(r#"{"foo": 2}"#, wrapper_from_reader.b.get());
 
     let wrapper_from_value: Wrapper =
-        serde_json::from_value(&json!({"a": 1, "b": {"foo": 2}, "c": 3})).unwrap();
+        serde_json::from_value(json!({"a": 1, "b": {"foo": 2}, "c": 3})).unwrap();
     assert_eq!(r#"{"foo":2}"#, wrapper_from_value.b.get());
 
     let wrapper_to_string = serde_json::to_string(&wrapper_from_str).unwrap();

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1899,13 +1899,13 @@ fn test_integer_key() {
         (r#"{"123 ":null}"#, "expected `\"` at line 1 column 6"),
     ]);
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({" 123":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>, Value>(json!({" 123":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",
     );
 
-    let err = from_value::<BTreeMap<i32, ()>>(json!({"123 ":null})).unwrap_err();
+    let err = from_value::<BTreeMap<i32, ()>, Value>(json!({"123 ":null})).unwrap_err();
     assert_eq!(
         err.to_string(),
         "invalid value: expected key to be a number in quotes",


### PR DESCRIPTION
_If the function needs ownership, you should pass by value. If the function only needs a reference, you should pass by reference._

-- https://stackoverflow.com/a/64814149/342293

`from_value` doesn't need to own its parameter, so it should use pass-by-reference.
