### PR TITLE
Move RawValue associated constants into same impl block as public functions

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -119,13 +119,6 @@ pub struct RawValue {
 }
 
 impl RawValue {
-    /// A literal JSON null value as `RawValue`.
-    pub const NULL: &'static RawValue = RawValue::from_borrowed("null");
-    /// A literal JSON boolean true value as `RawValue`.
-    pub const TRUE: &'static RawValue = RawValue::from_borrowed("true");
-    /// A literal JSON boolean false value as `RawValue`.
-    pub const FALSE: &'static RawValue = RawValue::from_borrowed("false");
-
     const fn from_borrowed(json: &str) -> &Self {
         unsafe { mem::transmute::<&str, &RawValue>(json) }
     }
@@ -175,6 +168,13 @@ impl Display for RawValue {
 }
 
 impl RawValue {
+    /// A literal JSON null value as `RawValue`.
+    pub const NULL: &'static RawValue = RawValue::from_borrowed("null");
+    /// A literal JSON boolean true value as `RawValue`.
+    pub const TRUE: &'static RawValue = RawValue::from_borrowed("true");
+    /// A literal JSON boolean false value as `RawValue`.
+    pub const FALSE: &'static RawValue = RawValue::from_borrowed("false");
+
     /// Convert an owned `String` of JSON data to an owned `RawValue`.
     ///
     /// This function is equivalent to `serde_json::from_str::<Box<RawValue>>`


### PR DESCRIPTION
| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/3e1b772d-b31b-4486-bf4c-9344c905c81e" width="400"> | <img src="https://github.com/user-attachments/assets/78aec3d1-a9e6-4aa7-b4ed-eb4d6038f642" width="400"> |