### PR TITLE
feat: Deserialize binary as JSON array

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -85,6 +85,17 @@ impl<'de> Deserialize<'de> for Value {
                 Ok(Value::String(value))
             }
 
+            #[cfg(any(feature = "std", feature = "alloc"))]
+            #[inline]
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Value, E> {
+                Ok(Value::Array(
+                    value
+                        .iter()
+                        .map(|v| Value::Number(Number::from(*v)))
+                        .collect(),
+                ))
+            }
+
             #[inline]
             fn visit_none<E>(self) -> Result<Value, E> {
                 Ok(Value::Null)


### PR DESCRIPTION
I'm using `rmp_serde` with `serde_json`. I want to be able to do something like:

```rust
let binary = vec![196, 39, 132, 41, 36, 231, 196, 82, 19, 131, 98, 76, 183, 39, 96, 20, 116, 59, 218, 195, 4, 22, 240, 167, 37, 50, 187, 162, 63, 216, 103, 212, 34, 103, 224, 154, 209, 255, 101, 36, 57];
let t: serde_json::Value = rmp_serde::from_slice(&binary).unwrap();
assert!(matches!(t, serde_json::Value::Array(_)));
```

It's not a perfect round trip if you try to reverse it because in the other direction this would now serialize as a msgpack array rather than binary data. At least in this direction, I believe it's reasonable to represent binary data as a numeric array.