### PR TITLE
Ensure the SWAR chunks are 64-bit in more cases

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -445,7 +445,22 @@ impl<'a> SliceRead<'a> {
         // than a naive loop. It runs faster than equivalent two-pass memchr2+SWAR code on
         // benchmarks and it's cross-platform, so probably the right fit.
         // [1]: https://groups.google.com/forum/#!original/comp.lang.c/2HtQXvg7iKc/xOJeipH6KLMJ
+
+        // The following architectures have native support for 64-bit integers,
+        // but have targets where usize is not 64-bit.
+        #[cfg(any(
+            target_arch = "aarch64",
+            target_arch = "x86_64",
+            target_arch = "wasm32",
+        ))]
+        type Chunk = u64;
+        #[cfg(not(any(
+            target_arch = "aarch64",
+            target_arch = "x86_64",
+            target_arch = "wasm32",
+        )))]
         type Chunk = usize;
+
         const STEP: usize = mem::size_of::<Chunk>();
         const ONE_BYTES: Chunk = Chunk::MAX / 255; // 0x0101...01
 


### PR DESCRIPTION
Various architectures have native support for 64-bit integers, but there are Rust targets for those architectures where the pointer size is intentionally just 32-bit. For SWAR this smaller pointer size would negatively affect those targets, so this PR ensures the chunk size stays 64-bit on those targets.

The same is done in various other crates, such as [hashbrown](https://github.com/rust-lang/hashbrown/blob/f1ba3b4547f5a8f0d4b679e4f44298138d89be59/src/raw/generic.rs#L10-L15). Though I wish there was some sort of `#[cfg(target_integer_width = "64")]`.