### PR TITLE
Optimize Unicode decoding by 1% 🤡

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -1055,15 +1055,17 @@ static HEX0: [i16; 256] = build_hex_table(0);
 static HEX1: [i16; 256] = build_hex_table(4);
 
 fn decode_four_hex_digits(a: u8, b: u8, c: u8, d: u8) -> Option<u16> {
-    let a = HEX1[a as usize];
-    let b = HEX0[b as usize];
-    let c = HEX1[c as usize];
-    let d = HEX0[d as usize];
+    let a = HEX1[a as usize] as i32;
+    let b = HEX0[b as usize] as i32;
+    let c = HEX1[c as usize] as i32;
+    let d = HEX0[d as usize] as i32;
+
+    let codepoint = ((a | b) << 8) | c | d;
 
     // A single sign bit check.
-    if (a | b | c | d) < 0 {
-        return None;
+    if codepoint >= 0 {
+        Some(codepoint as u16)
+    } else {
+        None
     }
-
-    Some((((a | b) << 8) | c | d) as u16)
 }


### PR DESCRIPTION
This removes two instructions (tops) and frees up one register. This is really, really stupid, and probably does not affect performance in practice (It does on the memory-bound War and Peace benchmark though. By 1%.), but I couldn't stop myself from patching this when I read the code with a fresh mind. Sorry.