### PR TITLE
Improve job names for miri jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,20 @@ jobs:
       - run: cargo check --locked
 
   miri:
-    name: Miri
+    name: Miri (${{matrix.name}})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - i686-unknown-linux-gnu
-          - mips-unknown-linux-gnu
+        include:
+          - name: 64-bit little endian
+            target: x86_64-unknown-linux-gnu
+          - name: 64-bit big endian
+            target: powerpc64-unknown-linux-gnu
+          - name: 32-bit little endian
+            target: i686-unknown-linux-gnu
+          - name: 32-bit big endian
+            target: mips-unknown-linux-gnu
     env:
       MIRIFLAGS: -Zmiri-strict-provenance
     timeout-minutes: 45


### PR DESCRIPTION
It's not that we care about any particular set of architectures. These jobs were added because we care about coverage in different endianness and pointer size.

**Before:**

<p align="center"><img src="https://github.com/user-attachments/assets/f446ef3c-ce7d-424d-8099-bc45cbdf2f2d" width="600"></p>

**After:**

<p align="center"><img src="https://github.com/user-attachments/assets/e77874ab-d26b-4229-8a9c-76494bef9281" width="600"></p>