### PR TITLE
Align `arbitrary_precision` number strings with zmij’s formatting

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -993,7 +993,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     fn scan_number(&mut self, buf: &mut String) -> Result<()> {
         match tri!(self.peek_or_null()) {
             b'.' => self.scan_decimal(buf),
-            e @ (b'e' | b'E') => self.scan_exponent(e as char, buf),
+            b'e' | b'E' => self.scan_exponent(buf),
             _ => Ok(()),
         }
     }
@@ -1018,26 +1018,32 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         }
 
         match tri!(self.peek_or_null()) {
-            e @ (b'e' | b'E') => self.scan_exponent(e as char, buf),
+            b'e' | b'E' => self.scan_exponent(buf),
             _ => Ok(()),
         }
     }
 
     #[cfg(feature = "arbitrary_precision")]
-    fn scan_exponent(&mut self, e: char, buf: &mut String) -> Result<()> {
+    fn scan_exponent(&mut self, buf: &mut String) -> Result<()> {
         self.eat_char();
-        buf.push(e);
+        buf.push('e');
 
-        match tri!(self.peek_or_null()) {
+        let has_sign = match tri!(self.peek_or_null()) {
             b'+' => {
                 self.eat_char();
                 buf.push('+');
+                true
             }
             b'-' => {
                 self.eat_char();
                 buf.push('-');
+                true
             }
-            _ => {}
+            _ => false,
+        };
+
+        if !has_sign {
+            buf.push('+');
         }
 
         // Make sure a digit follows the exponent place.

--- a/src/number.rs
+++ b/src/number.rs
@@ -279,8 +279,11 @@ impl Number {
         Some(Number { n })
     }
 
-    /// Returns the exact original JSON representation that this Number was
-    /// parsed from.
+    /// Returns the JSON representation that this Number was parsed from.
+    ///
+    /// When parsing with serde_json's `arbitrary_precision` feature enabled,
+    /// positive exponents are normalized to include an explicit `+` sign so
+    /// that `1e140` becomes `1e+140`.
     ///
     /// For numbers constructed not via parsing, such as by `From<i32>`, returns
     /// the JSON representation that serde\_json would serialize for this

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1037,22 +1037,28 @@ fn test_parse_number() {
 
     #[cfg(feature = "arbitrary_precision")]
     test_parse_ok(vec![
-        ("1e999", Number::from_string_unchecked("1e999".to_owned())),
+        ("1e999", Number::from_string_unchecked("1e+999".to_owned())),
         ("1e+999", Number::from_string_unchecked("1e+999".to_owned())),
-        ("-1e999", Number::from_string_unchecked("-1e999".to_owned())),
+        (
+            "-1e999",
+            Number::from_string_unchecked("-1e+999".to_owned()),
+        ),
         ("1e-999", Number::from_string_unchecked("1e-999".to_owned())),
-        ("1E999", Number::from_string_unchecked("1E999".to_owned())),
-        ("1E+999", Number::from_string_unchecked("1E+999".to_owned())),
-        ("-1E999", Number::from_string_unchecked("-1E999".to_owned())),
-        ("1E-999", Number::from_string_unchecked("1E-999".to_owned())),
-        ("1E+000", Number::from_string_unchecked("1E+000".to_owned())),
+        ("1E999", Number::from_string_unchecked("1e+999".to_owned())),
+        ("1E+999", Number::from_string_unchecked("1e+999".to_owned())),
+        (
+            "-1E999",
+            Number::from_string_unchecked("-1e+999".to_owned()),
+        ),
+        ("1E-999", Number::from_string_unchecked("1e-999".to_owned())),
+        ("1E+000", Number::from_string_unchecked("1e+000".to_owned())),
         (
             "2.3e999",
-            Number::from_string_unchecked("2.3e999".to_owned()),
+            Number::from_string_unchecked("2.3e+999".to_owned()),
         ),
         (
             "-2.3e999",
-            Number::from_string_unchecked("-2.3e999".to_owned()),
+            Number::from_string_unchecked("-2.3e+999".to_owned()),
         ),
     ]);
 }


### PR DESCRIPTION
When `serde_json` switched float formatting from `ryu` to `zmij`, serialized floats always include an explicit `+` in positive exponents (e.g. `1.23e+45`). However, numbers parsed via the `arbitrary_precision` feature keep the literal source text, so `1.23e45` stayed without the `+`. That meant the same numeric value round-tripped to different strings depending on whether it flowed through zmij `Value::from(1.23e45)` or through the `arbitrary_precision` parser, which was especially noticeable in code that mixes both paths or compares serialized JSON for equality.

This PR normalizes exponents as soon as we parse a string-based number: if an exponent lacks an explicit sign we insert a `+`. Now the canonical representation is consistent everywhere `arbitrary_precision` values serialize identically to zmij-emitted floats.
