### PR TITLE
Delete unused gcc installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@miri
-      - run: sudo apt-get install gcc-powerpc-linux-gnu
-        if: matrix.target == 'powerpc64-unknown-linux-gnu'
-      - run: sudo apt-get install gcc-mips-linux-gnu
-        if: matrix.target == 'mips-unknown-linux-gnu'
       - run: cargo miri setup
       - run: cargo miri test --target ${{matrix.target}}
       - run: cargo miri test --target ${{matrix.target}} --features preserve_order,float_roundtrip,arbitrary_precision,raw_value


### PR DESCRIPTION
I do not know why #1174 added these steps. [They are not present in the semver crate](https://github.com/dtolnay/semver/blob/1.0.23/.github/workflows/ci.yml#L103-L110), which also tests with miri on the same set of platforms.

The `gcc-powerpc-linux-gnu` installation has been failing in CI since February 27 with this 404 error:

```console
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  binutils-powerpc-linux-gnu cpp-13-powerpc-linux-gnu cpp-powerpc-linux-gnu
  gcc-13-cross-base gcc-13-powerpc-linux-gnu gcc-13-powerpc-linux-gnu-base
  gcc-14-cross-base libasan8-powerpc-cross libatomic1-powerpc-cross
  libc6-dev-powerpc-cross libc6-powerpc-cross libgcc-13-dev-powerpc-cross
  libgcc-s1-powerpc-cross libgomp1-powerpc-cross libstdc++6-powerpc-cross
  libubsan1-powerpc-cross linux-libc-dev-powerpc-cross
Suggested packages:
  binutils-doc gcc-13-locales cpp-13-doc cpp-doc gcc-13-doc manpages-dev
  gdb-powerpc-linux-gnu gcc-doc
The following NEW packages will be installed:
  binutils-powerpc-linux-gnu cpp-13-powerpc-linux-gnu cpp-powerpc-linux-gnu
  gcc-13-cross-base gcc-13-powerpc-linux-gnu gcc-13-powerpc-linux-gnu-base
  gcc-14-cross-base gcc-powerpc-linux-gnu libasan8-powerpc-cross
  libatomic1-powerpc-cross libc6-dev-powerpc-cross libc6-powerpc-cross
  libgcc-13-dev-powerpc-cross libgcc-s1-powerpc-cross libgomp1-powerpc-cross
  libstdc++6-powerpc-cross libubsan1-powerpc-cross
  linux-libc-dev-powerpc-cross
0 upgraded, 18 newly installed, 0 to remove and 12 not upgraded.
Need to get 43.0 MB of archives.
After this operation, 139 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [142 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 gcc-13-powerpc-linux-gnu-base amd64 13.3.0-6ubuntu2~24.04cross1 [51.7 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 cpp-13-powerpc-linux-gnu amd64 13.3.0-6ubuntu2~24.04cross1 [10.1 MB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 cpp-powerpc-linux-gnu amd64 4:13.2.0-7ubuntu1 [5328 B]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gcc-13-cross-base all 13.3.0-6ubuntu2~24.04cross1 [46.4 kB]
Ign:6 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 binutils-powerpc-linux-gnu amd64 2.42-4ubuntu2.3
Get:7 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 gcc-14-cross-base all 14.2.0-4ubuntu2~24.04cross1 [46.0 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libc6-powerpc-cross all 2.39-0ubuntu8cross1 [1369 kB]
Ign:6 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 binutils-powerpc-linux-gnu amd64 2.42-4ubuntu2.3
Get:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libgcc-s1-powerpc-cross all 14.2.0-4ubuntu2~24.04cross1 [39.9 kB]
Get:10 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libgomp1-powerpc-cross all 14.2.0-4ubuntu2~24.04cross1 [159 kB]
Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libatomic1-powerpc-cross all 14.2.0-4ubuntu2~24.04cross1 [9246 B]
Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libasan8-powerpc-cross all 14.2.0-4ubuntu2~24.04cross1 [2697 kB]
Ign:6 http://security.ubuntu.com/ubuntu noble-updates/main amd64 binutils-powerpc-linux-gnu amd64 2.42-4ubuntu2.3
Err:6 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 binutils-powerpc-linux-gnu amd64 2.42-4ubuntu2.3
  404  Not Found [IP: 52.252.163.49 80]
Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libstdc++6-powerpc-cross all 14.2.0-4ubuntu2~24.04cross1 [850 kB]
Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libubsan1-powerpc-cross all 14.2.0-4ubuntu2~24.04cross1 [1159 kB]
Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 libgcc-13-dev-powerpc-cross all 13.3.0-6ubuntu2~24.04cross1 [990 kB]
Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 gcc-13-powerpc-linux-gnu amd64 13.3.0-6ubuntu2~24.04cross1 [19.4 MB]
Get:17 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 gcc-powerpc-linux-gnu amd64 4:13.2.0-7ubuntu1 [1216 B]
Get:18 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 linux-libc-dev-powerpc-cross all 6.8.0-25.25cross1 [1390 kB]
Get:19 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 libc6-dev-powerpc-cross all 2.39-0ubuntu8cross1 [1716 kB]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/b/binutils/binutils-powerpc-linux-gnu_2.42-4ubuntu2.3_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 40.0 MB in 4s (9774 kB/s)
```