### PR TITLE
Eliminate local_inner_macros in favor of non-ident macro paths

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -50,11 +50,11 @@
 ///     "comma -->",
 /// ]);
 /// ```
-#[macro_export(local_inner_macros)]
+#[macro_export]
 macro_rules! json {
     // Hide distracting implementation details from the generated rustdoc.
     ($($json:tt)+) => {
-        json_internal!($($json)+)
+        $crate::json_internal!($($json)+)
     };
 }
 
@@ -65,7 +65,7 @@ macro_rules! json {
 //
 // Changes are fine as long as `json_internal!` does not call any new helper
 // macros and can still be invoked as `json_internal!($($json)+)`.
-#[macro_export(local_inner_macros)]
+#[macro_export]
 #[doc(hidden)]
 macro_rules! json_internal {
     //////////////////////////////////////////////////////////////////////////
@@ -77,57 +77,57 @@ macro_rules! json_internal {
 
     // Done with trailing comma.
     (@array [$($elems:expr,)*]) => {
-        json_internal_vec![$($elems,)*]
+        vec![$($elems,)*]
     };
 
     // Done without trailing comma.
     (@array [$($elems:expr),*]) => {
-        json_internal_vec![$($elems),*]
+        vec![$($elems),*]
     };
 
     // Next element is `null`.
     (@array [$($elems:expr,)*] null $($rest:tt)*) => {
-        json_internal!(@array [$($elems,)* json_internal!(null)] $($rest)*)
+        $crate::json_internal!(@array [$($elems,)* $crate::json_internal!(null)] $($rest)*)
     };
 
     // Next element is `true`.
     (@array [$($elems:expr,)*] true $($rest:tt)*) => {
-        json_internal!(@array [$($elems,)* json_internal!(true)] $($rest)*)
+        $crate::json_internal!(@array [$($elems,)* $crate::json_internal!(true)] $($rest)*)
     };
 
     // Next element is `false`.
     (@array [$($elems:expr,)*] false $($rest:tt)*) => {
-        json_internal!(@array [$($elems,)* json_internal!(false)] $($rest)*)
+        $crate::json_internal!(@array [$($elems,)* $crate::json_internal!(false)] $($rest)*)
     };
 
     // Next element is an array.
     (@array [$($elems:expr,)*] [$($array:tt)*] $($rest:tt)*) => {
-        json_internal!(@array [$($elems,)* json_internal!([$($array)*])] $($rest)*)
+        $crate::json_internal!(@array [$($elems,)* $crate::json_internal!([$($array)*])] $($rest)*)
     };
 
     // Next element is a map.
     (@array [$($elems:expr,)*] {$($map:tt)*} $($rest:tt)*) => {
-        json_internal!(@array [$($elems,)* json_internal!({$($map)*})] $($rest)*)
+        $crate::json_internal!(@array [$($elems,)* $crate::json_internal!({$($map)*})] $($rest)*)
     };
 
     // Next element is an expression followed by comma.
     (@array [$($elems:expr,)*] $next:expr, $($rest:tt)*) => {
-        json_internal!(@array [$($elems,)* json_internal!($next),] $($rest)*)
+        $crate::json_internal!(@array [$($elems,)* $crate::json_internal!($next),] $($rest)*)
     };
 
     // Last element is an expression with no trailing comma.
     (@array [$($elems:expr,)*] $last:expr) => {
-        json_internal!(@array [$($elems,)* json_internal!($last)])
+        $crate::json_internal!(@array [$($elems,)* $crate::json_internal!($last)])
     };
 
     // Comma after the most recent element.
     (@array [$($elems:expr),*] , $($rest:tt)*) => {
-        json_internal!(@array [$($elems,)*] $($rest)*)
+        $crate::json_internal!(@array [$($elems,)*] $($rest)*)
     };
 
     // Unexpected token after most recent element.
     (@array [$($elems:expr),*] $unexpected:tt $($rest:tt)*) => {
-        json_unexpected!($unexpected)
+        $crate::json_unexpected!($unexpected)
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -146,12 +146,12 @@ macro_rules! json_internal {
     // Insert the current entry followed by trailing comma.
     (@object $object:ident [$($key:tt)+] ($value:expr) , $($rest:tt)*) => {
         let _ = $object.insert(($($key)+).into(), $value);
-        json_internal!(@object $object () ($($rest)*) ($($rest)*));
+        $crate::json_internal!(@object $object () ($($rest)*) ($($rest)*));
     };
 
     // Current entry followed by unexpected token.
     (@object $object:ident [$($key:tt)+] ($value:expr) $unexpected:tt $($rest:tt)*) => {
-        json_unexpected!($unexpected);
+        $crate::json_unexpected!($unexpected);
     };
 
     // Insert the last entry without trailing comma.
@@ -161,78 +161,78 @@ macro_rules! json_internal {
 
     // Next value is `null`.
     (@object $object:ident ($($key:tt)+) (: null $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object [$($key)+] (json_internal!(null)) $($rest)*);
+        $crate::json_internal!(@object $object [$($key)+] ($crate::json_internal!(null)) $($rest)*);
     };
 
     // Next value is `true`.
     (@object $object:ident ($($key:tt)+) (: true $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object [$($key)+] (json_internal!(true)) $($rest)*);
+        $crate::json_internal!(@object $object [$($key)+] ($crate::json_internal!(true)) $($rest)*);
     };
 
     // Next value is `false`.
     (@object $object:ident ($($key:tt)+) (: false $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object [$($key)+] (json_internal!(false)) $($rest)*);
+        $crate::json_internal!(@object $object [$($key)+] ($crate::json_internal!(false)) $($rest)*);
     };
 
     // Next value is an array.
     (@object $object:ident ($($key:tt)+) (: [$($array:tt)*] $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object [$($key)+] (json_internal!([$($array)*])) $($rest)*);
+        $crate::json_internal!(@object $object [$($key)+] ($crate::json_internal!([$($array)*])) $($rest)*);
     };
 
     // Next value is a map.
     (@object $object:ident ($($key:tt)+) (: {$($map:tt)*} $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object [$($key)+] (json_internal!({$($map)*})) $($rest)*);
+        $crate::json_internal!(@object $object [$($key)+] ($crate::json_internal!({$($map)*})) $($rest)*);
     };
 
     // Next value is an expression followed by comma.
     (@object $object:ident ($($key:tt)+) (: $value:expr , $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object [$($key)+] (json_internal!($value)) , $($rest)*);
+        $crate::json_internal!(@object $object [$($key)+] ($crate::json_internal!($value)) , $($rest)*);
     };
 
     // Last value is an expression with no trailing comma.
     (@object $object:ident ($($key:tt)+) (: $value:expr) $copy:tt) => {
-        json_internal!(@object $object [$($key)+] (json_internal!($value)));
+        $crate::json_internal!(@object $object [$($key)+] ($crate::json_internal!($value)));
     };
 
     // Missing value for last entry. Trigger a reasonable error message.
     (@object $object:ident ($($key:tt)+) (:) $copy:tt) => {
         // "unexpected end of macro invocation"
-        json_internal!();
+        $crate::json_internal!();
     };
 
     // Missing colon and value for last entry. Trigger a reasonable error
     // message.
     (@object $object:ident ($($key:tt)+) () $copy:tt) => {
         // "unexpected end of macro invocation"
-        json_internal!();
+        $crate::json_internal!();
     };
 
     // Misplaced colon. Trigger a reasonable error message.
     (@object $object:ident () (: $($rest:tt)*) ($colon:tt $($copy:tt)*)) => {
         // Takes no arguments so "no rules expected the token `:`".
-        json_unexpected!($colon);
+        $crate::json_unexpected!($colon);
     };
 
     // Found a comma inside a key. Trigger a reasonable error message.
     (@object $object:ident ($($key:tt)*) (, $($rest:tt)*) ($comma:tt $($copy:tt)*)) => {
         // Takes no arguments so "no rules expected the token `,`".
-        json_unexpected!($comma);
+        $crate::json_unexpected!($comma);
     };
 
     // Key is fully parenthesized. This avoids clippy double_parens false
     // positives because the parenthesization may be necessary here.
     (@object $object:ident () (($key:expr) : $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
+        $crate::json_internal!(@object $object ($key) (: $($rest)*) (: $($rest)*));
     };
 
     // Refuse to absorb colon token into key expression.
     (@object $object:ident ($($key:tt)*) (: $($unexpected:tt)+) $copy:tt) => {
-        json_expect_expr_comma!($($unexpected)+);
+        $crate::json_expect_expr_comma!($($unexpected)+);
     };
 
     // Munch a token into the current key.
     (@object $object:ident ($($key:tt)*) ($tt:tt $($rest:tt)*) $copy:tt) => {
-        json_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
+        $crate::json_internal!(@object $object ($($key)* $tt) ($($rest)*) ($($rest)*));
     };
 
     //////////////////////////////////////////////////////////////////////////
@@ -254,11 +254,11 @@ macro_rules! json_internal {
     };
 
     ([]) => {
-        $crate::Value::Array(json_internal_vec![])
+        $crate::Value::Array(vec![])
     };
 
     ([ $($tt:tt)+ ]) => {
-        $crate::Value::Array(json_internal!(@array [] $($tt)+))
+        $crate::Value::Array($crate::json_internal!(@array [] $($tt)+))
     };
 
     ({}) => {
@@ -268,7 +268,7 @@ macro_rules! json_internal {
     ({ $($tt:tt)+ }) => {
         $crate::Value::Object({
             let mut object = $crate::Map::new();
-            json_internal!(@object object () ($($tt)+) ($($tt)+));
+            $crate::json_internal!(@object object () ($($tt)+) ($($tt)+));
             object
         })
     };
@@ -280,9 +280,8 @@ macro_rules! json_internal {
     };
 }
 
-// The json_internal macro above cannot invoke vec directly because it uses
-// local_inner_macros. A vec invocation there would resolve to $crate::vec.
-// Instead invoke vec here outside of local_inner_macros.
+// Used by old versions of Rocket.
+// Unused since https://github.com/rwf2/Rocket/commit/c74bcfd40a47b35330db6cafb88e4f3da83e0d17
 #[macro_export]
 #[doc(hidden)]
 macro_rules! json_internal_vec {

--- a/tests/ui/missing_colon.stderr
+++ b/tests/ui/missing_colon.stderr
@@ -9,4 +9,4 @@ note: while trying to match `@`
   |
   |     (@array [$($elems:expr,)*]) => {
   |      ^
-  = note: this error originates in the macro `json_internal` which comes from the expansion of the macro `json` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::json_internal` which comes from the expansion of the macro `json` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/missing_value.stderr
+++ b/tests/ui/missing_value.stderr
@@ -9,4 +9,4 @@ note: while trying to match `@`
   |
   |     (@array [$($elems:expr,)*]) => {
   |      ^
-  = note: this error originates in the macro `json_internal` which comes from the expansion of the macro `json` (in Nightly builds, run with -Z macro-backtrace for more info)
+  = note: this error originates in the macro `$crate::json_internal` which comes from the expansion of the macro `json` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
The syntax of using a path to call a macro has been stable since Rust 1.30. These days serde_json no longer supports anything older than Rust 1.56.