### PR TITLE
Add RawValue::from_string_unchecked

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -191,6 +191,40 @@ impl RawValue {
         Ok(Self::from_owned(json.into_boxed_str()))
     }
 
+    /// Convert an owned `String` of JSON data to an owned `RawValue` without
+    /// checking that it contains valid JSON.
+    ///
+    /// This is the unchecked counterpart of [`RawValue::from_string`], for
+    /// strings that are already known to be valid JSON, such as the output of
+    /// another JSON serializer. Unlike `from_string`, it does not re-parse the
+    /// string; the only cost is `String::into_boxed_str`.
+    ///
+    /// # Safety
+    ///
+    /// The string passed in must contain a single well-formed JSON value with
+    /// no leading or trailing whitespace. `RawValue` is written verbatim into
+    /// JSON output wherever it is embedded, and other code (including unsafe
+    /// code) is allowed to rely on `RawValue` upholding this invariant, in the
+    /// same way that unsafe code may rely on `str` containing valid UTF-8.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use serde_json::value::RawValue;
+    ///
+    /// let json = serde_json::to_string(&[1, 2, 3])?;
+    ///
+    /// // SAFETY: `json` was produced by serde_json's own serializer, so it is
+    /// // a single well-formed JSON value without surrounding whitespace.
+    /// let raw = unsafe { RawValue::from_string_unchecked(json) };
+    ///
+    /// assert_eq!(raw.get(), "[1,2,3]");
+    /// # Ok::<(), serde_json::Error>(())
+    /// ```
+    pub unsafe fn from_string_unchecked(json: String) -> Box<Self> {
+        Self::from_owned(json.into_boxed_str())
+    }
+
     /// Access the JSON text underlying a raw value.
     ///
     /// # Example

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -207,6 +207,10 @@ impl RawValue {
     /// code) is allowed to rely on `RawValue` upholding this invariant, in the
     /// same way that unsafe code may rely on `str` containing valid UTF-8.
     ///
+    /// In debug builds this contract is checked with a `debug_assert!` that
+    /// re-parses the input; the check is compiled out in release builds, so
+    /// only release performance matches the "no re-parse" guarantee above.
+    ///
     /// # Example
     ///
     /// ```
@@ -222,6 +226,11 @@ impl RawValue {
     /// # Ok::<(), serde_json::Error>(())
     /// ```
     pub unsafe fn from_string_unchecked(json: String) -> Box<Self> {
+        debug_assert!(
+            crate::from_str::<&Self>(&json).is_ok_and(|v| v.json.len() == json.len()),
+            "from_string_unchecked: input is not a single well-formed JSON value \
+             with no leading or trailing whitespace",
+        );
         Self::from_owned(json.into_boxed_str())
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2488,6 +2488,23 @@ fn test_raw_value_from_string_unchecked() {
     assert_eq!("[1,2,3]", raw.get());
 }
 
+// The debug_assert! inside from_string_unchecked is compiled out of release
+// builds, so #[should_panic] can only be exercised under debug (which is the
+// default `cargo test` profile).
+#[cfg(all(feature = "raw_value", debug_assertions))]
+#[test]
+#[should_panic = "from_string_unchecked"]
+fn test_raw_value_from_string_unchecked_debug_asserts_whitespace() {
+    let _ = unsafe { RawValue::from_string_unchecked(" 42".to_owned()) };
+}
+
+#[cfg(all(feature = "raw_value", debug_assertions))]
+#[test]
+#[should_panic = "from_string_unchecked"]
+fn test_raw_value_from_string_unchecked_debug_asserts_well_formed() {
+    let _ = unsafe { RawValue::from_string_unchecked("[1,".to_owned()) };
+}
+
 #[cfg(feature = "raw_value")]
 #[test]
 fn test_raw_invalid_utf8() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2457,6 +2457,39 @@ fn test_boxed_raw_value() {
 
 #[cfg(feature = "raw_value")]
 #[test]
+fn test_raw_value_from_string_unchecked() {
+    #[derive(Serialize)]
+    struct Wrapper {
+        a: i8,
+        b: Box<RawValue>,
+        c: i8,
+    }
+
+    let json = r#"{"foo":[1,2,3],"bar":"\"escaped\""}"#.to_owned();
+    let checked = RawValue::from_string(json.clone()).unwrap();
+    let unchecked = unsafe { RawValue::from_string_unchecked(json) };
+    assert_eq!(checked.get(), unchecked.get());
+
+    let wrapper = Wrapper {
+        a: 1,
+        b: unchecked,
+        c: 3,
+    };
+    let wrapper_to_string = serde_json::to_string(&wrapper).unwrap();
+    assert_eq!(
+        r#"{"a":1,"b":{"foo":[1,2,3],"bar":"\"escaped\""},"c":3}"#,
+        wrapper_to_string,
+    );
+
+    // A string with excess capacity is preserved as-is.
+    let mut spare = String::with_capacity(64);
+    spare.push_str("[1,2,3]");
+    let raw = unsafe { RawValue::from_string_unchecked(spare) };
+    assert_eq!("[1,2,3]", raw.get());
+}
+
+#[cfg(feature = "raw_value")]
+#[test]
 fn test_raw_invalid_utf8() {
     let j = &[b'"', b'\xCE', b'\xF8', b'"'];
     let value_err = serde_json::from_slice::<Value>(j).unwrap_err();


### PR DESCRIPTION
# Add `RawValue::from_string_unchecked`

An unchecked counterpart of `RawValue::from_string`, for strings that are already known to be valid JSON — typically the output of another JSON serializer, or JSON that was validated once and cached.

## Motivation

`RawValue::from_string` re-parses the entire input to establish the validity invariant. When the input is trusted by construction, that parse is pure overhead and becomes significant on hot paths that handle large payloads.

Concrete case: JSON-RPC servers (Ethereum execution clients such as reth and its forks) serve multi-megabyte, hot-cached or SIMD-serialized results. The only public way to embed such a payload today is `from_string`, whose validation scan claws back roughly a third of the serializer's gains — measured on x86_64/AVX2 for a 4 MB payload: serialize with sonic-rs 272 µs, then `from_string` validation 740 µs. jsonrpsee has the same redundant cost internally on every response it builds from its own serializer output (paritytech/jsonrpsee#1648).

## Design

Follows the `str::from_utf8` / `str::from_utf8_unchecked` precedent: the checked API stays the default, and the `unsafe fn` opts out of validation with the contract documented under `# Safety` — other code (including unsafe code) is allowed to rely on `RawValue` containing well-formed JSON, in the same way unsafe code may rely on `str` containing valid UTF-8.

Additive, no behavior change for existing APIs, gated behind the existing `raw_value` feature.
