### PR TITLE
add partialeq to RawValue

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -118,6 +118,12 @@ pub struct RawValue {
     json: str,
 }
 
+impl PartialEq for RawValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.json == other.json
+    }
+}
+
 impl RawValue {
     const fn from_borrowed(json: &str) -> &Self {
         unsafe { mem::transmute::<&str, &RawValue>(json) }


### PR DESCRIPTION
RawValue does not currently implement `PartialEq`, which is a blocker for:
https://github.com/gltf-rs/gltf/pull/442

This pr fixes implements `PartialEq` for `RawValue` to fix that.