### PR TITLE
Reject non-string enum object keys

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -2052,7 +2052,17 @@ impl<'de, 'a, R: Read<'de> + 'a> de::EnumAccess<'de> for VariantAccess<'a, R> {
     where
         V: de::DeserializeSeed<'de>,
     {
-        let val = tri!(seed.deserialize(&mut *self.de));
+        match tri!(self.de.parse_whitespace()) {
+            Some(b'"') => {}
+            Some(b'}') => return Err(self.de.peek_error(ErrorCode::ExpectedSomeValue)),
+            Some(_) => return Err(self.de.peek_error(ErrorCode::KeyMustBeAString)),
+            None => return Err(self.de.peek_error(ErrorCode::EofWhileParsingObject)),
+        }
+
+        let val = match seed.deserialize(MapKey { de: &mut *self.de }) {
+            Ok(value) => value,
+            Err(err) => return Err(self.de.fix_position(err)),
+        };
         tri!(self.de.parse_object_colon());
         Ok((val, self))
     }

--- a/tests/regression/issue979.rs
+++ b/tests/regression/issue979.rs
@@ -1,0 +1,29 @@
+use serde::de::{Deserializer, EnumAccess, VariantAccess, Visitor};
+use std::fmt;
+
+struct EnumVisitor;
+
+impl<'de> Visitor<'de> for EnumVisitor {
+    type Value = (Vec<bool>, ());
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("enum")
+    }
+
+    fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
+    where
+        A: EnumAccess<'de>,
+    {
+        let (key, variant) = data.variant()?;
+        variant.newtype_variant::<()>()?;
+        Ok((key, ()))
+    }
+}
+
+#[test]
+fn test() {
+    let mut de = serde_json::Deserializer::from_str("{[true]: null}");
+    let err = de.deserialize_enum("name", &[], EnumVisitor).unwrap_err();
+
+    assert!(err.to_string().contains("key must be a string"));
+}


### PR DESCRIPTION
## Summary
- validate that object-form enum variants start with a JSON string key
- deserialize enum object keys through the same `MapKey` path used by map keys
- add a regression test for malformed `{[true]: null}` input

Fixes #979

## Tests
- `cargo fmt --check`
- `cargo test --test regression issue979`
- `cargo test --test test test_parse_enum_errors`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
