### PR TITLE
Implement `FromStr` for `Map<String, Value>`

### DIFF
--- a/src/value/de.rs
+++ b/src/value/de.rs
@@ -272,6 +272,14 @@ impl<'de> serde::Deserializer<'de> for Map<String, Value> {
     }
 }
 
+
+impl FromStr for Map<String, Value> {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Error> {
+        super::super::de::from_str(s)
+    }
+}
+
 impl<'de> serde::Deserializer<'de> for Value {
     type Error = Error;
 


### PR DESCRIPTION
My use case is to enable:

```rust
    #[cfg_attr(feature = "clap", arg(long))] // <- clap requires one of From<OsString>, ... , FromStr
    #[cfg_attr(feature = "serde", serde(default))]
    pub whatever: Option<serde_json::Map<String, serde_json::Value>>,
```

I could write a value_parser for clap:

```rust
fn parse_json_object(s: &str) -> Result< serde_json::Map<String, serde_json::Value>, String> {
    serde_json::from_str(s).map_err(|error| error.to_string())
}
```

But that probably isn't doing the best job with respect to error formatting. 