### PR TITLE
Add `Object` type alias for JSON objects

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,6 +402,9 @@ pub use crate::ser::{to_writer, to_writer_pretty, Serializer};
 #[doc(inline)]
 pub use crate::value::{from_value, to_value, Map, Number, Value};
 
+/// Represents a JSON object.
+pub type Object = Map<alloc::string::String, Value>;
+
 // We only use our own error type; no need for From conversions provided by the
 // standard library's try! macro. This reduces lines of LLVM IR by 4%.
 macro_rules! tri {


### PR DESCRIPTION
This PR adds a convenient `Object` type alias to eliminate the need for repeatedly writing `Map<String, Value>` when working with JSON objects.

Instead of:
```rust
use serde_json::{Map, Value};
let obj: Map<String, Value> = serde_json::from_str(json_str)?;
```

Users can now write:
```rust
use serde_json::Object;
let obj: Object = serde_json::from_str(json_str)?;
```

Fixes #776 