### PR TITLE
Add literal 'null', 'true' and 'false' consts to `RawValue` struct.

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -120,11 +120,11 @@ pub struct RawValue {
 
 impl RawValue {
     /// A literal JSON null value as `RawValue`.
-    pub const NULL: &RawValue = RawValue::from_borrowed("null");
+    pub const NULL: &'static RawValue = RawValue::from_borrowed("null");
     /// A literal JSON boolean true value as `RawValue`.
-    pub const TRUE: &RawValue = RawValue::from_borrowed("true");
+    pub const TRUE: &'static RawValue = RawValue::from_borrowed("true");
     /// A literal JSON boolean false value as `RawValue`.
-    pub const FALSE: &RawValue = RawValue::from_borrowed("false");
+    pub const FALSE: &'static RawValue = RawValue::from_borrowed("false");
 
     const fn from_borrowed(json: &str) -> &Self {
         unsafe { mem::transmute::<&str, &RawValue>(json) }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -119,7 +119,14 @@ pub struct RawValue {
 }
 
 impl RawValue {
-    fn from_borrowed(json: &str) -> &Self {
+    /// A literal JSON null value as `RawValue`.
+    pub const NULL: &RawValue = RawValue::from_borrowed("null");
+    /// A literal JSON boolean true value as `RawValue`.
+    pub const TRUE: &RawValue = RawValue::from_borrowed("true");
+    /// A literal JSON boolean false value as `RawValue`.
+    pub const FALSE: &RawValue = RawValue::from_borrowed("false");
+
+    const fn from_borrowed(json: &str) -> &Self {
         unsafe { mem::transmute::<&str, &RawValue>(json) }
     }
 
@@ -148,7 +155,7 @@ impl ToOwned for RawValue {
 
 impl Default for Box<RawValue> {
     fn default() -> Self {
-        RawValue::from_borrowed("null").to_owned()
+        RawValue::NULL.to_owned()
     }
 }
 


### PR DESCRIPTION
I have been using `RawValue` a lot lately to implement server endpoints that accept large JSON objects, extract some specific fields and  ultimately save the entire JSON to the DB.

As part of this process, a proc-macro based JSON pre-processor is used to automate HTTP error responses. This also uses `RawValue` to avoid allocating when traversing unknown JSON data.

The pre-processor uses literal "null"'s as part of it's logic, and at the moment I'm deserializing a literal `"null"` string to `RawValue` every time I need one.

This could be done once and stored in a `LazyLock` or something similar, but I thought that adding literal values to the `RawValue` struct is the least complex solution.

What do you think?