### PR TITLE
Handle collect_str Display errors without panicking

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -448,7 +448,14 @@ where
         match write!(adapter, "{}", value) {
             Ok(()) => debug_assert!(adapter.error.is_none()),
             Err(fmt::Error) => {
-                return Err(Error::io(adapter.error.expect("there should be an error")));
+                return Err(adapter.error.map_or_else(
+                    || {
+                        <Error as ser::Error>::custom(
+                            "Display implementation returned an error unexpectedly",
+                        )
+                    },
+                    Error::io,
+                ));
             }
         }
         self.formatter

--- a/tests/regression/issue1328.rs
+++ b/tests/regression/issue1328.rs
@@ -1,0 +1,30 @@
+use serde::ser::{Serialize, Serializer};
+use std::fmt;
+
+struct BadDisplay;
+
+impl fmt::Display for BadDisplay {
+    fn fmt(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Err(fmt::Error)
+    }
+}
+
+impl Serialize for BadDisplay {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[test]
+fn test() {
+    let err = serde_json::to_string(&BadDisplay).unwrap_err();
+
+    assert!(err.is_data());
+    assert_eq!(
+        err.to_string(),
+        "Display implementation returned an error unexpectedly"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1328.

`Serializer::collect_str` currently assumes every `fmt::Error` came from serde_json's writer adapter, so a user `Display` implementation that returns `fmt::Error` panics when no writer error was captured. This returns a serde data error for that case while preserving the existing IO-error path when the adapter records one.

## Changes

- Convert user-originated `fmt::Error` from `collect_str` into a serde serialization error instead of unwrapping a missing adapter error.
- Add a regression test for `Display` returning `fmt::Error` through `collect_str`.

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test regression issue1328` (fails before this fix with `there should be an error`)
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test regression issue1328`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test --test regression`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test`
- `git diff --check`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.