### PR TITLE
Remove deprecated package authors field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "serde_json"
 version = "1.0.151"
-authors = ["Erick Tryzelaar <erick.tryzelaar@gmail.com>", "David Tolnay <dtolnay@gmail.com>"]
 categories = ["encoding", "parser-implementations", "no-std"]
 description = "A JSON serialization file format"
 documentation = "https://docs.rs/serde_json"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "serde_json-fuzz"
 version = "0.0.0"
-authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2021"
 publish = false
 

--- a/tests/crate/Cargo.toml
+++ b/tests/crate/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "serde_json_test"
 version = "0.0.0"
-authors = ["David Tolnay <dtolnay@gmail.com>"]
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068