### PR TITLE
Add i128 deserialization

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -45,6 +45,11 @@ impl<'de> Deserialize<'de> for Value {
             }
 
             #[inline]
+            fn visit_i128<E>(self, value: i128) -> Result<Value, E> {
+                Ok(Number::from_i128(value).map_or(Value::Null, Value::Number))
+            }
+
+            #[inline]
             fn visit_u64<E>(self, value: u64) -> Result<Value, E> {
                 Ok(Value::Number(value.into()))
             }

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -635,6 +635,24 @@ impl Value {
         }
     }
 
+    /// If the `Value` is an integer, represent it as i128 if possible. Returns
+    /// None otherwise.
+    ///
+    /// ```
+    /// # use serde_json::json;
+    /// #
+    /// let v = json!({ "a": 64, "b": 256.0 });
+    ///
+    /// assert_eq!(v["a"].as_i128(), Some(64));
+    /// assert_eq!(v["b"].as_i128(), None);
+    /// ```
+    pub fn as_i128(&self) -> Option<i128> {
+        match self {
+            Value::Number(n) => n.as_i128(),
+            _ => None,
+        }
+    }
+
     /// If the `Value` is an integer, represent it as u64 if possible. Returns
     /// None otherwise.
     ///


### PR DESCRIPTION
Implemented serde::de::Visitor::visit_i128.
This fixes compatability with Ipld::Integer when using DagJsonCodec.