### PR TITLE
Fix `json!` invocations when std prelude is not in scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,12 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
+// Not public API. Used from macro-generated code.
+#[doc(hidden)]
+pub mod __private {
+    pub use alloc::vec;
+}
+
 #[cfg(feature = "std")]
 #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 #[doc(inline)]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,12 +77,12 @@ macro_rules! json_internal {
 
     // Done with trailing comma.
     (@array [$($elems:expr,)*]) => {
-        vec![$($elems,)*]
+        $crate::__private::vec![$($elems,)*]
     };
 
     // Done without trailing comma.
     (@array [$($elems:expr),*]) => {
-        vec![$($elems),*]
+        $crate::__private::vec![$($elems),*]
     };
 
     // Next element is `null`.
@@ -254,7 +254,7 @@ macro_rules! json_internal {
     };
 
     ([]) => {
-        $crate::Value::Array(vec![])
+        $crate::Value::Array($crate::__private::vec![])
     };
 
     ([ $($tt:tt)+ ]) => {


### PR DESCRIPTION
Fixes #1164.