### PR TITLE
Introducing Serde JSON Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Serde JSON &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![Rustc Version 1.36+]][rustc]
+# Serde JSON &emsp; [![Build Status]][actions] [![Latest Version]][crates.io] [![Rustc Version 1.36+]][rustc] [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Serde%20JSON%20Guru-006BFF)](https://gurubase.io/g/serde-json)
 
 [Build Status]: https://img.shields.io/github/actions/workflow/status/serde-rs/json/ci.yml?branch=master
 [actions]: https://github.com/serde-rs/json/actions?query=branch%3Amaster


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Serde JSON Guru](https://gurubase.io/g/serde-json) to Gurubase. Serde JSON Guru uses the data from this repo and data from the [docs](https://serde.rs/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Serde JSON Guru", which highlights that Serde JSON now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Serde JSON Guru in Gurubase, just let me know that's totally fine.
