### PR TITLE
Correct documentation URL for Value's Index impl.

### DIFF
--- a/src/value/index.rs
+++ b/src/value/index.rs
@@ -14,7 +14,7 @@ use core::ops;
 ///
 /// [`get`]: ../enum.Value.html#method.get
 /// [`get_mut`]: ../enum.Value.html#method.get_mut
-/// [square-bracket indexing operator]: ../enum.Value.html#impl-Index%3CI%3E
+/// [square-bracket indexing operator]: ../enum.Value.html#impl-Index%3CI%3E-for-Value
 ///
 /// This trait is sealed and cannot be implemented for types outside of
 /// `serde_json`.


### PR DESCRIPTION
The current id doesn't exist, so the link just goes to the top of the docs for Value, rather than to the intended section covering `impl<I> Index<I> for Value`.