### PR TITLE
Recover raw values after losing the type

### DIFF
--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -23,6 +23,14 @@ impl Serialize for Value {
             #[cfg(any(feature = "std", feature = "alloc"))]
             Value::Object(m) => {
                 use serde::ser::SerializeMap;
+                #[cfg(feature = "raw_value")]
+                if m.len() == 1 {
+                    if let Some(Value::String(value)) = m.get(crate::raw::TOKEN) {
+                        if let Ok(value) = crate::raw::RawValue::from_string(value.clone()) {
+                            return value.serialize(serializer);
+                        }
+                    }
+                }
                 let mut map = tri!(serializer.serialize_map(Some(m.len())));
                 for (k, v) in m {
                     tri!(map.serialize_entry(k, v));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2407,6 +2407,21 @@ fn test_boxed_raw_value() {
 
 #[cfg(feature = "raw_value")]
 #[test]
+fn test_lost_raw_value() {
+    let value = Value::Object({
+        let mut value = serde_json::Map::default();
+        value.insert(
+            "$serde_json::private::RawValue".into(),
+            Value::String("0".into()),
+        );
+        value
+    });
+
+    assert_eq!(value.to_string(), "0");
+}
+
+#[cfg(feature = "raw_value")]
+#[test]
 fn test_raw_invalid_utf8() {
     let j = &[b'"', b'\xCE', b'\xF8', b'"'];
     let value_err = serde_json::from_slice::<Value>(j).unwrap_err();


### PR DESCRIPTION
Hello,

I have a use case where a struct with a raw value gets converted into a `Value`, which then needs to be serialized to JSON. Upon conversion, `RawValue` gets downcast to a `Map`, which loses the special serialization of `RawValue`, resulting in a JSON containing an object with one entry whose key equals `raw::TOKEN`.

I am wondering if you would be willing to have code for recovering the “rawness.”