### PR TITLE
fix docs for the arbitrary_precision feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ float_roundtrip = []
 # allows JSON numbers of arbitrary size/precision to be read into a Number and
 # written back to a JSON string without loss of precision.
 #
-# Unlike float_roundtrip, this feature makes JSON -> serde_json::Number -> JSON
+# Unlike float_roundtrip, this feature DOES NOT make JSON -> serde_json::Number -> JSON
 # produce output identical to the input.
 arbitrary_precision = []
 


### PR DESCRIPTION
float_roundtrip: Unlike arbitrary_precision, this feature makes f64 -> JSON -> f64 produce output identical to the input.

arbitrary_precision: Unlike float_roundtrip, this feature **DOES NOT** make JSON -> serde_json::Number -> JSON produce output identical to the input.