### PR TITLE
Add feature "sort_arrays" and API for sotring all arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "serde_json"
 version = "1.0.140"
-authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
+authors = [
+    "Erick Tryzelaar <erick.tryzelaar@gmail.com>",
+    "David Tolnay <dtolnay@gmail.com>",
+]
 categories = ["encoding", "parser-implementations", "no-std"]
 description = "A JSON serialization file format"
 documentation = "https://docs.rs/serde_json"
@@ -89,3 +92,5 @@ raw_value = []
 # overflow the stack after deserialization has completed, including, but not
 # limited to, Display and Debug and Drop impls.
 unbounded_depth = []
+
+sort_arrays = ["arbitrary_precision"]

--- a/src/map.rs
+++ b/src/map.rs
@@ -26,6 +26,7 @@ use alloc::collections::{btree_map, BTreeMap};
 use indexmap::IndexMap;
 
 /// Represents a JSON key/value type.
+#[cfg(not(feature = "sort_arrays"))]
 pub struct Map<K, V> {
     map: MapImpl<K, V>,
 }
@@ -34,6 +35,26 @@ pub struct Map<K, V> {
 type MapImpl<K, V> = BTreeMap<K, V>;
 #[cfg(feature = "preserve_order")]
 type MapImpl<K, V> = IndexMap<K, V>;
+
+/// Represents a JSON key/value type.
+#[cfg(feature = "sort_arrays")]
+pub struct Map<K: PartialOrd + Ord + Eq, V> {
+    map: MapImpl<K, V>,
+}
+#[cfg(feature = "sort_arrays")]
+impl PartialOrd for Map<String, Value> {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        self.map.partial_cmp(&other.map)
+    }
+}
+#[cfg(feature = "sort_arrays")]
+impl Ord for Map<String, Value> {
+    #[inline]
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.map.cmp(&other.map)
+    }
+}
 
 impl Map<String, Value> {
     /// Makes a new empty Map.

--- a/src/number.rs
+++ b/src/number.rs
@@ -18,7 +18,15 @@ use serde::{forward_to_deserialize_any, Deserialize, Deserializer, Serialize, Se
 pub(crate) const TOKEN: &str = "$serde_json::private::Number";
 
 /// Represents a JSON number, whether integer or floating point.
+#[cfg(not(feature = "sort_arrays"))]
 #[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Number {
+    n: N,
+}
+
+/// Represents a JSON number, whether integer or floating point.
+#[cfg(feature = "sort_arrays")]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Number {
     n: N,
 }


### PR DESCRIPTION
Add special feature `sort_arrays` and function to sort object and arrays.


It is necessary for storing JSON and comparing with previous JSON. For example for prevent DDOS attack where attacker reorder elements in array and create new request body and avoid block by rate limit.