### PR TITLE
Match CharEscape discriminants to ESCAPE table entries

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1514,26 +1514,27 @@ impl<'a, W: io::Write, F: Formatter> ser::Serializer for RawValueStrEmitter<'a, 
 }
 
 /// Represents a character escape code in a type-safe manner.
+#[repr(u8)]
 pub enum CharEscape {
     /// An escaped quote `"`
-    Quote,
+    Quote = b'"',
     /// An escaped reverse solidus `\`
-    ReverseSolidus,
+    ReverseSolidus = b'\\',
     /// An escaped solidus `/`
-    Solidus,
+    Solidus = b'/',
     /// An escaped backspace character (usually escaped as `\b`)
-    Backspace,
+    Backspace = b'b',
     /// An escaped form feed character (usually escaped as `\f`)
-    FormFeed,
+    FormFeed = b'f',
     /// An escaped line feed character (usually escaped as `\n`)
-    LineFeed,
+    LineFeed = b'n',
     /// An escaped carriage return character (usually escaped as `\r`)
-    CarriageReturn,
+    CarriageReturn = b'r',
     /// An escaped tab character (usually escaped as `\t`)
-    Tab,
+    Tab = b't',
     /// An escaped ASCII plane control character (usually escaped as
     /// `\u00XX` where `XX` are two hex characters)
-    AsciiControl(u8),
+    AsciiControl(u8) = b'u',
 }
 
 /// This trait abstracts away serializing the JSON control characters, which allows the user to


### PR DESCRIPTION
In agreement with https://github.com/serde-rs/json/pull/1273#issuecomment-3090337192, this shows no discernible performance change on my machines, despite seeming like it might make a difference in each of the following conversions:

https://github.com/serde-rs/json/blob/6843c3660ec3394b15da016902e001f8381dfe92/src/ser.rs#L1770-L1782

https://github.com/serde-rs/json/blob/6843c3660ec3394b15da016902e001f8381dfe92/src/ser.rs#L2111-L2122

<details>
<summary>Compiler Explorer</summary>

```rust
use core::hint;

pub enum CharEscape1 {
    Quote,
    ReverseSolidus,
    Solidus,
    Backspace,
    FormFeed,
    LineFeed,
    CarriageReturn,
    Tab,
    AsciiControl(u8),
}

#[repr(u8)]
pub enum CharEscape2 {
    Quote = b'"',
    ReverseSolidus = b'\\',
    Solidus = b'/',
    Backspace = b'b',
    FormFeed = b'f',
    LineFeed = b'n',
    CarriageReturn = b'r',
    Tab = b't',
    AsciiControl(u8) = b'u',
}

#[unsafe(no_mangle)]
pub fn charescape1_to_u8(char_escape: CharEscape1) -> u8 {
    match char_escape { 
        CharEscape1::Quote => b'"', 
        CharEscape1::ReverseSolidus => b'\\', 
        CharEscape1::Solidus => b'/', 
        CharEscape1::Backspace => b'b', 
        CharEscape1::FormFeed => b'f', 
        CharEscape1::LineFeed => b'n', 
        CharEscape1::CarriageReturn => b'r', 
        CharEscape1::Tab => b't', 
        CharEscape1::AsciiControl(_) => b'u', 
    }
}

#[unsafe(no_mangle)]
pub fn charescape2_to_u8(char_escape: CharEscape2) -> u8 {
    match char_escape { 
        CharEscape2::Quote => b'"', 
        CharEscape2::ReverseSolidus => b'\\', 
        CharEscape2::Solidus => b'/', 
        CharEscape2::Backspace => b'b', 
        CharEscape2::FormFeed => b'f', 
        CharEscape2::LineFeed => b'n', 
        CharEscape2::CarriageReturn => b'r', 
        CharEscape2::Tab => b't', 
        CharEscape2::AsciiControl(_) => b'u', 
    }
}

#[unsafe(no_mangle)]
pub unsafe fn u8_to_charescape1(escape: u8, byte: u8) -> CharEscape1 {
    match escape { 
        self::BB => CharEscape1::Backspace, 
        self::TT => CharEscape1::Tab, 
        self::NN => CharEscape1::LineFeed, 
        self::FF => CharEscape1::FormFeed, 
        self::RR => CharEscape1::CarriageReturn, 
        self::QU => CharEscape1::Quote, 
        self::BS => CharEscape1::ReverseSolidus, 
        self::UU => CharEscape1::AsciiControl(byte), 
        _ => unsafe { hint::unreachable_unchecked() }, 
    }
}

#[unsafe(no_mangle)]
pub unsafe fn u8_to_charescape2(escape: u8, byte: u8) -> CharEscape2 {
    match escape { 
        self::BB => CharEscape2::Backspace, 
        self::TT => CharEscape2::Tab, 
        self::NN => CharEscape2::LineFeed, 
        self::FF => CharEscape2::FormFeed, 
        self::RR => CharEscape2::CarriageReturn, 
        self::QU => CharEscape2::Quote, 
        self::BS => CharEscape2::ReverseSolidus, 
        self::UU => CharEscape2::AsciiControl(byte), 
        _ => unsafe { hint::unreachable_unchecked() }, 
    }
}

const BB: u8 = b'b';
const TT: u8 = b't';
const NN: u8 = b'n';
const FF: u8 = b'f';
const RR: u8 = b'r';
const QU: u8 = b'"';
const BS: u8 = b'\\';
const UU: u8 = b'u';
```

```asm
charescape1_to_u8:
        movzx   eax, dil
        lea     rcx, [rip + .Lswitch.table.charescape1_to_u8]
        movzx   eax, byte ptr [rax + rcx]
        ret

charescape2_to_u8:
        mov     eax, edi
        ret

u8_to_charescape1:
        mov     edx, esi
        movzx   eax, dil
        add     eax, -92
        cmp     eax, 25
        ja      .LBB2_8
        lea     rcx, [rip + .LJTI2_0]
        movsxd  rax, dword ptr [rcx + 4*rax]
        add     rax, rcx
        jmp     rax
.LBB2_9:
        mov     al, 1
        ret
.LBB2_5:
        mov     al, 5
        ret
.LBB2_8:
        xor     eax, eax
        ret
.LBB2_6:
        mov     al, 4
        ret
.LBB2_2:
        mov     al, 3
        ret
.LBB2_4:
        mov     al, 7
        ret
.LBB2_10:
        mov     al, 8
        ret
.LBB2_7:
        mov     al, 6
        ret
.LBB2_3:
        ud2
.LJTI2_0:
        .long   .LBB2_9-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_2-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_6-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_5-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_7-.LJTI2_0
        .long   .LBB2_3-.LJTI2_0
        .long   .LBB2_4-.LJTI2_0
        .long   .LBB2_10-.LJTI2_0

u8_to_charescape2:
        mov     edx, esi
        mov     eax, edi
        ret

.Lswitch.table.charescape1_to_u8:
        .ascii  "\"\\/bfnrtu"
```

</details>
