### PR TITLE
Add support for 128 bit HashMap key serialization

### DIFF
--- a/src/value/ser.rs
+++ b/src/value/ser.rs
@@ -505,6 +505,10 @@ impl serde::Serializer for MapKeySerializer {
         Ok(value.to_string())
     }
 
+    fn serialize_i128(self, value: i128) -> Result<String> {
+        Ok(value.to_string())
+    }
+
     fn serialize_u8(self, value: u8) -> Result<String> {
         Ok(value.to_string())
     }
@@ -518,6 +522,10 @@ impl serde::Serializer for MapKeySerializer {
     }
 
     fn serialize_u64(self, value: u64) -> Result<String> {
+        Ok(value.to_string())
+    }
+
+    fn serialize_u128(self, value: u128) -> Result<String> {
         Ok(value.to_string())
     }
 


### PR DESCRIPTION
Now `HashMap` doesn't support i128/u128 key serialization (deserialization works). 
Example of code:
```rust
let mut b = HashMap::new();
b.insert(0_i128, String::new());
serde_json::to_value(b).unwrap();
```
Error:
```bash
Error("i128 is not supported", line: 0, column: 0)
```
I don't find any reason why. So I added the missing methods. 