### PR TITLE
perf: use swar to skip whitespace

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -250,19 +250,8 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         Error::syntax(reason, position.line, position.column)
     }
 
-    /// Returns the first non-whitespace byte without consuming it, or `None` if
-    /// EOF is encountered.
     fn parse_whitespace(&mut self) -> Result<Option<u8>> {
-        loop {
-            match tri!(self.peek()) {
-                Some(b' ' | b'\n' | b'\t' | b'\r') => {
-                    self.eat_char();
-                }
-                other => {
-                    return Ok(other);
-                }
-            }
-        }
+        self.read.parse_whitespace()
     }
 
     #[cold]

--- a/src/de.rs
+++ b/src/de.rs
@@ -1059,25 +1059,37 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     }
 
     fn end_seq(&mut self) -> Result<()> {
-        match tri!(self.parse_whitespace()) {
-            Some(b']') => {
-                self.eat_char();
-                Ok(())
-            }
-            Some(b',') => {
-                self.eat_char();
-                match self.parse_whitespace() {
-                    Ok(Some(b']')) => Err(self.peek_error(ErrorCode::TrailingComma)),
-                    _ => Err(self.peek_error(ErrorCode::TrailingCharacters)),
+        let mut first = true;
+        loop {
+            let err = match tri!(self.read.parse_whitespace_slow()) {
+                Some(v) if first => {
+                    first = false;
+                    let one = v == b']';
+                    let two = v == b',';
+
+                    if one | two {
+                        self.eat_char();
+                    }
+
+                    match (one, two) {
+                        (true, _) => return Ok(()),
+                        (_, true) => continue,
+                        _ => ErrorCode::TrailingCharacters,
+                    }
                 }
-            }
-            Some(_) => Err(self.peek_error(ErrorCode::TrailingCharacters)),
-            None => Err(self.peek_error(ErrorCode::EofWhileParsingList)),
+                Some(v) => match v {
+                    b']' => ErrorCode::TrailingComma,
+                    _ => ErrorCode::TrailingCharacters,
+                },
+                _ => ErrorCode::EofWhileParsingList,
+            };
+
+            return Err(self.peek_error(err));
         }
     }
 
     fn end_map(&mut self) -> Result<()> {
-        match tri!(self.parse_whitespace()) {
+        match tri!(self.read.parse_whitespace_slow()) {
             Some(b'}') => {
                 self.eat_char();
                 Ok(())

--- a/src/read.rs
+++ b/src/read.rs
@@ -65,6 +65,11 @@ pub trait Read<'de>: private::Sealed {
     #[doc(hidden)]
     fn parse_whitespace(&mut self) -> Result<Option<u8>>;
 
+    #[doc(hidden)]
+    fn parse_whitespace_slow(&mut self) -> Result<Option<u8>> {
+        self.parse_whitespace()
+    }
+
     /// Assumes the previous byte was a quotation mark. Parses a JSON-escaped
     /// string until the next quotation mark using the given scratch space if
     /// necessary. The scratch space is initially empty.
@@ -659,6 +664,23 @@ impl<'a> Read<'a> for SliceRead<'a> {
         Ok(res)
     }
 
+    fn parse_whitespace_slow(&mut self) -> Result<Option<u8>> {
+        let res = loop {
+            if self.index >= self.slice.len() {
+                break None;
+            }
+
+            let tmp = self.slice[self.index];
+            if !matches!(tmp, b' ' | b'\t' | b'\n' | b'\r') {
+                break Some(tmp);
+            }
+
+            self.index += 1;
+        };
+
+        Ok(res)
+    }
+
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'a, 's, str>> {
         self.parse_str_bytes(scratch, true, as_str)
     }
@@ -784,6 +806,11 @@ impl<'a> Read<'a> for StrRead<'a> {
     #[inline]
     fn parse_whitespace(&mut self) -> Result<Option<u8>> {
         self.delegate.parse_whitespace()
+    }
+
+    #[inline]
+    fn parse_whitespace_slow(&mut self) -> Result<Option<u8>> {
+        self.delegate.parse_whitespace_slow()
     }
 
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'a, 's, str>> {

--- a/src/read.rs
+++ b/src/read.rs
@@ -60,6 +60,11 @@ pub trait Read<'de>: private::Sealed {
     #[doc(hidden)]
     fn byte_offset(&self) -> usize;
 
+    /// Returns the first non-whitespace byte without consuming it, or `None` if
+    /// EOF is encountered.
+    #[doc(hidden)]
+    fn parse_whitespace(&mut self) -> Result<Option<u8>>;
+
     /// Assumes the previous byte was a quotation mark. Parses a JSON-escaped
     /// string until the next quotation mark using the given scratch space if
     /// necessary. The scratch space is initially empty.
@@ -332,6 +337,15 @@ where
         }
     }
 
+    fn parse_whitespace(&mut self) -> Result<Option<u8>> {
+        loop {
+            match tri!(self.peek()) {
+                Some(b' ' | b'\n' | b'\t' | b'\r') => self.discard(),
+                other => return Ok(other),
+            }
+        }
+    }
+
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'de, 's, str>> {
         self.parse_str_bytes(scratch, true, as_str)
             .map(Reference::Copied)
@@ -584,6 +598,67 @@ impl<'a> Read<'a> for SliceRead<'a> {
         self.index
     }
 
+    fn parse_whitespace(&mut self) -> Result<Option<u8>> {
+        #[cfg(fast_arithmetic = "64")]
+        type Chunk = u64;
+        #[cfg(fast_arithmetic = "32")]
+        type Chunk = u32;
+
+        const SIZE: usize = mem::size_of::<Chunk>();
+        const ONES: Chunk = Chunk::MAX / 0xFF;
+        const HIGH: Chunk = ONES * 0x80;
+        const LOW: Chunk = ONES * 0x7F;
+
+        let mut fast = false;
+        let res = loop {
+            if self.index >= self.slice.len() {
+                break None;
+            }
+
+            let tmp = self.slice[self.index];
+            if !matches!(tmp, b' ' | b'\t' | b'\n' | b'\r') {
+                break Some(tmp);
+            }
+
+            self.index += 1;
+            if fast && self.index + SIZE <= self.slice.len() {
+                let chunk = unsafe {
+                    self.slice
+                        .as_ptr()
+                        .add(self.index)
+                        .cast::<Chunk>()
+                        .read_unaligned()
+                        .to_le()
+                };
+
+                let a = chunk ^ (Chunk::from(b' ') * ONES);
+                let b = chunk ^ (Chunk::from(b'\n') * ONES);
+                let c = chunk ^ (Chunk::from(b'\t') * ONES);
+                let d = chunk ^ (Chunk::from(b'\r') * ONES);
+
+                let a = !(a & LOW).wrapping_add(LOW) & !(a & HIGH);
+                let b = !(b & LOW).wrapping_add(LOW) & !(b & HIGH);
+                let c = !(c & LOW).wrapping_add(LOW) & !(c & HIGH);
+                let d = !(d & LOW).wrapping_add(LOW) & !(d & HIGH);
+
+                let mask = !(a | b | c | d) & HIGH;
+
+                if mask != 0 {
+                    self.index += mask.trailing_zeros() as usize >> 3;
+                    // SAFETY: Using `get_unchecked` because the compiler is
+                    //         unable to know that the index is within bounds.
+                    break unsafe { Some(*self.slice.get_unchecked(self.index)) };
+                }
+
+                self.index += SIZE
+            }
+
+            fast = true
+        };
+
+        Ok(res)
+    }
+
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'a, 's, str>> {
         self.parse_str_bytes(scratch, true, as_str)
     }
@@ -706,6 +781,11 @@ impl<'a> Read<'a> for StrRead<'a> {
         self.delegate.byte_offset()
     }
 
+    #[inline]
+    fn parse_whitespace(&mut self) -> Result<Option<u8>> {
+        self.delegate.parse_whitespace()
+    }
+
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'a, 's, str>> {
         self.delegate.parse_str_bytes(scratch, true, |_, bytes| {
             // The deserialization input came in as &str with a UTF-8 guarantee,
@@ -785,6 +865,10 @@ where
 
     fn byte_offset(&self) -> usize {
         R::byte_offset(self)
+    }
+
+    fn parse_whitespace(&mut self) -> Result<Option<u8>> {
+        R::parse_whitespace(self)
     }
 
     fn parse_str<'s>(&'s mut self, scratch: &'s mut Vec<u8>) -> Result<Reference<'de, 's, str>> {


### PR DESCRIPTION
I don't know if you will accept it but, using swar to skip whitespace improves performance when skipping over large amount of whitespaces. But also degrades, when there is none at all. I tried to avoid the degradation but was unable to do it. I've tried checking for 1-2 chars outside the loop but the generated asm was doing that already and manually doing it somehow made it even worse.

```
                      old             new        change
-- with -C target-cpu=native --------------------------
twitter/struct    753.11 MiB/s    804.69 MiB/s   +6.85%
twitter/dom       245.85 MiB/s    248.78 MiB/s   +1.19%
citm/struct       787.24 MiB/s    958.22 MiB/s  +21.72%
citm/dom          384.28 MiB/s    427.41 MiB/s  +11.22%
canada/struct     588.49 MiB/s    558.73 MiB/s   -5.06%
canada/dom        148.92 MiB/s    136.03 MiB/s   -8.65%

-- without --------------------------------------------
twitter/struct    749.26 MiB/s    796.89 MiB/s   +6.36%
twitter/dom       248.85 MiB/s    249.94 MiB/s   +0.44%
citm/struct       844.54 MiB/s    992.05 MiB/s  +17.46%
citm/dom          394.14 MiB/s    427.33 MiB/s   +8.42%
canada/struct     581.38 MiB/s    546.50 MiB/s   -6.00%
canada/dom        149.54 MiB/s    139.65 MiB/s   -6.61%
```

Running with `-C target-cpu=native` just made it use YMM register to perform the same operations...