### PR TITLE
Oops, fix skip_to_escape on BE architectures

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2504,7 +2504,7 @@ fn test_control_character_search() {
     for n in 0..16 {
         for m in 0..16 {
             test_parse_err::<String>(&[(
-                &format!("\"{}\n{}\"", ".".repeat(n), ".".repeat(m)),
+                &format!("\"{}\n{}\"", " ".repeat(n), " ".repeat(m)),
                 "control character (\\u0000-\\u001F) found while parsing a string at line 2 column 0",
             )]);
         }


### PR DESCRIPTION
I have belatedly realized that using `leading_zeros` does not, in fact, work on big-endian machines. I have updated the test to trigger the failure (reproduce with `cargo miri test --test test --target powerpc64-unknown-linux-gnu test_control_character_search`) and switched to the slower-but-correct `from_le_bytes` method instead.