### PR TITLE
Set fast_arithmetic=64 for riscv64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,7 @@ fn main() {
         || target_arch == "loongarch64"
         || target_arch == "mips64"
         || target_arch == "powerpc64"
+        || target_arch == "riscv64"
         || target_arch == "wasm32"
         || target_arch == "x86_64"
         || target_pointer_width == "64"


### PR DESCRIPTION
riscv64 also has an ilp32 variant[1][2].

[1] https://github.com/ruyisdk/riscv-gnu-toolchain-rv64ilp32
[2] https://fedoraproject.org/wiki/Architectures/RISC-V/64ILP32