### PR TITLE
Delete unneeded imports in doc code

### DIFF
--- a/src/number.rs
+++ b/src/number.rs
@@ -268,8 +268,6 @@ impl Number {
     /// numbers.
     ///
     /// ```
-    /// # use std::f64;
-    /// #
     /// # use serde_json::Number;
     /// #
     /// assert!(Number::from_f64(256.0).is_some());
@@ -298,8 +296,6 @@ impl Number {
     /// numbers.
     ///
     /// ```
-    /// # use std::i128;
-    /// #
     /// # use serde_json::Number;
     /// #
     /// assert!(Number::from_i128(256).is_some());


### PR DESCRIPTION
`std::f64` used to be needed for the `std::f64::NAN` constant, but a new `f64::NAN` **associated** constant has been stable since Rust 1.43. https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.NAN

`std::i128` is from https://github.com/serde-rs/json/pull/1141 and was never used.