### PR TITLE
Move call to tri! out of check_recursion!

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1870,8 +1870,9 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
             Some(b'{') => {
                 check_recursion! {
                     self.eat_char();
-                    let value = tri!(visitor.visit_enum(VariantAccess::new(self)));
+                    let ret = visitor.visit_enum(VariantAccess::new(self));
                 }
+                let value = tri!(ret);
 
                 match tri!(self.parse_whitespace()) {
                     Some(b'}') => {


### PR DESCRIPTION
As far as I can see, all uses of `check_recursion!` except this one don't early-return. The current code decreases `remaining_depth` but doesn't increase it back on visit failure. I don't have a test, but this is probably a bug.