### PR TITLE
Forward `serde_json::value::RawValue` to `serde_json::RawValue`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -398,6 +398,9 @@ pub use crate::ser::{to_string, to_string_pretty, to_vec, to_vec_pretty};
 pub use crate::ser::{to_writer, to_writer_pretty, Serializer};
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Map, Number, Value};
+#[cfg(feature = "raw_value")]
+#[doc(inline)]
+pub use crate::value::{to_raw_value, RawValue};
 
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.


### PR DESCRIPTION
Given that `Value` is in the root of the crate I argue that `RawValue` should be at the same level.

I use `RawValue` even more than I use `Value` and I would like to see it promoted, even if that just means
making the import more inviting to use.