### PR TITLE
Speed up \uXXXX parsing and improve WTF-8 handling

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1575,7 +1575,10 @@ impl<'de, 'a, R: Read<'de>> de::Deserializer<'de> for &'a mut Deserializer<R> {
     ///
     /// The behavior of serde_json is specified to fail on non-UTF-8 strings
     /// when deserializing into Rust UTF-8 string types such as String, and
-    /// succeed with non-UTF-8 bytes when deserializing using this method.
+    /// succeed with the bytes representing the [WTF-8] encoding of code points
+    /// when deserializing using this method.
+    ///
+    /// [WTF-8]: https://simonsapin.github.io/wtf-8
     ///
     /// Escape sequences are processed as usual, and for `\uXXXX` escapes it is
     /// still checked if the hex number represents a valid Unicode code point.

--- a/src/read.rs
+++ b/src/read.rs
@@ -898,7 +898,7 @@ fn parse_unicode_escape<'de, R: Read<'de>>(
     validate: bool,
     scratch: &mut Vec<u8>,
 ) -> Result<()> {
-    let n = tri!(read.decode_hex_escape());
+    let mut n = tri!(read.decode_hex_escape());
 
     // Non-BMP characters are encoded as a sequence of two hex
     // escapes, representing UTF-16 surrogates. If deserializing a
@@ -909,56 +909,64 @@ fn parse_unicode_escape<'de, R: Read<'de>>(
         return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
     }
 
-    if n < 0xD800 || n > 0xDBFF {
-        // Every u16 outside of the surrogate ranges is guaranteed to be a
-        // legal char.
-        push_wtf8_codepoint(n as u32, scratch);
+    loop {
+        if n < 0xD800 || n > 0xDBFF {
+            // Every u16 outside of the surrogate ranges is guaranteed to be a
+            // legal char.
+            push_wtf8_codepoint(n as u32, scratch);
+            return Ok(());
+        }
+
+        // n is a leading surrogate, we now expect a trailing surrogate.
+        let n1 = n;
+
+        if tri!(peek_or_eof(read)) == b'\\' {
+            read.discard();
+        } else {
+            return if validate {
+                read.discard();
+                error(read, ErrorCode::UnexpectedEndOfHexEscape)
+            } else {
+                push_wtf8_codepoint(n1 as u32, scratch);
+                Ok(())
+            };
+        }
+
+        if tri!(peek_or_eof(read)) == b'u' {
+            read.discard();
+        } else {
+            return if validate {
+                read.discard();
+                error(read, ErrorCode::UnexpectedEndOfHexEscape)
+            } else {
+                push_wtf8_codepoint(n1 as u32, scratch);
+                // The \ prior to this byte started an escape sequence,
+                // so we need to parse that now. This recursive call
+                // does not blow the stack on malicious input because
+                // the escape is not \u, so it will be handled by one
+                // of the easy nonrecursive cases.
+                parse_escape(read, validate, scratch)
+            };
+        }
+
+        let n2 = tri!(read.decode_hex_escape());
+
+        if n2 < 0xDC00 || n2 > 0xDFFF {
+            if validate {
+                return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
+            }
+            push_wtf8_codepoint(n1 as u32, scratch);
+            // If n2 is a leading surrogate, we need to restart.
+            n = n2;
+            continue;
+        }
+
+        // This value is in range U+10000..=U+10FFFF, which is always a
+        // valid codepoint.
+        let n = (((n1 - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000;
+        push_wtf8_codepoint(n, scratch);
         return Ok(());
     }
-
-    // n is a leading surrogate, we now expect a trailing surrogate.
-    let n1 = n;
-
-    if tri!(peek_or_eof(read)) == b'\\' {
-        read.discard();
-    } else {
-        return if validate {
-            read.discard();
-            error(read, ErrorCode::UnexpectedEndOfHexEscape)
-        } else {
-            push_wtf8_codepoint(n1 as u32, scratch);
-            Ok(())
-        };
-    }
-
-    if tri!(peek_or_eof(read)) == b'u' {
-        read.discard();
-    } else {
-        return if validate {
-            read.discard();
-            error(read, ErrorCode::UnexpectedEndOfHexEscape)
-        } else {
-            push_wtf8_codepoint(n1 as u32, scratch);
-            // The \ prior to this byte started an escape sequence,
-            // so we need to parse that now. This recursive call
-            // does not blow the stack on malicious input because
-            // the escape is not \u, so it will be handled by one
-            // of the easy nonrecursive cases.
-            parse_escape(read, validate, scratch)
-        };
-    }
-
-    let n2 = tri!(read.decode_hex_escape());
-
-    if n2 < 0xDC00 || n2 > 0xDFFF {
-        return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
-    }
-
-    // This value is in range U+10000..=U+10FFFF, which is always a
-    // valid codepoint.
-    let n = (((n1 - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000;
-    push_wtf8_codepoint(n, scratch);
-    Ok(())
 }
 
 /// Adds a WTF-8 codepoint to the end of the buffer. This is a more efficient

--- a/src/read.rs
+++ b/src/read.rs
@@ -898,67 +898,66 @@ fn parse_unicode_escape<'de, R: Read<'de>>(
     validate: bool,
     scratch: &mut Vec<u8>,
 ) -> Result<()> {
-    let c = match tri!(read.decode_hex_escape()) {
-        n @ 0xDC00..=0xDFFF => {
-            return if validate {
-                error(read, ErrorCode::LoneLeadingSurrogateInHexEscape)
-            } else {
-                push_wtf8_codepoint(n as u32, scratch);
-                Ok(())
-            };
-        }
+    let n = tri!(read.decode_hex_escape());
 
-        // Non-BMP characters are encoded as a sequence of two hex
-        // escapes, representing UTF-16 surrogates. If deserializing a
-        // utf-8 string the surrogates are required to be paired,
-        // whereas deserializing a byte string accepts lone surrogates.
-        n1 @ 0xD800..=0xDBFF => {
-            if tri!(peek_or_eof(read)) == b'\\' {
-                read.discard();
-            } else {
-                return if validate {
-                    read.discard();
-                    error(read, ErrorCode::UnexpectedEndOfHexEscape)
-                } else {
-                    push_wtf8_codepoint(n1 as u32, scratch);
-                    Ok(())
-                };
-            }
+    // Non-BMP characters are encoded as a sequence of two hex
+    // escapes, representing UTF-16 surrogates. If deserializing a
+    // utf-8 string the surrogates are required to be paired,
+    // whereas deserializing a byte string accepts lone surrogates.
+    if validate && n >= 0xDC00 && n <= 0xDFFF {
+        // XXX: This is actually a trailing surrogate.
+        return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
+    }
 
-            if tri!(peek_or_eof(read)) == b'u' {
-                read.discard();
-            } else {
-                return if validate {
-                    read.discard();
-                    error(read, ErrorCode::UnexpectedEndOfHexEscape)
-                } else {
-                    push_wtf8_codepoint(n1 as u32, scratch);
-                    // The \ prior to this byte started an escape sequence,
-                    // so we need to parse that now. This recursive call
-                    // does not blow the stack on malicious input because
-                    // the escape is not \u, so it will be handled by one
-                    // of the easy nonrecursive cases.
-                    parse_escape(read, validate, scratch)
-                };
-            }
+    if n < 0xD800 || n > 0xDBFF {
+        // Every u16 outside of the surrogate ranges is guaranteed to be a
+        // legal char.
+        push_wtf8_codepoint(n as u32, scratch);
+        return Ok(());
+    }
 
-            let n2 = tri!(read.decode_hex_escape());
+    // n is a leading surrogate, we now expect a trailing surrogate.
+    let n1 = n;
 
-            if n2 < 0xDC00 || n2 > 0xDFFF {
-                return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
-            }
+    if tri!(peek_or_eof(read)) == b'\\' {
+        read.discard();
+    } else {
+        return if validate {
+            read.discard();
+            error(read, ErrorCode::UnexpectedEndOfHexEscape)
+        } else {
+            push_wtf8_codepoint(n1 as u32, scratch);
+            Ok(())
+        };
+    }
 
-            // This value is in range U+10000..=U+10FFFF, which is always a
-            // valid codepoint.
-            (((n1 - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000
-        }
+    if tri!(peek_or_eof(read)) == b'u' {
+        read.discard();
+    } else {
+        return if validate {
+            read.discard();
+            error(read, ErrorCode::UnexpectedEndOfHexEscape)
+        } else {
+            push_wtf8_codepoint(n1 as u32, scratch);
+            // The \ prior to this byte started an escape sequence,
+            // so we need to parse that now. This recursive call
+            // does not blow the stack on malicious input because
+            // the escape is not \u, so it will be handled by one
+            // of the easy nonrecursive cases.
+            parse_escape(read, validate, scratch)
+        };
+    }
 
-        // Every u16 outside of the surrogate ranges above is guaranteed
-        // to be a legal char.
-        n => n as u32,
-    };
+    let n2 = tri!(read.decode_hex_escape());
 
-    push_wtf8_codepoint(c, scratch);
+    if n2 < 0xDC00 || n2 > 0xDFFF {
+        return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
+    }
+
+    // This value is in range U+10000..=U+10FFFF, which is always a
+    // valid codepoint.
+    let n = (((n1 - 0xD800) as u32) << 10 | (n2 - 0xDC00) as u32) + 0x1_0000;
+    push_wtf8_codepoint(n, scratch);
     Ok(())
 }
 


### PR DESCRIPTION
Altogether, this speeds up \u-encoded War and Peace parsing by 20%. Performance on json-benchmark is slightly affected: there are some 5% improvements and a -1% regression, but I'm willing to write that off as noise from an imperfect benchmark setup.

This PR should be more readable per-commit w/o whitespace changes. In addition to the above, it includes a variation on #877, since it's easier to implement with this design.