### PR TITLE
Implement `Deserializer` for `Map<String, Value>` and `&Map<String, Value>`

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -535,6 +535,22 @@ macro_rules! delegate_iterator {
     }
 }
 
+impl<'de> de::IntoDeserializer<'de, crate::Error> for Map<String, Value> {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
+impl<'de> de::IntoDeserializer<'de, crate::Error> for &'de Map<String, Value> {
+    type Deserializer = Self;
+
+    fn into_deserializer(self) -> Self::Deserializer {
+        self
+    }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 /// A view into a single entry in a map, which may either be vacant or occupied.

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -311,18 +311,17 @@ impl<'de> serde::Deserializer<'de> for Value {
     where
         V: Visitor<'de>,
     {
-        let (variant, value) = match self {
-            Value::Object(value) => return value.deserialize_enum(name, variants, visitor),
-            Value::String(variant) => (variant, None),
-            other => {
-                return Err(serde::de::Error::invalid_type(
-                    other.unexpected(),
-                    &"string or map",
-                ));
-            }
-        };
-
-        visitor.visit_enum(EnumDeserializer { variant, value })
+        match self {
+            Value::Object(value) => value.deserialize_enum(name, variants, visitor),
+            Value::String(variant) => visitor.visit_enum(EnumDeserializer {
+                variant,
+                value: None,
+            }),
+            other => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"string or map",
+            )),
+        }
     }
 
     #[inline]
@@ -843,18 +842,17 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     where
         V: Visitor<'de>,
     {
-        let (variant, value) = match self {
-            Value::Object(value) => return value.deserialize_enum(name, variants, visitor),
-            Value::String(variant) => (variant, None),
-            other => {
-                return Err(serde::de::Error::invalid_type(
-                    other.unexpected(),
-                    &"string or map",
-                ));
-            }
-        };
-
-        visitor.visit_enum(EnumRefDeserializer { variant, value })
+        match self {
+            Value::Object(value) => value.deserialize_enum(name, variants, visitor),
+            Value::String(variant) => visitor.visit_enum(EnumRefDeserializer {
+                variant,
+                value: None,
+            }),
+            other => Err(serde::de::Error::invalid_type(
+                other.unexpected(),
+                &"string or map",
+            )),
+        }
     }
 
     #[inline]

--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -187,15 +187,6 @@ where
     }
 }
 
-fn visit_object<'de, V>(object: Map<String, Value>, visitor: V) -> Result<V::Value, Error>
-where
-    V: Visitor<'de>,
-{
-    use serde::de::Deserializer;
-
-    object.deserialize_any(visitor)
-}
-
 impl<'de> serde::Deserializer<'de> for Map<String, Value> {
     type Error = Error;
 
@@ -282,7 +273,7 @@ impl<'de> serde::Deserializer<'de> for Value {
             #[cfg(not(any(feature = "std", feature = "alloc")))]
             Value::String(_) => unreachable!(),
             Value::Array(v) => visit_array(v, visitor),
-            Value::Object(v) => visit_object(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
         }
     }
 
@@ -461,7 +452,7 @@ impl<'de> serde::Deserializer<'de> for Value {
         V: Visitor<'de>,
     {
         match self {
-            Value::Object(v) => visit_object(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -477,7 +468,7 @@ impl<'de> serde::Deserializer<'de> for Value {
     {
         match self {
             Value::Array(v) => visit_array(v, visitor),
-            Value::Object(v) => visit_object(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -591,8 +582,10 @@ impl<'de> VariantAccess<'de> for VariantDeserializer {
     where
         V: Visitor<'de>,
     {
+        use serde::de::Deserializer;
+
         match self.value {
-            Some(Value::Object(v)) => visit_object(v, visitor),
+            Some(Value::Object(v)) => v.deserialize_any(visitor),
             Some(other) => Err(serde::de::Error::invalid_type(
                 other.unexpected(),
                 &"struct variant",
@@ -733,15 +726,6 @@ where
     }
 }
 
-fn visit_object_ref<'de, V>(object: &'de Map<String, Value>, visitor: V) -> Result<V::Value, Error>
-where
-    V: Visitor<'de>,
-{
-    use serde::de::Deserializer;
-
-    object.deserialize_any(visitor)
-}
-
 impl<'de> serde::Deserializer<'de> for &'de Map<String, Value> {
     type Error = Error;
 
@@ -823,7 +807,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
             Value::Number(n) => n.deserialize_any(visitor),
             Value::String(v) => visitor.visit_borrowed_str(v),
             Value::Array(v) => visit_array_ref(v, visitor),
-            Value::Object(v) => visit_object_ref(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
         }
     }
 
@@ -998,7 +982,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
         V: Visitor<'de>,
     {
         match self {
-            Value::Object(v) => visit_object_ref(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -1014,7 +998,7 @@ impl<'de> serde::Deserializer<'de> for &'de Value {
     {
         match self {
             Value::Array(v) => visit_array_ref(v, visitor),
-            Value::Object(v) => visit_object_ref(v, visitor),
+            Value::Object(v) => v.deserialize_any(visitor),
             _ => Err(self.invalid_type(&visitor)),
         }
     }
@@ -1111,8 +1095,10 @@ impl<'de> VariantAccess<'de> for VariantRefDeserializer<'de> {
     where
         V: Visitor<'de>,
     {
+        use serde::de::Deserializer;
+
         match self.value {
-            Some(Value::Object(v)) => visit_object_ref(v, visitor),
+            Some(Value::Object(v)) => v.deserialize_any(visitor),
             Some(other) => Err(serde::de::Error::invalid_type(
                 other.unexpected(),
                 &"struct variant",


### PR DESCRIPTION
This PR adds `Deserializer` impls for `Map<String, Value>` and `&Map<String, Value>` and `IntoDeserializer` impls for the same. The first commit moves the relevant code from the value `Deserializer` impl into the new map impls. The last two are some small cleanups to use the map deserializer impl directly.

I put the `Deserializer` trait impls in `src/value/de.rs` so that they can reuse the existing helpers there. If you would prefer that they go elsewhere I am happy to move them.

Closes #1134