### PR TITLE
Vectorize string parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,7 @@
     clippy::wildcard_imports,
     // things are often more readable this way
     clippy::cast_lossless,
+    clippy::items_after_statements,
     clippy::module_name_repetitions,
     clippy::redundant_else,
     clippy::shadow_unrelated,

--- a/src/read.rs
+++ b/src/read.rs
@@ -426,53 +426,49 @@ impl<'a> SliceRead<'a> {
         }
     }
 
-    #[inline(always)]
     fn skip_to_escape(&mut self, forbid_control_characters: bool) {
         let rest = &self.slice[self.index..];
-        let end = self.index + memchr::memchr2(b'"', b'\\', rest).unwrap_or(rest.len());
 
         if !forbid_control_characters {
-            self.index = end;
+            self.index += memchr::memchr2(b'"', b'\\', rest).unwrap_or(rest.len());
             return;
         }
 
-        // We now wish to check if the chunk contains a byte in range 0x00..=0x1F. Ideally, this
-        // would be integrated this into the memchr2 check above, but memchr does not support this
-        // at the moment. Therefore, use a variation on Mycroft's algorithm [1] to provide
-        // performance better than a naive loop. It runs faster than just a single memchr call on
-        // benchmarks and is faster than both SSE2 and AVX-based code, and it's cross-platform, so
-        // probably the right fit.
+        // We wish to find the first byte in range 0x00..=0x1F or " or \. Ideally, we'd use
+        // something akin to memchr3, but the memchr crate does not support this at the moment.
+        // Therefore, we use a variation on Mycroft's algorithm [1] to provide performance better
+        // than a naive loop. It runs faster than equivalent two-pass memchr2+SWAR code on
+        // benchmarks and it's cross-platform, so probably the right fit.
         // [1]: https://groups.google.com/forum/#!original/comp.lang.c/2HtQXvg7iKc/xOJeipH6KLMJ
-        const STEP: usize = mem::size_of::<usize>();
+        type Chunk = usize;
+        const STEP: usize = mem::size_of::<Chunk>();
+        const ONE_BYTES: Chunk = Chunk::MAX / 255; // 0x0101...01
 
-        // Moving this to a local variable removes a spill in the hot loop.
-        let mut index = self.index;
-
-        if self.slice.len() >= STEP {
-            while index < end.min(self.slice.len() - STEP + 1) {
-                // We can safely overread past end in most cases. This ensures that SWAR code is
-                // used to handle the tail in the hot path.
-                const ONE_BYTES: usize = usize::MAX / 255;
-                let chars = usize::from_ne_bytes(self.slice[index..][..STEP].try_into().unwrap());
-                let mask = chars.wrapping_sub(ONE_BYTES * 0x20) & !chars & (ONE_BYTES << 7);
-
-                if mask != 0 {
-                    index += mask.trailing_zeros() as usize / 8;
-                    break;
-                }
-
-                index += STEP;
-            }
-        }
-
-        if index < end {
-            if let Some(offset) = self.slice[index..end].iter().position(|&c| c <= 0x1F) {
-                self.index = index + offset;
+        for chunk in rest.chunks_exact(STEP) {
+            let chars = Chunk::from_ne_bytes(chunk.try_into().unwrap());
+            let contains_ctrl = chars.wrapping_sub(ONE_BYTES * 0x20) & !chars;
+            let chars_quote = chars ^ (ONE_BYTES * Chunk::from(b'"'));
+            let contains_quote = chars_quote.wrapping_sub(ONE_BYTES) & !chars_quote;
+            let chars_backslash = chars ^ (ONE_BYTES * Chunk::from(b'\\'));
+            let contains_backslash = chars_backslash.wrapping_sub(ONE_BYTES) & !chars_backslash;
+            let masked = (contains_ctrl | contains_quote | contains_backslash) & (ONE_BYTES << 7);
+            if masked != 0 {
+                // SAFETY: chunk is in-bounds for slice
+                self.index = unsafe { chunk.as_ptr().offset_from(self.slice.as_ptr()) } as usize
+                    + masked.trailing_zeros() as usize / 8;
                 return;
             }
         }
 
-        self.index = end;
+        self.skip_to_escape_slow();
+    }
+
+    #[cold]
+    #[inline(never)]
+    fn skip_to_escape_slow(&mut self) {
+        while self.index < self.slice.len() && !is_escape(self.slice[self.index]) {
+            self.index += 1;
+        }
     }
 
     /// The big optimization here over IoRead is that if the string contains no
@@ -823,8 +819,6 @@ pub trait Fused: private::Sealed {}
 impl<'a> Fused for SliceRead<'a> {}
 impl<'a> Fused for StrRead<'a> {}
 
-// This is only used in IoRead. SliceRead hardcodes the arguments to memchr.
-#[cfg(feature = "std")]
 fn is_escape(ch: u8) -> bool {
     ch == b'"' || ch == b'\\' || ch < 0x20
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -465,6 +465,7 @@ impl<'a> SliceRead<'a> {
             }
         }
 
+        self.index += rest.len() / STEP * STEP;
         self.skip_to_escape_slow();
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -453,9 +453,14 @@ impl<'a> SliceRead<'a> {
             let contains_backslash = chars_backslash.wrapping_sub(ONE_BYTES) & !chars_backslash;
             let masked = (contains_ctrl | contains_quote | contains_backslash) & (ONE_BYTES << 7);
             if masked != 0 {
+                let addresswise_first_bit = if cfg!(target_endian = "little") {
+                    masked.trailing_zeros()
+                } else {
+                    masked.leading_zeros()
+                };
                 // SAFETY: chunk is in-bounds for slice
                 self.index = unsafe { chunk.as_ptr().offset_from(self.slice.as_ptr()) } as usize
-                    + masked.trailing_zeros() as usize / 8;
+                    + addresswise_first_bit as usize / 8;
                 return;
             }
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2497,3 +2497,22 @@ fn hash_positive_and_negative_zero() {
         assert_eq!(rand.hash_one(k1), rand.hash_one(k2));
     }
 }
+
+#[test]
+fn test_control_character_search() {
+    // Different space circumstances
+    for n in 0..16 {
+        for m in 0..16 {
+            test_parse_err::<String>(&[(
+                &format!("\"{}\n{}\"", ".".repeat(n), ".".repeat(m)),
+                "control character (\\u0000-\\u001F) found while parsing a string at line 2 column 0",
+            )]);
+        }
+    }
+
+    // Multiple occurrences
+    test_parse_err::<String>(&[(
+        &"\"\t\n\r\"",
+        "control character (\\u0000-\\u001F) found while parsing a string at line 1 column 2",
+    )]);
+}


### PR DESCRIPTION
I've implemented [your suggestion here](https://github.com/serde-rs/json/pull/1160#pullrequestreview-2203573484), and I need a bit of your input regarding my approach.

What we *really* want is to find the first character s.t. `ch == b'"' || ch == b'\\' || ch < 0x20`. memchr3 supports searches of kind `ch == a || ch == b || ch == c`, which is almost what we need. SIMD comparisons for equality and non-equality are not significantly different performance-wise or implementation-wise, so memchr could theoretically help us out. I've filed https://github.com/BurntSushi/memchr/issues/157, but chances are this isn't going to be implemented anytime soon.

The second best thing -- and I want to articulate that this is *not* the more performant solution -- is to first use SIMD to scan for `"` or `\` and then find escapes in an ad-hoc way. However, it turns out that `ch < 0x20` in a hot loop is not any faster than `ESCAPES[ch]`, on benchmarks at least. The reason is likely that the table is brought into L1 cache and the string isn't, so the speed of string iteration shadows the concerns about table access.

This forces us to use SIMD in serde-json *directly*. Luckily, there's a way to implement what we need in an architecture-agnostic way, *and* it's faster than using intrinsics on my benchmarks. This unfortunately increases code complexity a bit and requires an `#[inline(always)]` annotation, but this is what we get in return:

```
                    old (MB/s)  new (MB/s)  perf increase
canada dom          289         289         0%
canada struct       423         433         +2.4%
citm dom            359         361         +0.1%
citm struct         910         886         -2.6%
twitter dom         302         326         +7.9%
twitter struct      611         754         +23%
```

I'd say this is a good result overall, but the citm pessimization bothers me a bit. It seems like the new implementation is slower when most of the strings are very short (less than 16 characters, perhaps?). In practice, this happens when the data contains lots of objects with many keys but small values, e.g. `{"areaId": 205706007, "blockIds": []}` x 10k in citm.

So the questions are:

- Is increased the mental complexity of the core of serde-json fine?
- Is significantly optimizing long strings but pessimizing short strings fine?