### PR TITLE
Compat note for RawValue/flattening & tagged enum

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -111,6 +111,17 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 /// struct SomeStruct {
 ///     raw_value: Box<RawValue>,
 /// }
+///
+/// # Serde feature compatibility
+///
+/// You cannot use `RawValue` on any field of a struct that gets
+/// `#[serde(flatten)]`ed into an outer struct.
+///
+/// You also cannot use `RawValue` in any variant of an internally-tagged enum.
+///
+/// Flattened structs and internally tagged enums use intermediate data
+/// structures during deserialization which lose the magic token required for
+/// `RawValue` to work.
 /// ```
 #[cfg_attr(docsrs, doc(cfg(feature = "raw_value")))]
 #[repr(transparent)]


### PR DESCRIPTION
It's not obvious that RawValue can't be used with serveral serde features, and the runtime errors are quite opaque. From the number of issues on github and annecdotally, people get bit by this fairly often.

This change simply adds a note to RawValue's doc comments about two such scenarios that it won't work with. The phrasing could probably be improved/tightned up and maybe links could be added to explain why? My brain is just fried from running into both cases today and not getting anything done as a result.


Alternately
-----------

- It seems like these cases might be resolveable by https://github.com/serde-rs/serde/issues/1183 . Maybe this doc comment could reference that issue directly, instead.

- Maybe the error messages could somehow be improved?


Related issues
--------------

- #497
- #545
- #599
- #779
- #883
- #1051
- #1099 