### PR TITLE
Expose RawValue::from_borrowed_unchecked

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -120,7 +120,17 @@ pub struct RawValue {
 
 impl RawValue {
     const fn from_borrowed(json: &str) -> &Self {
-        unsafe { mem::transmute::<&str, &RawValue>(json) }
+        unsafe { Self::from_borrowed_unchecked(json) }
+    }
+
+    /// Create a `RawValue` from a borrowed string.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that the string is valid JSON.
+    /// This function does not perform any validation.
+    pub const unsafe fn from_borrowed_unchecked(json: &str) -> &Self {
+        mem::transmute::<&str, &RawValue>(json)
     }
 
     fn from_owned(json: Box<str>) -> Box<Self> {


### PR DESCRIPTION
Expose an unsafe `RawValue::from_borrowed_unchecked` method to create `RawValue` from str slice.

Closes https://github.com/serde-rs/json/issues/1310