### PR TITLE
Allow implementing Formatter and Serializer in no-std environments

### DIFF
--- a/src/io/core.rs
+++ b/src/io/core.rs
@@ -5,12 +5,14 @@ use alloc::vec::Vec;
 use core::fmt::{self, Display};
 use core::result;
 
+/// Simple ErrorKind to mimic std::io::ErrorKind.
 pub enum ErrorKind {
+    /// A catch-all.
     Other,
 }
 
-// I/O errors can never occur in no-std mode. All our no-std I/O implementations
-// are infallible.
+/// I/O errors can never occur in no-std mode. All our no-std I/O implementations
+/// are infallible.
 pub struct Error;
 
 impl Display for Error {
@@ -20,16 +22,22 @@ impl Display for Error {
 }
 
 impl Error {
-    pub(crate) fn new(_kind: ErrorKind, _error: &'static str) -> Error {
+    /// Creates a new I/O error to mimic std::io::Error interface.
+    /// In no-std mode, this is a no-op.
+    pub fn new(_kind: ErrorKind, _error: &'static str) -> Error {
         Error
     }
 }
 
+/// Mimic std::io::Result.
 pub type Result<T> = result::Result<T, Error>;
 
+/// A minimal reimplementation of `std::io::Write`.
 pub trait Write {
+    /// Writes a buffer into this writer, returning how many bytes were written.
     fn write(&mut self, buf: &[u8]) -> Result<usize>;
 
+    /// Writes an entire buffer into this writer.
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         // All our Write impls in no_std mode always write the whole buffer in
         // one call infallibly.
@@ -39,10 +47,11 @@ pub trait Write {
         Ok(())
     }
 
+    /// Flushes this writer.
     fn flush(&mut self) -> Result<()>;
 }
 
-impl<W: Write> Write for &mut W {
+impl<W: Write + ?Sized> Write for &mut W {
     #[inline]
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         (*self).write(buf)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -422,14 +422,13 @@ mod macros;
 pub mod de;
 pub mod error;
 pub mod map;
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub mod ser;
-#[cfg(not(feature = "std"))]
-mod ser;
 pub mod value;
-
+#[cfg(feature = "std")]
 mod io;
+#[cfg(not(feature = "std"))]
+#[cfg_attr(docsrs, doc(cfg(not(feature = "std"))))]
+pub mod io;
 #[cfg(feature = "std")]
 mod iter;
 #[cfg(feature = "float_roundtrip")]


### PR DESCRIPTION
Currently `ser` is not exposed in `no-std` builds because it relies on a local, `alloc` friendly implementation of core std::io logic. This allows `serde_json` to use the same interfaces in std and no-std environments.

Unfortunately this means that extending `serde_json` by implementing the `Formatter` and/or the `Serializer` is not feasible in `no-std` environments.

I am the maintainer of https://github.com/evik42/serde-json-canonicalizer that extends `serde_json` with a `Formatter` that creates canonical JSON (as defined in RFC8785). The canonicalizer needs to implement `Serializer` also because of #1020.
To be able to use the canonicalizer in `no-std` environment it either needs to be lifted into `serde_json` (probably not the best solution) or it needs access to the `Formatter`, `Serializer` and the `io` implementation (simpler solution).

This PR achieves the simpler solution by exposing additional modules in `no-std` environment and does not affect the workings of `serde_json` in any way.