### PR TITLE
Document behavior of write_f32/f64 on non-finite floats

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1688,6 +1688,20 @@ pub trait Formatter {
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
+    ///
+    /// # Special cases
+    ///
+    /// This function **does not** check for NaN or infinity. If the input
+    /// number is not a finite float, the printed representation will be some
+    /// correctly formatted but unspecified numerical value.
+    ///
+    /// Please check [`is_finite`] yourself before calling this function, or
+    /// check [`is_nan`] and [`is_infinite`] and handle those cases yourself
+    /// with a different `Formatter` method.
+    ///
+    /// [`is_finite`]: f32::is_finite
+    /// [`is_nan`]: f32::is_nan
+    /// [`is_infinite`]: f32::is_infinite
     #[inline]
     fn write_f32<W>(&mut self, writer: &mut W, value: f32) -> io::Result<()>
     where
@@ -1699,6 +1713,20 @@ pub trait Formatter {
     }
 
     /// Writes a floating point value like `-31.26e+12` to the specified writer.
+    ///
+    /// # Special cases
+    ///
+    /// This function **does not** check for NaN or infinity. If the input
+    /// number is not a finite float, the printed representation will be some
+    /// correctly formatted but unspecified numerical value.
+    ///
+    /// Please check [`is_finite`] yourself before calling this function, or
+    /// check [`is_nan`] and [`is_infinite`] and handle those cases yourself
+    /// with a different `Formatter` method.
+    ///
+    /// [`is_finite`]: f64::is_finite
+    /// [`is_nan`]: f64::is_nan
+    /// [`is_infinite`]: f64::is_infinite
     #[inline]
     fn write_f64<W>(&mut self, writer: &mut W, value: f64) -> io::Result<()>
     where


### PR DESCRIPTION
This matches equivalent documentation on `ryu::Buffer::format_finite`.
https://docs.rs/ryu/1.0.19/ryu/struct.Buffer.html#method.format_finite