### PR TITLE
fix: indexmap minimal version with Map::shift_insert()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/serde-rs/json"
 rust-version = "1.56"
 
 [dependencies]
-indexmap = { version = "2.2.1", optional = true }
+indexmap = { version = "2.2.3", optional = true }
 itoa = "1.0"
 ryu = "1.0"
 serde = { version = "1.0.194", default-features = false }


### PR DESCRIPTION
PR #1149 introduced `Map::shift_insert()` but version of `indexmap` stayed on `2.2.1` which doesn't have this, causing issue on build where `serde_json` is used as a dep.

Updating dep to minimal version of `2.2.3`

(Let me know if it should be `2.2.6` because it's the version in the lock)