### PR TITLE
feat: impl Default for &Value

### DIFF
--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -924,6 +924,13 @@ impl Default for Value {
     }
 }
 
+impl<'a> Default for &'a Value {
+    fn default() -> Self {
+        const DEFAULT: Value = Value::Null;
+        &DEFAULT
+    }
+}
+
 mod de;
 mod from;
 mod index;


### PR DESCRIPTION
A rounded edge for:
```
let val: Value;
val.pointer("/foo).unwrap_or_default()
```

Obviously not required.