### PR TITLE
Add a safety comment to unsafe block

### DIFF
--- a/src/read.rs
+++ b/src/read.rs
@@ -977,6 +977,10 @@ fn push_wtf8_codepoint(n: u32, scratch: &mut Vec<u8>) {
 
     scratch.reserve(4);
 
+    // SAFETY: After the `reserve` call, `scratch` has at least 4 bytes of allocated but
+    // unintialized memory after its last initialized byte, which is where `ptr` points. All
+    // reachable match arms write `encoded_len` bytes to that region and update the length
+    // accordingly, and `encoded_len` is always <= 4.
     unsafe {
         let ptr = scratch.as_mut_ptr().add(scratch.len());
 


### PR DESCRIPTION
I noted the lack of a comment when performing a review. The implementation is safe, just not documented.

