### PR TITLE
Add Map::shift_insert()

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -127,6 +127,17 @@ impl Map<String, Value> {
         self.map.insert(k, v)
     }
 
+    /// Insert a key-value pair in the map at the given index.
+    ///
+    /// If the map did not have this key present, `None` is returned.
+    ///
+    /// If the map did have this key present, the key is moved to the new
+    /// position, the value is updated, and the old value is returned.
+    #[cfg(feature = "preserve_order")]
+    pub fn shift_insert(&mut self, index: usize, k: String, v: Value) -> Option<Value> {
+        self.map.shift_insert(index, k, v)
+    }
+
     /// Removes a key from the map, returning the value at the key if the key
     /// was previously in the map.
     ///

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -16,6 +16,17 @@ fn test_preserve_order() {
 }
 
 #[test]
+#[cfg(feature = "preserve_order")]
+fn test_shift_insert() {
+    let mut v: Value = from_str(r#"{"b":null,"a":null,"c":null}"#).unwrap();
+    let val = v.as_object_mut().unwrap();
+    val.shift_insert(0, "d".to_string(), Value::Null);
+
+    let keys: Vec<_> = val.keys().collect();
+    assert_eq!(keys, &["d", "b", "a", "c"]);
+}
+
+#[test]
 fn test_append() {
     // Sorted order
     #[cfg(not(feature = "preserve_order"))]


### PR DESCRIPTION
This method inserts a key-value pair in the map at the given index. If
the map did not have this key present, `None` is returned. If the map
did have this key present, the key is moved to the new position, the
value is updated, and the old value is returned.

This is useful when you want to insert a key-value pair at a specific
position in the map, and is a necessary method when writing a JSON
editor that can mutate the keys in a JSON object.

This is only enabled when the preserve-order feature flag is enabled.

```rust
map.shift_insert(0, "foo", "bar")
```

Mirrors the logic in [`IndexMap::shift_insert()`](https://docs.rs/indexmap/2.2.6/indexmap/map/struct.IndexMap.html#method.shift_insert)