### PR TITLE
Fix EnumAccess.variant to enforce key must be a string

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -2052,9 +2052,15 @@ impl<'de, 'a, R: Read<'de> + 'a> de::EnumAccess<'de> for VariantAccess<'a, R> {
     where
         V: de::DeserializeSeed<'de>,
     {
-        let val = tri!(seed.deserialize(&mut *self.de));
-        tri!(self.de.parse_object_colon());
-        Ok((val, self))
+        match tri!(self.de.parse_whitespace()) {
+            Some(b'"') => {
+                let val = tri!(seed.deserialize(&mut *self.de));
+                tri!(self.de.parse_object_colon());
+                Ok((val, self))
+            }
+            Some(_) => Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
+            None => Err(self.de.peek_error(ErrorCode::EofWhileParsingValue)),
+        }
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1311,7 +1311,7 @@ fn test_parse_option() {
 fn test_parse_enum_errors() {
     test_parse_err::<Animal>(
         &[
-            ("{}", "expected value at line 1 column 2"),
+            ("{}", "key must be a string at line 1 column 2"),
             ("[]", "expected value at line 1 column 1"),
             ("\"unknown\"",
              "unknown variant `unknown`, expected one of `Dog`, `Frog`, `Cat`, `AntHive` at line 1 column 9"),


### PR DESCRIPTION
## Summary
- Fix `EnumAccess::variant` to enforce that the next character is a double quote before parsing the variant name
- This prevents parsing malformed JSON like `{[true]: null}` where the key is not a string

## Changes
- In `src/de.rs`, the `variant_seed` method now checks for a opening double quote before calling `seed.deserialize()`, returning a `KeyMustBeAString` error if the character is not a double quote

## Testing
- Updated the test case in `tests/test.rs` to reflect the new error message for empty objects `{}` 

Fixes #979