### PR TITLE
Add Clone and Debug impls to map iterators

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -1056,6 +1056,7 @@ impl<'a> IntoIterator for &'a Map<String, Value> {
 }
 
 /// An iterator over a serde_json::Map's entries.
+#[derive(Clone, Debug)]
 pub struct Iter<'a> {
     iter: IterImpl<'a>,
 }
@@ -1081,6 +1082,7 @@ impl<'a> IntoIterator for &'a mut Map<String, Value> {
 }
 
 /// A mutable iterator over a serde_json::Map's entries.
+#[derive(Debug)]
 pub struct IterMut<'a> {
     iter: IterMutImpl<'a>,
 }
@@ -1106,6 +1108,7 @@ impl IntoIterator for Map<String, Value> {
 }
 
 /// An owning iterator over a serde_json::Map's entries.
+#[derive(Debug)]
 pub struct IntoIter {
     iter: IntoIterImpl,
 }
@@ -1120,6 +1123,7 @@ delegate_iterator!((IntoIter) => (String, Value));
 //////////////////////////////////////////////////////////////////////////////
 
 /// An iterator over a serde_json::Map's keys.
+#[derive(Clone, Debug)]
 pub struct Keys<'a> {
     iter: KeysImpl<'a>,
 }
@@ -1134,6 +1138,7 @@ delegate_iterator!((Keys<'a>) => &'a String);
 //////////////////////////////////////////////////////////////////////////////
 
 /// An iterator over a serde_json::Map's values.
+#[derive(Clone, Debug)]
 pub struct Values<'a> {
     iter: ValuesImpl<'a>,
 }
@@ -1148,6 +1153,7 @@ delegate_iterator!((Values<'a>) => &'a Value);
 //////////////////////////////////////////////////////////////////////////////
 
 /// A mutable iterator over a serde_json::Map's values.
+#[derive(Debug)]
 pub struct ValuesMut<'a> {
     iter: ValuesMutImpl<'a>,
 }
@@ -1162,6 +1168,7 @@ delegate_iterator!((ValuesMut<'a>) => &'a mut Value);
 //////////////////////////////////////////////////////////////////////////////
 
 /// An owning iterator over a serde_json::Map's values.
+#[derive(Debug)]
 pub struct IntoValues {
     iter: IntoValuesImpl,
 }


### PR DESCRIPTION
I've noticed that the iterators for `Map` are missing some traits that are implemented by their counterpart in `std::collections` and `indexmap`: namely, `Clone` and `Debug`. AFAICT, there's no reason for those to be missing, and they can be useful. I found myself missing `Clone` on `Iter`, for example.

Initially, I'd included `Default` among these, but it's not supported on Rust 1.65 and older.